### PR TITLE
add dashboard page

### DIFF
--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -23,6 +23,11 @@ async function getPermissions (credentials) {
     licences: {
       read: false,
       edit: false
+    },
+    admin: {
+      defra: false,
+      project: false,
+      system : false
     }
   };
 
@@ -34,6 +39,18 @@ async function getPermissions (credentials) {
     }
     if (roles.length === 1 && roles[0].role === 'primary_user') {
       permissions.licences.edit = true;
+    }
+    const isDefraAdmin = roles.find(r => r.role === 'admin');
+    if(isDefraAdmin){
+      permissions.admin.defra = true;
+    }
+    const isProjectAdmin = roles.find(r => r.role === 'project_admin');
+    if(isProjectAdmin){
+      permissions.admin.project = true;
+    }
+    const isSysAdmin = roles.find(r => r.role === 'system_admin');
+    if(isSysAdmin){
+      permissions.admin.system = true;
     }
   }
 

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -20,6 +20,8 @@ function viewContextDefaults (request) {
   viewContext.debug.request = request.info;
   viewContext.debug.request.path = request.path;
 
+  viewContext.labels={}
+  viewContext.labels.licences='Your licences'
   // Main nav links
   viewContext.propositionLinks = [];
 
@@ -38,7 +40,19 @@ function viewContextDefaults (request) {
     });
   }
 
+
+  if (request.permissions && request.permissions.admin.defra) {
+    viewContext.labels.licences='Licences'
+    viewContext.propositionLinks.push({
+      id: 'dashboard',
+      text: 'Service Dashboard',
+      url: '/dashboard'
+    });
+  }
+
   viewContext.user = request.auth.credentials;
+
+  viewContext.permissions=request.permissions;
 
   if (request.auth.credentials) {
     viewContext.tracking = request.auth.credentials.user_data;

--- a/src/routes/VmL.js
+++ b/src/routes/VmL.js
@@ -19,18 +19,26 @@ module.exports = [
     path: '/',
     handler: function (request, reply) {
       console.log(request.query);
-      if (request.query.access && request.query.access === 'PB01') {
-        var fs = require('fs');
-        const indexPath = path.join(__dirname, '/../views/water/index.html');
-        fs.readFile(indexPath, function (err, data) {
-          if (err) {
-            throw err;
-          }
-          reply(data.toString());
-        });
+      console.log('node env '+process.env.NODE_ENV);
+
+      if (process.env.NODE_ENV != 'PREPROD'){
+        console.log('redirect to licences')
+          return reply.redirect('/licences');
       } else {
-        reply('unauthorised').code(401);
+        if (request.query.access && request.query.access === 'PB01') {
+          var fs = require('fs');
+          const indexPath = path.join(__dirname, '/../views/water/index.html');
+          fs.readFile(indexPath, function (err, data) {
+            if (err) {
+              throw err;
+            }
+            reply(data.toString());
+          });
+        } else {
+          reply('unauthorised').code(401);
+        }
       }
+
     },
     config: { auth: false,
       validate: {
@@ -487,12 +495,17 @@ module.exports = [
         }
       }
     }},
-  { method: 'GET',
-    path: '/system/performance/dashboard/v1',
-    handler: VmL.dashboard,
-    config: {
-      description: 'Show the dashboard'
-    }},
+    { method: 'GET',
+      path: '/dashboard',
+      handler: VmL.dashboard,
+      config: {
+        description: 'System Dashboard',
+        plugins: {
+          hapiRouteAcl: {
+            permissions: ['admin:defra']
+          }
+        }
+      }},
 
   {
     method: '*',

--- a/src/views/water/dashboard.html
+++ b/src/views/water/dashboard.html
@@ -2,11 +2,11 @@
 <main id="content">
   {{>element-phase-tag}}
 
-  {{>element-heading-large content='Loading dashboard'}}
+  {{>element-heading-large content='Service dashboard'}}
   <div class="article-container">
     <article role="article" class="group">
       <div class="inner text">
-        <p>Please wait...</p>
+        <p>Click here to view the <a class="link" target="_blank" href="https://datastudio.google.com/embed/u/0/reporting/1on24bMHI1dyJqegI40BF7lFFYTsa6YLx/page/lY4N">Service Dashboard</p>
       </div>
     </article>
   </div>

--- a/src/views/water/licence.html
+++ b/src/views/water/licence.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
       </ol>
     </div>

--- a/src/views/water/licence_error.html
+++ b/src/views/water/licence_error.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences">Error</a></li>
       </ol>
     </div>

--- a/src/views/water/licences-add/add-licences.html
+++ b/src/views/water/licences-add/add-licences.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/add-licences">Request access</a></li>
       </ol>

--- a/src/views/water/licences-add/security-code.html
+++ b/src/views/water/licences-add/security-code.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/security-code">Security code</a></li>
       </ol>

--- a/src/views/water/licences-add/select-address.html
+++ b/src/views/water/licences-add/select-address.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/add-licences">Request access</a></li>
       </ol>

--- a/src/views/water/licences-add/select-licences-error.html
+++ b/src/views/water/licences-add/select-licences-error.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/add-licences">Request access</a></li>
       </ol>

--- a/src/views/water/licences-add/select-licences.html
+++ b/src/views/water/licences-add/select-licences.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/add-licences">Request access</a></li>
       </ol>

--- a/src/views/water/licences-add/verification-sent.html
+++ b/src/views/water/licences-add/verification-sent.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences_add">Manage your licences</a></li>
         <li><a href="/add-licences">Request access</a></li>
       </ol>

--- a/src/views/water/licences_admin.html
+++ b/src/views/water/licences_admin.html
@@ -6,11 +6,14 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">{{ labels.licences }}</a></li>
+
+        <li><a href="/licences">Licences</a></li>
       </ol>
 
     </div>
   </nav>
+
+
 
   {{#equal error.name "ValidationError" }}
   <div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
@@ -34,15 +37,20 @@
   </div>
   {{/equal}}
 
+  {{#if permissions.admin.defra}}
+  {{>element-heading-large content='Licences'}}
+  {{else}}
   {{>element-heading-large content='Your licences'}}
-
-  {{#if showVerificationAlert }}
-  <div class="panel panel-border-wide alert-default medium-space">
-    Have you received a security code by post? <a href="/security-code">Enter your code here</a>
-  </div>
   {{/if}}
 
+
+
+
   {{#if enableSearch}}
+  <p>
+    You can search for licences using user email, partial licence number or licence name
+  </p>
+
   <form novalidate method="GET" action="/licences" name="licenceSearch">
 
   <!-- Licence search form -->
@@ -60,7 +68,11 @@
 
     <div class="column-two-fifths">
       <div class="form-group form-group--horizontal">
+        {{#if permissions.admin.defra}}
+        <label class="form-label form-label--bold" for="licenceNumber">Search licences</label>
+        {{else}}
         <label class="form-label form-label--bold" for="licenceNumber">Search your licences</label>
+        {{/if}}
         <span class="form-hint">Enter a licence number or name</span>
         <input maxlength="32" type="search" class="form-control form-control--block" name="licenceNumber" id="licenceNumber" value="{{ query.licenceNumber }}" />
       </div>
@@ -76,6 +88,11 @@
   {{/if}}
 
 
+
+
+
+
+  {{#if showResults}}
   <!-- Results page goes here -->
   <div class="license-results" id="results">
 
@@ -108,6 +125,7 @@
     {{/each}}
 
   </div>
+  {{/if}}
 
 
   {{#greaterThan pagination.pageCount 1}}

--- a/src/views/water/licences_conditions.html
+++ b/src/views/water/licences_conditions.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
         <li><a href="/licences/{{ licence_id }}/conditions">Abstraction conditions</a></li>
 

--- a/src/views/water/licences_contact.html
+++ b/src/views/water/licences_contact.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
         <li><a href="/licences/{{ licence_id }}/rename">Contact details</a></li>
 

--- a/src/views/water/licences_map.html
+++ b/src/views/water/licences_map.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.LicenceSerialNo }}</a></li>
       </ol>
     </div>

--- a/src/views/water/licences_points.html
+++ b/src/views/water/licences_points.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
         <li><a href="/licences/{{ licence_id }}/points">Abstraction points</a></li>
 

--- a/src/views/water/licences_purposes.html
+++ b/src/views/water/licences_purposes.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
         <li><a href="/licences/{{ licence_id }}/purposes">Abstraction purposes</a></li>
 

--- a/src/views/water/licences_rename.html
+++ b/src/views/water/licences_rename.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{ licence_id }}">Licence number: {{ licenceData.licenceNumber }}</a></li>
         <li><a href="/licences/{{ licence_id }}/rename">Name this licence</a></li>
 

--- a/src/views/water/licences_terms.html
+++ b/src/views/water/licences_terms.html
@@ -8,7 +8,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol >
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/licences/{{licence_id}}">Licence number: {{ licenceData.licenceNumber }}</a></li>
       </ol>
     </div>

--- a/src/views/water/manage_licences.html
+++ b/src/views/water/manage_licences.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
 
       </ol>

--- a/src/views/water/manage_licences_add.html
+++ b/src/views/water/manage_licences_add.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
         <li><a href="/manage_licences_add">Access more licences</a></li>
       </ol>

--- a/src/views/water/manage_licences_add_access_form.html
+++ b/src/views/water/manage_licences_add_access_form.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
         <li><a href="/manage_licences/add_access">Add access</a></li>
 

--- a/src/views/water/manage_licences_added_access.html
+++ b/src/views/water/manage_licences_added_access.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
         <li><a href="/manage_licences/add_access">Add access</a></li>
       </ol>

--- a/src/views/water/manage_licences_remove_access_form.html
+++ b/src/views/water/manage_licences_remove_access_form.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
         <li><a href="/manage_licences/remove_access">Remove access</a></li>
       </ol>

--- a/src/views/water/manage_licences_removed_access.html
+++ b/src/views/water/manage_licences_removed_access.html
@@ -5,7 +5,7 @@
     <div class="breadcrumbs">
       {{>element-header-links}}
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/manage_licences">Manage licences</a></li>
         <li><a href="/manage_licences/remove_access">Remove access</a></li>
       </ol>

--- a/src/views/water/update_password.html
+++ b/src/views/water/update_password.html
@@ -5,7 +5,7 @@
   <nav>
     <div class="breadcrumbs">
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/update_password">Update password</a></li>
       </ol>
     </div>

--- a/src/views/water/updated_password.html
+++ b/src/views/water/updated_password.html
@@ -4,7 +4,7 @@
   <nav>
     <div class="breadcrumbs">
       <ol>
-        <li><a href="/licences">Your licences</a></li>
+        <li><a href="/licences">{{ labels.licences }}</a></li>
         <li><a href="/update_password">Update password</a></li>
       </ol>
     </div>


### PR DESCRIPTION
include dashboard link for admin users,
pass permissions to view layer
check for and assign admin permissions, initially adding 3 permission types : admin.[ defra | project | system ] (project and admin don't currently exist as roles)
modify all pages that contain "licences" link to show as "licences" or "your licences" depending on whether user is admin or not
only require access param at route and show start page on pre-prod (as this will be not provided by our service)
kitchen sink