### PR TITLE
Set textarea maxlength to 8000 when entering licences to prevent 9000…

### DIFF
--- a/src/views/partials/widget-textarea.html
+++ b/src/views/partials/widget-textarea.html
@@ -5,5 +5,5 @@
     <span class="form-hint">{{ this.hint }}</span>
     {{/if}}
   </label>
-  <textarea class="form-control form-control-3-4" name="{{ this.name }}" id="{{ this.name }}" rows="5"></textarea>
+  <textarea maxlength="8000" class="form-control form-control-3-4" name="{{ this.name }}" id="{{ this.name }}" rows="5"></textarea>
 </div>

--- a/src/views/water/licences-add/add-licences.html
+++ b/src/views/water/licences-add/add-licences.html
@@ -105,7 +105,7 @@
             </fieldset>
 
           </label>
-          <textarea maxlength="9000" class="form-control form-control-3-4" name="licence_no" id="licence_no" rows="5" required >{{ payload.licence_no }}</textarea>
+          <textarea maxlength="8000" class="form-control form-control-3-4" name="licence_no" id="licence_no" rows="5" required >{{ payload.licence_no }}</textarea>
         </div>
 
         <input type="submit" value="Continue" class="button" role="button"/>


### PR DESCRIPTION
… character overflow issue (by a significant margin). NB: No individual entity currently holds enough licences to generate more than ~4k chars