### PR TITLE
feat/WATER-1069: Adds accessibilty page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /out/
 server-status
 lcov.info
+*.swp

--- a/src/controllers/registration.js
+++ b/src/controllers/registration.js
@@ -99,7 +99,7 @@ async function postEmailAddress (request, reply, options = {}) {
  */
 function getRegisterSuccess (request, reply) {
   const viewContext = View.contextDefaults(request);
-  viewContext.pageTitle = "We have sent you an email with a new link to use";
+  viewContext.pageTitle = 'We have sent you an email with a new link to use';
   return reply.view('water/register_success', viewContext);
 }
 

--- a/src/controllers/serviceStatus.js
+++ b/src/controllers/serviceStatus.js
@@ -1,11 +1,11 @@
-const IDM = require('../lib/connectors/idm')
-const CRM = require('../lib/connectors/crm')
-const permits = require('../lib/connectors/permit')
-const water = require('../lib/connectors/water')
+const IDM = require('../lib/connectors/idm');
+const CRM = require('../lib/connectors/crm');
+const permits = require('../lib/connectors/permit');
+const water = require('../lib/connectors/water');
 
 async function serviceStatus (request, reply) {
-  var errors = 0
-  var html = '<html><head><body><table><tr><th>Service</th><th>Info</th></tr>'
+  var errors = 0;
+  var html = '<html><head><body><table><tr><th>Service</th><th>Info</th></tr>';
   var data = {
     idm: {},
     crm: {},
@@ -13,98 +13,98 @@ async function serviceStatus (request, reply) {
       import: {}
     },
     permitrepo: {}
-  }
+  };
   try {
     const userData = await IDM.usersClient.findMany({}, {}, {
       'perPage': 1
-    })
-    data.idm.users = userData.pagination.totalRows
-    html += `<tr><td>IDM Users</td><td>${data.idm.users}</td></tr>`
-    const idmKPI = await IDM.kpi.findMany({}, {}, {})
-    idmKPI.data.forEach((d)=>{
-    html += `<tr><td>&nbsp</td><td>${d.datapoint}</td><td>${d.value}</td><td>${d.description}</td></tr>`
-    data.idm[d.datapoint]=d.value
-    })
+    });
+    data.idm.users = userData.pagination.totalRows;
+    html += `<tr><td>IDM Users</td><td>${data.idm.users}</td></tr>`;
+    const idmKPI = await IDM.kpi.findMany({}, {}, {});
+    idmKPI.data.forEach((d) => {
+      html += `<tr><td>&nbsp</td><td>${d.datapoint}</td><td>${d.value}</td><td>${d.description}</td></tr>`;
+      data.idm[d.datapoint] = d.value;
+    });
   } catch (e) {
-    html += `<tr><td>IDM Users</td><td>ERROR</td></tr>`
-    errors++
+    html += `<tr><td>IDM Users</td><td>ERROR</td></tr>`;
+    errors++;
   }
 
   try {
     const documentData = await CRM.documents.findMany({}, {}, {
       'perPage': 1
-    })
-    data.crm.documents = documentData.pagination.totalRows
-    html += `<tr><td>CRM Documents</td><td>${data.crm.documents}</td></tr>`
-    const crmKPI = await CRM.kpi.findMany({}, {}, {})
-    crmKPI.data.forEach((d)=>{
-    html += `<tr><td>&nbsp</td><td>${d.datapoint}</td><td>${d.value}</td><td>${d.description}</td></tr>`
-    data.crm[d.datapoint]=d.value
-    })
+    });
+    data.crm.documents = documentData.pagination.totalRows;
+    html += `<tr><td>CRM Documents</td><td>${data.crm.documents}</td></tr>`;
+    const crmKPI = await CRM.kpi.findMany({}, {}, {});
+    crmKPI.data.forEach((d) => {
+      html += `<tr><td>&nbsp</td><td>${d.datapoint}</td><td>${d.value}</td><td>${d.description}</td></tr>`;
+      data.crm[d.datapoint] = d.value;
+    });
   } catch (e) {
-    console.log(e)
-    html += `<tr><td>CRM Documents</td><td>ERROR</td></tr>`
-    errors++
+    console.log(e);
+    html += `<tr><td>CRM Documents</td><td>ERROR</td></tr>`;
+    errors++;
   }
 
   try {
     const verificationData = await CRM.verification.findMany({}, {}, {
       'perPage': 1
-    })
-    data.crm.verifications = verificationData.pagination.totalRows
-    html += `<tr><td>CRM Verifications</td><td>${data.crm.verifications}</td></tr>`
+    });
+    data.crm.verifications = verificationData.pagination.totalRows;
+    html += `<tr><td>CRM Verifications</td><td>${data.crm.verifications}</td></tr>`;
   } catch (e) {
-    html += `<tr><td>CRM Verifications</td><td>ERROR</td></tr>`
-    errors++
+    html += `<tr><td>CRM Verifications</td><td>ERROR</td></tr>`;
+    errors++;
   }
 
   try {
     const permitData = await permits.licences.findMany({}, {}, {
       'perPage': 1
-    })
-    data.permitrepo.permits = permitData.pagination.totalRows
-    html += `<tr><td>Permit Repo Permits</td><td>${data.permitrepo.permits}</td></tr>`
+    });
+    data.permitrepo.permits = permitData.pagination.totalRows;
+    html += `<tr><td>Permit Repo Permits</td><td>${data.permitrepo.permits}</td></tr>`;
   } catch (e) {
-    html += `<tr><td>Permit Repo Permits</td><td>ERROR</td></tr>`
-    errors++
+    html += `<tr><td>Permit Repo Permits</td><td>ERROR</td></tr>`;
+    errors++;
   }
 
-  data.waterservice.import = {}
+  data.waterservice.import = {};
   try {
     const importDataComplate = await water.pendingImport.findMany({
       'status': 1
     }, {}, {
       'perPage': 1
-    })
-    data.waterservice.import.complete = importDataComplate.pagination.totalRows
-    html += `<tr><td>Imported Permits</td><td>${data.waterservice.import.complete}</td></tr>`
+    });
+    data.waterservice.import.complete = importDataComplate.pagination.totalRows;
+    html += `<tr><td>Imported Permits</td><td>${data.waterservice.import.complete}</td></tr>`;
   } catch (e) {
-    html += `<tr><td>Imported Permits</td><td>ERROR</td></tr>`
-    errors++
+    html += `<tr><td>Imported Permits</td><td>ERROR</td></tr>`;
+    errors++;
   }
   try {
     const importDataPending = await water.pendingImport.findMany({
       'status': 0
     }, {}, {
       'perPage': 1
-    })
-    data.waterservice.import.pending = importDataPending.pagination.totalRows
-    html += `<tr><td>Pending Permits</td><td>${data.waterservice.import.pending}</td></tr>`
+    });
+    data.waterservice.import.pending = importDataPending.pagination.totalRows;
+    html += `<tr><td>Pending Permits</td><td>${data.waterservice.import.pending}</td></tr>`;
   } catch (e) {
-    html += `<tr><td>Pending Permits</td><td>ERROR</td></tr>`
-    errors++
+    html += `<tr><td>Pending Permits</td><td>ERROR</td></tr>`;
+    errors++;
   }
 
-  html += `<tr><td><b>Errors<b></td><td> ${errors} ERRORS REPORTED</td></tr>`
-  html += '</body></html>'
+  html += `<tr><td><b>Errors<b></td><td> ${errors} ERRORS REPORTED</td></tr>`;
+  html += '</body></html>';
 
   if (request.query.format && request.query.format === 'json') {
-    return reply(data)
+    return reply(data);
   } else {
-    return reply(html)
+    return reply(html);
   }
 }
 
 module.exports = {
   serviceStatus
-}
+};

--- a/src/lib/VmL.js
+++ b/src/lib/VmL.js
@@ -1,7 +1,13 @@
-const View = require('../lib/view');
+const View = require('./view');
 
 function getRoot (request, reply) {
   reply.file('./staticindex.html');
+}
+
+function getAccessibility (request, reply) {
+  const viewContext = View.contextDefaults(request);
+  viewContext.pageTitle = 'Accessibility';
+  return reply.view('water/accessibility', viewContext);
 }
 
 function getCookies (request, reply) {
@@ -42,11 +48,12 @@ function getHoldingPage (request, reply) {
 }
 
 module.exports = {
-  getRoot: getRoot,
+  getRoot,
   getCookies,
+  getAccessibility,
   getPrivacyPolicy,
-  fourOhFour: fourOhFour,
-  getFeedback: getFeedback,
+  fourOhFour,
+  getFeedback,
   // dashboard,
   getHoldingPage
 };

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -3,7 +3,7 @@ console.log(__dirname);
 function viewContextDefaults (request) {
   var viewContext = {};
 
-  viewContext.isAuthenticated = request.auth.isAuthenticated;
+  viewContext.isAuthenticated = !!request.state.sid;
   viewContext.query = request.query;
   viewContext.payload = request.payload;
   viewContext.session = request.session;

--- a/src/routes/VmL.js
+++ b/src/routes/VmL.js
@@ -51,6 +51,12 @@ module.exports = [
   { method: 'GET', path: '/feedback', config: { auth: false }, handler: VmL.getFeedback },
   { method: 'GET', path: '/cookies', config: { description: 'Displays cookie information', auth: false }, handler: VmL.getCookies },
   { method: 'GET', path: '/privacy-policy', config: { description: 'Displays privacy policy', auth: false }, handler: VmL.getPrivacyPolicy },
+  {
+    method: 'GET',
+    path: '/accessibility',
+    config: { description: 'Displays an accessibility statement', auth: false },
+    handler: VmL.getAccessibility
+  },
   { method: 'GET', path: '/tmp', config: { auth: false }, handler: VmL.getRoot },
   { method: 'GET', path: '/signout', config: {}, handler: AuthController.getSignout },
 

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -349,6 +349,15 @@ handlebars.registerHelper('abstractionConditions', function (quantities) {
 
 const Path = require('path');
 
+const footerSupportLinks = `
+  <h2 class="sr-only">Support Links</h2>
+  <ul>
+    <li><a href="/cookies">Cookies</a></li>
+    <li><a href="/privacy-policy">Privacy</a></li>
+    <li><a href="/accessibility">Accessibility</a></li>
+  </ul>
+`;
+
 const defaultContext = {
   assetPath: '/public/',
   topOfPage: 'Login Handler',
@@ -369,7 +378,7 @@ const defaultContext = {
 
   afterHeader: '',
   footerTop: '',
-  footerSupportLinks: '<h2 class="sr-only">Support Links</h2><ul><li><a href="/cookies">Cookies</a></li><li><a href="/privacy-policy">Privacy</a></li></ul>',
+  footerSupportLinks,
   licenceMessage: '<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>',
   bodyEnd: ''
 };

--- a/src/views/water/accessibility.html
+++ b/src/views/water/accessibility.html
@@ -1,0 +1,35 @@
+{{> styles}}
+<main id="content" tabindex="-1">
+  {{>element-phase-tag}}{{>element-main-nav}}
+
+  <a class="link-back" href="/licences">Back</a>
+
+  <h1 class="heading-large">{{ pageTitle }}</h1>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h2 class="heading-medium">Service accessibility statement</h2>
+      <p>
+        We aim to make the Manage your water abstraction or impoundment licence
+        service as accessible and easy to use as possible. All of our web pages
+        are designed and tested to meet <a target="_blank" href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines</a>
+        to level AA, and all except one successfully meet that standard.
+      </p>
+
+      <h2 class="heading-medium">Pages that do not meet the WCAG AA standard</h2>
+      <p>
+        Our feedback survey does not currently meet the same accessibility standards as the rest
+        of our service. We are working with the software provider to improve accessibility on this page.
+      </p>
+
+      <h2 class="heading-medium">How to contact us</h2>
+      <p>
+        If you want to give feedback about this service or have any questions about
+        accessibility, please email us at <a href="mailTo:water_abstractiondigital@environment-agency.gov.uk">water_abstractiondigital@environment-agency.gov.uk</a>.
+        We will respond within 5 working days.
+      </p>
+    </div>
+  </div>
+</main>
+{{> footerjs}}

--- a/src/views/water/feedback.html
+++ b/src/views/water/feedback.html
@@ -4,7 +4,21 @@
 
   {{>element-heading-large content='Tell us what you think about this service'}}
 
-        <iframe id="ss-embed-frame" onload="window.parent.parent.scrollTo(0,0)" src="https://www.smartsurvey.co.uk/s/FYWJN/" style="width:100%;height:800px;border:0px;padding-bottom:4px;" frameborder="0"><a href="https://www.smartsurvey.co.uk/s/FYWJN/">Please take our survey</a></iframe>
+  <div class="panel panel-border-wide alert-default">
+    <h2 class="heading-medium">Problems viewing this page?</h2>
+    <p>
+      We are currently working to improve the accessibility standard of this page.
+      If you are having problems viewing it, you can email your feedback to us
+      instead: <a href="mailTo:water_abstractiondigital.environment-agency.gov.uk">water_abstractiondigital.environment-agency.gov.uk</a>
+    </p>
+  </div>
+
+  <iframe id="ss-embed-frame" onload="window.parent.parent.scrollTo(0,0)"
+    src="https://www.smartsurvey.co.uk/s/FYWJN/"
+    style="width:100%;height:800px;border:0px;padding-bottom:4px;"
+    frameborder="0">
+     <a href="https://www.smartsurvey.co.uk/s/FYWJN/">Please take our survey</a>
+  </iframe>
 </main>
 {{> footerjs}}
 {{> debug}}

--- a/test/lib/VmL.js
+++ b/test/lib/VmL.js
@@ -13,6 +13,12 @@ lab.experiment('vml.getRoot', () => {
     Code.expect(vml.getRoot).to.be.a.function();
   });
 });
+
+lab.experiment('vml.getAccessibility', () => {
+  lab.test('function exists', async () => {
+    Code.expect(vml.getAccessibility).to.be.a.function();
+  });
+});
 //
 // lab.experiment('vml.getUpdatePassword', () => {
 //   lab.test('function exists', async () => {

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const { expect } = require('code')
+
+const view = require('../../src/lib/view');
+
+/*
+ * Gets the minimal request object that allows the tests to run.
+ */
+const getBaseRequest = () => ({
+  state: {},
+  connection: {},
+  sessionStore: {
+    get: (key) => key
+  },
+  url: {},
+  permissions: {
+    admin: {},
+    licences: {}
+  },
+  auth: {
+    credentials: {}
+  },
+  info: {}
+});
+
+lab.experiment('lib/view.contextDefaults', () => {
+
+  lab.test('isAuthenticated is false when no sid in state', async () => {
+    const request = getBaseRequest();
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.isAuthenticated).to.be.false();
+  });
+
+  lab.test('isAuthenticated is true when the sid is in state', async () => {
+    const request = getBaseRequest();
+    request.state.sid = { sid: 'test-sid' };
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.isAuthenticated).to.be.true();
+  });
+});
+


### PR DESCRIPTION
- Adds a new page for the accessibility statement
- Adds new route to show statement at `/accessibility`
- Adds the link to the new page in the footer support links.
- Changes the logic in the default view context to determine the
authenticated status using the SID to allow an authenticated user to be
identified even when browsing a page that does not require
authentication.
- Ran `npm run lint` which added some trailing semi colons.