### PR TITLE
Correctly identify level HOF types

### DIFF
--- a/src/lib/licence-transformer/index.js
+++ b/src/lib/licence-transformer/index.js
@@ -10,19 +10,18 @@ const FORMAT_NALD = 'NALD';
 const FORMAT_CSV = 'CSV';
 
 class UnsupportedLicenceFormatError extends Error {
-  constructor(message) {
+  constructor (message) {
     super(message);
     this.name = 'UnsupportedLicenceFormatError';
   }
 };
 
 class LicenceTransformer {
-
   /**
    * Constructor
    * @param {Object} data - licence data
    */
-  async load(data) {
+  async load (data) {
     const format = this.guessFormat(data);
 
     switch (format) {
@@ -45,25 +44,21 @@ class LicenceTransformer {
    * Export data
    * @return {Object}
    */
-  export() {
+  export () {
     return this.transformer.export();
   }
-
 
   /**
    * Guess the data format from the supplied data
    * @param {Object}
    * @return {String} data format
    */
-  guessFormat(data) {
-    if('vmlVersion' in data && data.vmlVersion === 2) {
+  guessFormat (data) {
+    if ('vmlVersion' in data && data.vmlVersion === 2) {
       return FORMAT_NALD;
     }
     return FORMAT_CSV;
   }
-
-
 }
-
 
 module.exports = LicenceTransformer;

--- a/src/modules/view-licences/helpers.js
+++ b/src/modules/view-licences/helpers.js
@@ -137,7 +137,9 @@ async function loadLicenceData (entityId, documentId) {
   };
 }
 
-const hasLatestReading = measure => has(measure, 'latestReading.id');
+const hasLatestReading = measure => has(measure, 'latestReading.value');
+const isLevelMeasure = measure => measure.parameter === 'level';
+const isFlowMeasure = measure => measure.parameter === 'flow';
 
 /**
  * Logic for selecting which measure to display:
@@ -145,28 +147,19 @@ const hasLatestReading = measure => has(measure, 'latestReading.id');
  * - if 2 measures, and 1 hof type, show the matching one
  * - if 2 measures, and 2 hof types, show flow
  * @param {Object} riverLevel - data returned from water river level API
- * @param {Object} hofTypes - contains flags for cesFlow and cesLevel
+ * @param {Object} hofTypes - contains flags for cesFlow and cesLev
  * @return {Object} measure the selected measure - level/flow
  */
 function selectRiverLevelMeasure (riverLevel, hofTypes) {
-  if (riverLevel.measures.length === 1) {
-    const measure = riverLevel.measures[0];
-    return hasLatestReading(measure) ? measure : undefined;
-  }
-
   const flow = find(riverLevel.measures, measure => {
-    return measure.parameter === 'flow' && hasLatestReading(measure);
+    return isFlowMeasure(measure) && hasLatestReading(measure);
   });
 
   const level = find(riverLevel.measures, measure => {
-    return measure.parameter === 'level' && hasLatestReading(measure);
+    return isLevelMeasure(measure) && hasLatestReading(measure);
   });
 
-  if (hofTypes.cesLevel && !hofTypes.cesFlow) {
-    return level;
-  }
-
-  return flow;
+  return (hofTypes.cesLev && !hofTypes.cesFlow) ? level : flow;
 }
 
 /**

--- a/test/modules/view-licences/helpers.js
+++ b/test/modules/view-licences/helpers.js
@@ -9,7 +9,7 @@ const { selectRiverLevelMeasure } = require('../../../src/modules/view-licences/
 
 const getTestMeasure = (parameter = 'flow', hasLatestReading = true) => {
   const latestReading = hasLatestReading
-    ? { id: 'test-reading', value: 0.321 }
+    ? { value: 0.321 }
     : 'http://example.com';
 
   return {
@@ -24,62 +24,62 @@ lab.experiment('selectRiverLevelMeasure', () => {
     const riverLevel = {
       measures: [getTestMeasure()]
     };
-    const hofTypes = { cesFlow: true, cesLevel: false };
+    const hofTypes = { cesFlow: true, cesLev: false };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure.id).to.equal('test-flow');
   });
 
   lab.test('returns undefined if the measure does not contain a latest reading', async () => {
     const riverLevel = { measures: [getTestMeasure('flow', false)] };
-    const hofTypes = { cesFlow: true, cesLevel: false };
+    const hofTypes = { cesFlow: true, cesLev: false };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure).to.be.undefined();
   });
 
-  lab.test('returns level if cesLevel is true and cesFlow is false', async () => {
+  lab.test('returns level if cesLev is true and cesFlow is false', async () => {
     const riverLevel = {
       measures: [
         getTestMeasure('flow'),
         getTestMeasure('level')
       ]
     };
-    const hofTypes = { cesFlow: false, cesLevel: true };
+    const hofTypes = { cesFlow: false, cesLev: true };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure.id).to.equal('test-level');
   });
 
-  lab.test('returns undefined if cesLevel is true and cesFlow is false, but no latest reading', async () => {
+  lab.test('returns undefined if cesLev is true and cesFlow is false, but no latest reading', async () => {
     const riverLevel = {
       measures: [
         getTestMeasure('flow', false),
         getTestMeasure('level', false)
       ]
     };
-    const hofTypes = { cesFlow: false, cesLevel: true };
+    const hofTypes = { cesFlow: false, cesLev: true };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure).to.be.undefined();
   });
 
-  lab.test('returns flow if cesLevel is false and cesFlow is true', async () => {
+  lab.test('returns flow if cesLev is false and cesFlow is true', async () => {
     const riverLevel = {
       measures: [
         getTestMeasure('flow'),
         getTestMeasure('level')
       ]
     };
-    const hofTypes = { cesFlow: true, cesLevel: false };
+    const hofTypes = { cesFlow: true, cesLev: false };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure.id).to.equal('test-flow');
   });
 
-  lab.test('returns undefined if cesLevel is false and cesFlow is true, but no latest reading', async () => {
+  lab.test('returns undefined if cesLev is false and cesFlow is true, but no latest reading', async () => {
     const riverLevel = {
       measures: [
         getTestMeasure('flow', false),
         getTestMeasure('level', false)
       ]
     };
-    const hofTypes = { cesFlow: true, cesLevel: false };
+    const hofTypes = { cesFlow: true, cesLev: false };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure).to.be.undefined();
   });


### PR DESCRIPTION
bugfix/WATER-1119

Fixes a bug where the station does not report a valid level reading when
it is actually available.