### PR TITLE
WATER-1131: Handling gauging station 404

### DIFF
--- a/src/views/water/view-licences/gauging-station.html
+++ b/src/views/water/view-licences/gauging-station.html
@@ -6,15 +6,17 @@
 
   <div class="grid-row">
       <div class="column-full">
-        <h1 class="heading-large heading-large--tight-above">
-            <span class="heading-secondary">At National Grid Reference {{ ngrPointStr riverLevel.ngr }}</span>
-            Data from {{ riverLevel.label }}
+          {{#if riverLevel}}
+          <h1 class="heading-large heading-large--tight-above">
+              <span class="heading-secondary">At National Grid Reference {{ ngrPointStr riverLevel.ngr }}</span>
+              Data from {{ riverLevel.label }}
           </h1>
+          {{/if}}
 
           {{#if hasGaugingStationMeasurement}}
           <div class="data">
               <span class="data-item bold-xxlarge">{{ gsValue measure riverLevel.stageScale }}</span>
-              <span class="data-item">Recorded at <span class="bold-small">{{ formatISOTime measure.latestReading.dateTime }} on {{ formatISODate measure.latestReading.dateTime }}
+              <span class="data-item">Recorded at <span class="bold-small">{{ formatISOTime measure.latestReading.dateTime }} on {{ formatISODate measure.latestReading.dateTime }}</span></span>
           </div>
           {{ else }}
           <div class="data">

--- a/test/modules/view-licences/helpers.js
+++ b/test/modules/view-licences/helpers.js
@@ -4,8 +4,10 @@ const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 
 const { expect } = require('code');
+const sinon = require('sinon');
 
-const { selectRiverLevelMeasure } = require('../../../src/modules/view-licences/helpers');
+const { selectRiverLevelMeasure, loadRiverLevelData } = require('../../../src/modules/view-licences/helpers');
+const waterConnector = require('../../../src/lib/connectors/water');
 
 const getTestMeasure = (parameter = 'flow', hasLatestReading = true) => {
   const latestReading = hasLatestReading
@@ -82,5 +84,42 @@ lab.experiment('selectRiverLevelMeasure', () => {
     const hofTypes = { cesFlow: true, cesLev: false };
     const measure = selectRiverLevelMeasure(riverLevel, hofTypes);
     expect(measure).to.be.undefined();
+  });
+});
+
+lab.experiment('loadRiverLevelData', () => {
+  const hofTypes = { cesLevel: true, cesFlow: false };
+
+  lab.beforeEach(async () => {
+    sinon.stub(waterConnector, 'getRiverLevel');
+  });
+
+  lab.afterEach(async () => {
+    waterConnector.getRiverLevel.restore();
+  });
+
+  lab.test('returns null riverLevel and measure when no station reference', async () => {
+    const riverLevelData = await loadRiverLevelData(null, hofTypes);
+    expect(riverLevelData).to.equal({ riverLevel: null, measure: null });
+  });
+
+  lab.test('returns the river level and measure when the station is returned', async () => {
+    const response = {
+      measures: [{
+        latestReading: { value: 21.7 },
+        parameter: 'flow',
+        valueType: 'instantaneous'
+      }]
+    };
+    waterConnector.getRiverLevel.resolves(response);
+    const riverLevelData = await loadRiverLevelData(1234, hofTypes);
+    expect(riverLevelData.measure).to.be.an.object();
+    expect(riverLevelData.riverLevel).to.be.an.object();
+  });
+
+  lab.test('returns null riverLevel and measure when no station is found', async () => {
+    waterConnector.getRiverLevel.rejects({ statusCode: 404 });
+    const riverLevelData = await loadRiverLevelData(null, hofTypes);
+    expect(riverLevelData).to.equal({ riverLevel: null, measure: null });
   });
 });


### PR DESCRIPTION
Handles gauging stations that are linked to from a license that don't
currently have any data. So where the open data return a 404.

Instead of showing an error page, the gauging station page is still
shown, but with a message telling the user that there is no data.

 - Changes the view-licences helper to return a null object if the
station returns a 404.
 - Adds a unit test for this.
 - Changes the importing of the connector, to import the full object to
allow sinon to stub the required functions.