### PR TITLE
feat/WATER-991

### DIFF
--- a/src/lib/licence-transformer/base-transformer.js
+++ b/src/lib/licence-transformer/base-transformer.js
@@ -4,11 +4,11 @@
  */
 
 class BaseTransformer {
-  constructor(data) {
+  constructor (data) {
     this.data = data;
   }
 
-  export() {
+  export () {
     return this.data;
   }
 }

--- a/src/lib/licence-transformer/nald-transformer.js
+++ b/src/lib/licence-transformer/nald-transformer.js
@@ -51,6 +51,7 @@ class NALDTransformer extends BaseTransformer {
       licenceHolderInitials: licenceHolderParty.INITIALS,
       licenceHolderName: licenceHolderParty.NAME,
       effectiveDate: data.ORIG_EFF_DATE,
+      currentVersionEffectiveStartDate: currentVersion.EFF_ST_DATE,
       expiryDate: data.EXPIRY_DATE,
       versionCount: data.data.versions.length,
       conditions: conditions,

--- a/src/views/water/view-licences/licence.html
+++ b/src/views/water/view-licences/licence.html
@@ -39,10 +39,9 @@
   <h1 class="heading-large">Licence number {{ licenceData.licenceNumber }}</h1>
   {{/if}}
 
-
-  <p>Starts {{ formatDate licenceData.effectiveDate }}
+  <p>Current licence version started on {{ formatDate licenceData.currentVersionEffectiveStartDate }}
      {{#if licenceData.expiryDate }}
-      and ends {{ formatToDate licenceData.expiryDate }}
+      and ends on {{ formatToDate licenceData.expiryDate }}
      {{else}}
       and has no end date
      {{/if}}


### PR DESCRIPTION
Extracts the effective start date from the current licence
and uses this data over the effective licence start date when showing
the start and end date on the licence page.