### PR TITLE
Only auto-select flow/level if it matches a HoF.

### DIFF
--- a/src/modules/view-licences/helpers.js
+++ b/src/modules/view-licences/helpers.js
@@ -149,13 +149,12 @@ const isFlowMeasure = measure => measure.parameter === 'flow';
  * @param {Object} hofTypes - HoF types with booleans for cesLev and cesFlow
  */
 function autoSelectRiverLevelMeasure (flow, level, hofTypes) {
-  if (flow && hofTypes.cesFlow && !hofTypes.cesLev) {
+  if (flow && hofTypes.cesFlow) {
     return flow;
   }
-  if (level && !hofTypes.cesFlow && hofTypes.cesLev) {
+  if (level && hofTypes.cesLev) {
     return level;
   }
-  return flow || level;
 }
 
 /**

--- a/test/modules/view-licences/helpers.js
+++ b/test/modules/view-licences/helpers.js
@@ -111,9 +111,40 @@ lab.experiment('loadRiverLevelData', () => {
         valueType: 'instantaneous'
       }]
     };
+    const hofTypes = { cesFlow: true, cesLev: false };
     waterConnector.getRiverLevel.resolves(response);
     const riverLevelData = await loadRiverLevelData(1234, hofTypes);
     expect(riverLevelData.measure).to.be.an.object();
+    expect(riverLevelData.riverLevel).to.be.an.object();
+  });
+
+  lab.test('does not return flow if only level HoF type in licence', async () => {
+    const response = {
+      measures: [{
+        latestReading: { value: 21.7 },
+        parameter: 'flow',
+        valueType: 'instantaneous'
+      }]
+    };
+    const hofTypes = { cesFlow: false, cesLev: true };
+    waterConnector.getRiverLevel.resolves(response);
+    const riverLevelData = await loadRiverLevelData(1234, hofTypes);
+    expect(riverLevelData.measure).to.be.undefined();
+    expect(riverLevelData.riverLevel).to.be.an.object();
+  });
+
+  lab.test('does not return level if only flow HoF type in licence', async () => {
+    const response = {
+      measures: [{
+        latestReading: { value: 21.7 },
+        parameter: 'level',
+        valueType: 'instantaneous'
+      }]
+    };
+    const hofTypes = { cesFlow: true, cesLev: false };
+    waterConnector.getRiverLevel.resolves(response);
+    const riverLevelData = await loadRiverLevelData(1234, hofTypes);
+    expect(riverLevelData.measure).to.be.undefined();
     expect(riverLevelData.riverLevel).to.be.an.object();
   });
 


### PR DESCRIPTION
Don't auto-select measure unless it matches a HoF condition in the licence.
