### PR TITLE
feat/WATER-1100: Last email by address route

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "exclude_patterns": [
+    "data",
+    "govuk_modules",
+    "node_modules",
+    "public",
+    "test",
+    "src/lib/logger/vendor"
+  ]
+}

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,7 @@
+// default settings for lab test runs.
+//
+// This is overridden if arguments are passed to lab via the command line.
+module.exports = {
+  // This version global seems to be introduced by sinon.
+  globals: 'version'
+};

--- a/index.js
+++ b/index.js
@@ -198,4 +198,5 @@ if (!module.parent) {
     console.log(`Service ${process.env.servicename} running at: ${server.info.uri}`);
   });
 }
+
 module.exports = server;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3615,12 +3615,12 @@
       "dev": true
     },
     "hapi-pg-rest-api": {
-      "version": "https://github.com/DEFRA/hapi-pg-rest-api.git#b59a5a8656ec0675023244d15a659292c3741154",
+      "version": "git+https://github.com/DEFRA/hapi-pg-rest-api.git#b59a5a8656ec0675023244d15a659292c3741154",
       "requires": {
         "joi": "13.1.2",
         "lodash": "4.17.5",
         "moment": "2.20.1",
-        "mongo-sql": "5.0.3",
+        "mongo-sql": "5.0.4",
         "object-walk": "0.1.1",
         "uuid": "3.1.0"
       }
@@ -5307,9 +5307,9 @@
       }
     },
     "mongo-sql": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/mongo-sql/-/mongo-sql-5.0.3.tgz",
-      "integrity": "sha512-+BXHMwkkMkpHRv/m9NFk2VAnr/8gY6oNM2FZfBqFcWGl0sEbAGFBk4TQzZGy8nTSN+CPavB01rrkugRN4Vs4AA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/mongo-sql/-/mongo-sql-5.0.4.tgz",
+      "integrity": "sha512-PDpt6WCpt0HM6jnQe5OkWp53nLZVqKmRLL9lAuZroyLLgV/mtM3V0lLCwAauVd7vBgA8yxamt5mm/jkYiNUAzg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -8887,6 +8887,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "heroku-prebuild": "npm install --only=dev",
     "heroku-postbuild": "gulp clean && gulp copy-govuk-files && gulp install-govuk-files && gulp copy-static-assets && gulp sass",
-    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --coverage-path ./src/ --ignore version -r lcov -o lcov.info -r console -o stdout",
+    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --coverage-path ./src/ -r lcov -o lcov.info -r console -o stdout",
     "test-cov-html": "lab -r html -o coverage.html",
     "docs": "jsdoc -c conf.jsdoc.json && cd ./out && serve -o -p 3011",
     "lint": "./node_modules/.bin/eslint ./src/**/*.js --fix",
@@ -75,6 +75,7 @@
     "pg": "^7.4.1",
     "request-promise-native": "^1.0.5",
     "sentence-case": "^2.1.1",
+    "url-join": "^4.0.0",
     "vision": "^4.1.1",
     "winston": "^2.4.3",
     "yar": "^8.1.2"

--- a/src/lib/connectors/water-service/notifications.js
+++ b/src/lib/connectors/water-service/notifications.js
@@ -1,0 +1,26 @@
+const urlJoin = require('url-join');
+const rp = require('request-promise-native').defaults({
+  proxy: null,
+  strictSSL: false
+});
+const { APIClient } = require('hapi-pg-rest-api');
+
+const client = new APIClient(rp, {
+  endpoint: `${process.env.WATER_URI}/notification`,
+  headers: {
+    Authorization: process.env.JWT_TOKEN
+  }
+});
+
+/**
+ * Gets the most recent notification for the given email address.
+ * @param {String} emailAddress
+ */
+client.getLatestEmailByAddress = emailAddress => {
+  const filter = { recipient: emailAddress, message_type: 'email' };
+  const sort = { send_after: -1 };
+  const pagination = { page: 1, perPage: 1 };
+  return client.findMany(filter, sort, pagination);
+};
+
+module.exports = client;

--- a/src/lib/connectors/water.js
+++ b/src/lib/connectors/water.js
@@ -5,9 +5,11 @@ const rp = require('request-promise-native').defaults({
 });
 const { APIClient } = require('hapi-pg-rest-api');
 
-function sendNotifyMessage (message_ref, recipient, personalisation) {
+const notifications = require('./water-service/notifications');
+
+function sendNotifyMessage (messageRef, recipient, personalisation) {
   return new Promise((resolve, reject) => {
-    var uri = `${process.env.WATER_URI}/notify/${message_ref}?token=${process.env.JWT_TOKEN}`;
+    var uri = `${process.env.WATER_URI}/notify/${messageRef}?token=${process.env.JWT_TOKEN}`;
     var requestBody = {
       recipient: recipient,
       personalisation: personalisation
@@ -49,13 +51,6 @@ const taskConfig = new APIClient(rp, {
 
 const events = new APIClient(rp, {
   endpoint: `${process.env.WATER_URI}/event`,
-  headers: {
-    Authorization: process.env.JWT_TOKEN
-  }
-});
-
-const notifications = new APIClient(rp, {
-  endpoint: `${process.env.WATER_URI}/notification`,
   headers: {
     Authorization: process.env.JWT_TOKEN
   }

--- a/src/lib/hapi-error-plugin.js
+++ b/src/lib/hapi-error-plugin.js
@@ -8,6 +8,7 @@
  */
 const { contextDefaults } = require('./view');
 const logger = require('./logger');
+const { get } = require('lodash');
 
 const errorPlugin = {
   register (server, options, next) {
@@ -19,8 +20,10 @@ const errorPlugin = {
         // Create view context
         const view = contextDefaults(request);
 
+        const ignore = get(request, 'route.settings.plugins.errorPlugin.ignore', false);
+
         // Boom errors
-        if (res.isBoom) {
+        if (!ignore && res.isBoom) {
           // ALWAYS Log the error
           logger.error(res);
 

--- a/src/modules/notifications/routes.js
+++ b/src/modules/notifications/routes.js
@@ -26,7 +26,7 @@ const getStep = {
   handler: controller.getStep
 };
 
-module.exports = {
+const routes = {
   getResetPassword: {
     method: 'GET',
     path: '/admin/notifications',
@@ -171,5 +171,27 @@ module.exports = {
     },
     handler: controller.postSend
   }
-
 };
+
+if (parseInt(process.env.test_mode) === 1) {
+  routes.findEmailByAddress = {
+    method: 'GET',
+    path: '/notifications/last',
+    handler: controller.findLastEmail,
+    config: {
+      plugins: {
+        errorPlugin: {
+          ignore: true
+        }
+      },
+      auth: false,
+      validate: {
+        query: Joi.object().keys({
+          email: Joi.string().required()
+        })
+      }
+    }
+  };
+}
+
+module.exports = routes;

--- a/test/modules/notifications/controller.js
+++ b/test/modules/notifications/controller.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const server = require('../../../index');
+const { expect } = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const sinon = require('sinon');
+const client = require('../../../src/lib/connectors/water-service/notifications');
+
+if (process.env.test_mode) {
+  lab.experiment('findLastEmail', () => {
+    lab.beforeEach(async () => {
+      sinon.stub(client, 'getLatestEmailByAddress');
+    });
+
+    lab.afterEach(async () => {
+      client.getLatestEmailByAddress.restore();
+    });
+
+    lab.test('returns a 400 for a missing email', async () => {
+      const request = {
+        method: 'GET',
+        url: '/notifications/last'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    lab.test('returns a 404 if no items are found', async () => {
+      client.getLatestEmailByAddress.resolves({
+        data: [],
+        error: null,
+        pagination: { page: 1, perPage: 1, totalRows: 0, pageCount: 0 }
+      });
+
+      const request = {
+        method: 'GET',
+        url: '/notifications/last?email=test'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(404);
+    });
+
+    lab.test('returns a 200 with the expected data', async () => {
+      client.getLatestEmailByAddress.resolves({
+        data: [{ id: 1 }, { id: 2 }],
+        error: null,
+        pagination: { page: 1, perPage: 1, totalRows: 2, pageCount: 1 }
+      });
+
+      const request = {
+        method: 'GET',
+        url: '/notifications/last?email=test'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].id).to.equal(1);
+    });
+  });
+}


### PR DESCRIPTION
Adds a route that is only accessible when `test_mode` is set to `1`.

This endpoint will return the most recently sent email notification for
a given email address.

 - Adds a `.labrc.js` file to configure the global variables that are to be ignored by lab's leak checks.
 - Adds code climate config to ignore migrations dir.