### PR TITLE
WATER-1130 Removes extra spacing for conditions

### DIFF
--- a/src/views/partials/licence-condition.html
+++ b/src/views/partials/licence-condition.html
@@ -83,8 +83,7 @@
 
       </div>
       {{/each}}
-      <br />
     {{/each}}
   </div>
-
 </div>
+{{#unless @last}}<br />{{/unless}}

--- a/src/views/water/view-licences/conditions.html
+++ b/src/views/water/view-licences/conditions.html
@@ -30,7 +30,6 @@
 
     <br />
 
-
   {{#equal licenceData.conditions.length 0}}
   <p>
   Sorry, we do not hold any information about your conditions on our system yet.
@@ -39,13 +38,9 @@
   </p>
   {{/equal}}
 
-
-
   {{#each licenceData.conditions }}
     {{>licence-condition this}}
   {{/each}}
-
-
 
 </main>
 {{> footerjs}}


### PR DESCRIPTION
Changes the licence-condition partial to only include a line break if
the condition is not the last in an iterator.