### PR TITLE
WATER-1070: Wider inputs

### DIFF
--- a/src/views/water/notifications/data.html
+++ b/src/views/water/notifications/data.html
@@ -29,7 +29,7 @@
         <input type="hidden" name="csrf_token" value="{{ csrfToken }}" />
 
         <div class="grid-row medium-space">
-          <div class="column-two-thirds">
+          <div class="column-full">
 
             {{#each task.config.variables}}
               {{#equal this.widget 'dropdown' }}


### PR DESCRIPTION
Changes the containing column class to `column-full` from
`column-two-thirds` to allow the inputs to be slightly wider.