### PR TITLE
Bug-fix: Collect all validation errors

### DIFF
--- a/src/modules/notifications/contact-routes.js
+++ b/src/modules/notifications/contact-routes.js
@@ -48,6 +48,9 @@ module.exports = {
             'contact-job-title': Joi.string().required(),
             'csrf_token': Joi.string().guid().required(),
             'redirect': Joi.string().allow('')
+          },
+          options: {
+            abortEarly: false
           }
         }
       }
@@ -89,6 +92,9 @@ module.exports = {
           activeNavLink: 'notifications'
         },
         formValidator: {
+          options: {
+            abortEarly: false
+          },
           payload: {
             'csrf_token': Joi.string().guid().required(),
             'contact-email': VALID_EMAIL,

--- a/src/modules/notifications/lib/task-data.js
+++ b/src/modules/notifications/lib/task-data.js
@@ -114,7 +114,7 @@ class TaskData {
       this.data.params[name] = this.mappers[mapper].import(name, payload);
     });
 
-    const { error } = Joi.validate(this.data.params, schema, { allowUnknown: true });
+    const { error } = Joi.validate(this.data.params, schema, { abortEarly: false, allowUnknown: true });
 
     return { error: this.mapJoiError(error, widgets) };
   }
@@ -237,7 +237,7 @@ class TaskData {
       ...query
     };
 
-    const { error } = Joi.validate(query, this.createJoiSchema(widgets), { allowUnknown: true });
+    const { error } = Joi.validate(query, this.createJoiSchema(widgets), { abortEarly: false, allowUnknown: true });
 
     return { error: this.mapJoiError(error, widgets) };
   }


### PR DESCRIPTION
WATER-1289

Changes the behaviour of Joi to collect all the validation errors rather
than existing on the first error.

This means that the forms will show all the errors at once to the user.

In this change, this effects the notification templates and the two
forms that collect the user's contact information prior to sending a
notification.