### PR TITLE
Bug-fix: Prevent browser validation on contact form

### DIFF
--- a/src/views/water/notifications/contact-details.html
+++ b/src/views/water/notifications/contact-details.html
@@ -13,7 +13,7 @@
       <p>This is the information that will be available to your public contacts.</p>
 
 
-      <form method="POST" action="/admin/notifications/contact-details">
+      <form novalidate method="POST" action="/admin/notifications/contact-details">
         <input type="hidden" name="csrf_token" value="{{ csrfToken }}" />
 {{> contact-details-addresses }}
         <button type="submit" class="button">Continue</button>


### PR DESCRIPTION
WATER-1292

Adds the `novalidate` attribute to the form in the contact details page.