### PR TITLE
feature: Use IDM application over admin flag

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -3,5 +3,15 @@
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
   // This version global seems to be introduced by sinon.
-  globals: 'version'
+  globals: 'version',
+
+  'coverage-exclude': [
+    'data',
+    'govuk_modules',
+    'node_modules',
+    'public',
+    'src/lib/logger/vendor',
+    'test',
+    'views'
+  ]
 };

--- a/config.js
+++ b/config.js
@@ -1,5 +1,9 @@
 module.exports = {
 
+  idm: {
+    application: 'water_vml'
+  },
+
   defaultAuth: {
     strategy: 'standard',
     mode: 'try'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "heroku-prebuild": "npm install --only=dev",
     "heroku-postbuild": "gulp clean && gulp copy-govuk-files && gulp install-govuk-files && gulp copy-static-assets && gulp sass",
-    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --coverage-path ./src/ -r lcov -o lcov.info -r console -o stdout",
+    "test": "./node_modules/lab/bin/lab -t 55 -m 0 -r lcov -o lcov.info -r console -o stdout",
     "test-cov-html": "lab -r html -o coverage.html",
     "docs": "jsdoc -c conf.jsdoc.json && cd ./out && serve -o -p 3011",
     "lint": "./node_modules/.bin/eslint ./src/**/*.js --fix",

--- a/src/lib/connectors/idm.js
+++ b/src/lib/connectors/idm.js
@@ -12,8 +12,7 @@ const client = new APIClient(rp, {
     Authorization: process.env.JWT_TOKEN
   }
 });
-
-
+const config = require('../../../config');
 const idmKPI = require('./idm/kpi');
 
 /**
@@ -44,12 +43,12 @@ function resetPassword (email, mode = 'reset', params = {}) {
  * @param {String} resetGuid - the password reset GUID issued by email
  * @return {Promise} resolves with user record if found or null otherwise
  */
-async function getUserByResetGuid (reset_guid) {
+async function getUserByResetGuid (resetGuid) {
   const {
     error,
     data
   } = await client.findMany({
-    reset_guid
+    reset_guid: resetGuid
   });
   if (error) {
     throw error;
@@ -84,43 +83,23 @@ function getUser (userId) {
   return client.findOne(userId.toLowerCase());
 }
 
-function login (user_name, password) {
-  return new Promise((resolve, reject) => {
-    var data = {
-      user_name: user_name,
-      password: password
-    };
-    var uri = process.env.IDM_URI + '/user/login' + '?token=' + process.env.JWT_TOKEN;
-    var method = 'post';
-    Helpers.makeURIRequestWithBody(uri, method, data)
-      .then((response) => {
-        // console.log('login response')
-        // console.log(response.body)
-        response.body.sessionGUID = Helpers.createGUID();
-        resolve(response);
-      }).catch((response) => {
-        // console.log(response)
-        // console.log('rejecting in idm.login')
-        reject(response);
-      });
-  });
+function login (userName, password) {
+  return verifyCredentials(userName, password)
+    .then((response) => {
+      response.body.sessionGUID = Helpers.createGUID();
+      return response;
+    });
 }
 
-function verifyCredentials (user_name, password) {
-  return new Promise((resolve, reject) => {
-    var data = {
-      user_name: user_name,
-      password: password
-    };
-    var uri = process.env.IDM_URI + '/user/login' + '?token=' + process.env.JWT_TOKEN;
-    var method = 'post';
-    Helpers.makeURIRequestWithBody(uri, method, data)
-      .then((response) => {
-        resolve(response);
-      }).catch((response) => {
-        reject(response);
-      });
-  });
+function verifyCredentials (userName, password) {
+  const data = {
+    user_name: userName,
+    password: password,
+    application: config.idm.application
+  };
+  const uri = `${process.env.IDM_URI}/user/login?token=${process.env.JWT_TOKEN}`;
+  const method = 'post';
+  return Helpers.makeURIRequestWithBody(uri, method, data);
 }
 
 function getPasswordResetLink (emailAddress) {
@@ -171,7 +150,7 @@ const usersClient = new APIClient(rp, {
 });
 
 module.exports = {
-  login: login,
+  login,
   resetPassword,
   getPasswordResetLink: getPasswordResetLink,
   updatePassword: updatePassword,


### PR DESCRIPTION
The IDM has changed to no longer have a on off switch for a user being
granted access to the admin application.

Now users are assigned to an application which will either be view my
licence or admin.

This has a dependency on [new IDM code](https://github.com/DEFRA/water-abstraction-tactical-idm/pull/48)