### PR TITLE
Fix: Missing update when changing IDM admin

### DIFF
--- a/src/lib/connectors/idm.js
+++ b/src/lib/connectors/idm.js
@@ -68,9 +68,9 @@ function createUserWithoutPassword (emailAddress) {
     user_name: emailAddress.toLowerCase(),
     password: Helpers.createGUID(),
     reset_guid: Helpers.createGUID(),
-    admin: 0,
     user_data: {},
-    reset_required: 1
+    reset_required: 1,
+    application: config.idm.application
   });
 }
 


### PR DESCRIPTION
IDM admin is now removed so the registration needed to be updated to
include the application and not the admin field