### PR TITLE
Feature: Handle user role with returns permission

### DIFF
--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { intersection } = require('lodash');
+// Using lodash functions over some native functions because
+// they are forgiving to undefined.
+const { size, find, includes, intersection, get } = require('lodash');
+
 /**
  * Permissions module
  *
@@ -21,31 +24,66 @@ const { intersection } = require('lodash');
  * @param {String|Array} type - the role type or types to match
  * @return {Number} number of roles of specified type
  */
-function countRoles (roles, type) {
+const countRoles = (roles = [], type) => {
   // Handle array or string
   const types = typeof (type) === 'string' ? [type] : type;
   return roles.reduce((memo, role) => {
-    return types.includes(role.role) ? memo + 1 : memo;
+    return includes(types, role.role) ? memo + 1 : memo;
   }, 0);
-}
+};
 
-const hasMatch = (requiredScopes, userScopes) => intersection(requiredScopes, userScopes).length > 0;
+/**
+ * Checks if the user has a scope that is in the list of required scopes
+ *
+ * @param {array} requiredScopes A list of strings representing the scopes that are required for a resource
+ * @param {array} userScopes The list of strings representing the scopes a user has
+ * @returns {boolean}
+ */
+const hasMatch = (requiredScopes, userScopes) => {
+  return size(intersection(requiredScopes, userScopes)) > 0;
+};
 
-const isExternal = (scope = []) => scope.includes('external');
-const isVmlAdmin = (scope = []) => hasMatch(['internal', 'ar_user', 'ar_approver'], scope);
-const isPrimaryUser = (roles = []) => !!roles.find(role => role.role === 'primary_user');
+/**
+ * Does the role object have a role property of 'user'?
+ */
+const isUserRole = role => get(role, 'role') === 'user';
+
+/**
+ * Does the role object have a role property of 'primary_user'?
+ */
+const isPrimaryUserRole = role => get(role, 'role') === 'primary_user';
+
+/**
+ * Checks if there is a scope called 'external'
+ *
+ * @param scope An array of strings
+ */
+const isExternal = scope => includes(scope, 'external');
+
+const isVmlAdmin = scope => hasMatch(['internal', 'ar_user', 'ar_approver'], scope);
+const isPrimaryUser = roles => !!find(roles, isPrimaryUserRole);
 
 const canReadLicence = entityId => !!entityId;
-const canEditAbstractionReform = (scope = []) => hasMatch(['ar_user', 'ar_approver'], scope);
+const canEditAbstractionReform = scope => hasMatch(['ar_user', 'ar_approver'], scope);
 
-const canApproveAbstractionReform = (scope = []) => scope.includes('ar_approver');
+const canApproveAbstractionReform = scope => includes(scope, 'ar_approver');
 
-const canEditLicence = (scope = [], roles = []) => {
-  return isExternal(scope) && roles.length === 1 && isPrimaryUser(roles);
+const canEditLicence = (scope, roles) => {
+  return isExternal(scope) && size(roles) === 1 && isPrimaryUser(roles);
 };
 
 const canViewMutlipleLicences = (scope = [], roles = []) => {
   return isExternal(scope) && countRoles(roles, ['user', 'primary_user']) > 1;
+};
+
+const getUserRole = roles => find(roles, isUserRole);
+
+const canPerformReturns = (scope = [], roles = []) => {
+  if (isExternal(scope)) {
+    const user = getUserRole(roles);
+    return isPrimaryUser(roles) || get(user, 'permissions.returns', false);
+  }
+  return false;
 };
 
 /**
@@ -60,7 +98,8 @@ const getPermissions = (credentials = {}) => {
     licences: {
       read: canReadLicence(entityId),
       edit: canEditLicence(scope, roles),
-      multi: canViewMutlipleLicences(scope, roles)
+      multi: canViewMutlipleLicences(scope, roles),
+      returns: canPerformReturns(scope, roles)
     },
     admin: {
       defra: isVmlAdmin(scope)

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -44,14 +44,16 @@ const hasMatch = (requiredScopes, userScopes) => {
 };
 
 /**
- * Does the role object have a role property of 'user'?
- */
-const isUserRole = role => get(role, 'role') === 'user';
-
-/**
  * Does the role object have a role property of 'primary_user'?
+ * { role: 'primary_user' }
  */
 const isPrimaryUserRole = role => get(role, 'role') === 'primary_user';
+
+/**
+ * Is this a role with a role value of user_returns.
+ * { role: 'user_returns' }
+ */
+const isUserReturnsRole = role => get(role, 'role') === 'user_returns';
 
 /**
  * Checks if there is a scope called 'external'
@@ -62,6 +64,7 @@ const isExternal = scope => includes(scope, 'external');
 
 const isVmlAdmin = scope => hasMatch(['internal', 'ar_user', 'ar_approver'], scope);
 const isPrimaryUser = roles => !!find(roles, isPrimaryUserRole);
+const isUserReturnsUser = roles => !!find(roles, isUserReturnsRole);
 
 const canReadLicence = entityId => !!entityId;
 const canEditAbstractionReform = scope => hasMatch(['ar_user', 'ar_approver'], scope);
@@ -76,14 +79,9 @@ const canViewMutlipleLicences = (scope = [], roles = []) => {
   return isExternal(scope) && countRoles(roles, ['user', 'primary_user']) > 1;
 };
 
-const getUserRole = roles => find(roles, isUserRole);
-
 const canPerformReturns = (scope = [], roles = []) => {
-  if (isExternal(scope)) {
-    const user = getUserRole(roles);
-    return isPrimaryUser(roles) || get(user, 'permissions.returns', false);
-  }
-  return false;
+  return isExternal(scope) &&
+    (isPrimaryUser(roles) || isUserReturnsUser(roles));
 };
 
 /**

--- a/src/lib/sign-in.js
+++ b/src/lib/sign-in.js
@@ -35,7 +35,7 @@ async function getIDMUser (emailAddress) {
  * @param {String} emailAddress - email address of user
  * @return {Object} returns object with data stored in secure cookie
  */
-async function auto (request, emailAddress, userData = {}, lastlogin) {
+async function auto (request, emailAddress) {
   const user = await getIDMUser(emailAddress);
   const entityId = await CRM.entities.getOrCreateIndividual(user.user_name);
   await idm.updateExternalId(user, entityId);
@@ -53,36 +53,36 @@ async function auto (request, emailAddress, userData = {}, lastlogin) {
     csrf_token: createGUID()
   });
 
-  if (!userData.usertype) {
-    userData.usertype = 'external';
-  }
-
-  if (lastlogin) {
-    userData.newuser = false;
-    userData.lastlogin = lastlogin;
-  } else {
-    userData.newuser = true;
-    userData.lastlogin = null;
-  }
-
   // Data to store in cookie
-  const session = {
-    sid: sessionId,
-    username: emailAddress.toLowerCase().trim(),
-    user_id: user.user_id,
-    entity_id: entityId,
-    user_data: userData,
-    lastlogin: lastlogin,
-    roles,
-    scope: get(user, 'role.scopes', [])
-  };
+  const session = createSessionData(sessionId, user, entityId, roles);
 
   // Set user info in signed cookie
   request.cookieAuth.set(session);
-
   return session;
 }
 
+/**
+ * Create an object that is to be persisted in the cookies
+ */
+const createSessionData = (sessionId, user, entityId, entityRoles) => {
+  const session = {
+    sid: sessionId,
+    username: user.user_name.toLowerCase().trim(),
+    user_id: user.user_id,
+    entity_id: entityId,
+    user_data: user.user_data || {},
+    lastlogin: user.lastlogin,
+    roles: entityRoles,
+    scope: get(user, 'role.scopes', [])
+  };
+
+  session.user_data.newuser = !!user.lastlogin;
+  session.user_data.lastlogin = user.lastlogin || null;
+
+  return session;
+};
+
 module.exports = {
-  auto
+  auto,
+  createSessionData
 };

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -74,9 +74,7 @@ async function postSignin (request, reply) {
     const {
       body: {
         reset_required: resetRequired,
-        reset_guid: resetGuid,
-        user_data: userData,
-        last_login: lastLogin
+        reset_guid: resetGuid
       }
     } = await IDM.login(request.payload.user_id, request.payload.password);
 
@@ -87,7 +85,7 @@ async function postSignin (request, reply) {
       return reply.redirect(`reset_password_change_password?resetGuid=${resetGuid}&forced=1`);
     }
 
-    const session = await signIn.auto(request, request.payload.user_id, userData, lastLogin);
+    const session = await signIn.auto(request, request.payload.user_id);
 
     // Redirect user
     const permissions = getPermissions(session);

--- a/test/lib/permissions.js
+++ b/test/lib/permissions.js
@@ -110,11 +110,7 @@ lab.experiment('getPermissions::agent with data returns', () => {
   let permissions;
 
   lab.beforeEach(async () => {
-    const userRole = {
-      role: 'user',
-      permissions: { returns: true }
-    };
-    const credentials = getCredentials(['external'], [userRole], 'entity-id');
+    const credentials = getCredentials(['external'], ['user', 'user_returns'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 

--- a/test/lib/sign-in.js
+++ b/test/lib/sign-in.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const { expect } = require('code');
+
+const { createSessionData } = require('../../src/lib/sign-in');
+
+lab.experiment('sign-in.createSessionData', () => {
+  let sessionData;
+  let sessionId;
+  let emailAddress;
+  let userId;
+  let entityId;
+  let user;
+  let roles;
+
+  lab.beforeEach(async () => {
+    sessionId = 'test-session-id';
+    userId = 'user-id';
+    entityId = 'entity-id';
+    emailAddress = 'unit-test@example.com';
+    roles = [{ role: 'admin' }];
+
+    user = {
+      user_id: userId,
+      user_name: emailAddress,
+      user_data: { test: 'data' },
+      role: { scopes: ['test-scope'] },
+      lastlogin: 'last-login'
+    };
+
+    sessionData = createSessionData(sessionId, user, entityId, roles);
+  });
+
+  lab.test('adds the session id', async () => {
+    expect(sessionData.sid).to.equal(sessionId);
+  });
+
+  lab.test('add the email address as the user name', async () => {
+    expect(sessionData.username).to.equal('unit-test@example.com');
+  });
+
+  lab.test('lowercases the email address', async () => {
+    const data = createSessionData(sessionId, {
+      user_name: 'UNIT-test@EXAMPLE.com'
+    });
+    expect(data.username).to.equal('unit-test@example.com');
+  });
+
+  lab.test('trims the email address', async () => {
+    const data = createSessionData(sessionId, {
+      user_name: '   unit-test@example.com    '
+    });
+    expect(data.username).to.equal('unit-test@example.com');
+  });
+
+  lab.test('adds the user id', async () => {
+    expect(sessionData.user_id).to.equal(userId);
+  });
+
+  lab.test('adds the entity id', async () => {
+    expect(sessionData.entity_id).to.equal(entityId);
+  });
+
+  lab.test('adds the user data from the user object', async () => {
+    expect(sessionData.user_data.test).to.equal('data');
+  });
+
+  lab.test('adds the last login value from the user', async () => {
+    expect(sessionData.lastlogin).to.equal(user.lastlogin);
+  });
+
+  lab.test('adds the roles', async () => {
+    expect(sessionData.roles).to.equal(roles);
+  });
+
+  lab.test('adds the scopes from the user', async () => {
+    expect(sessionData.scope).to.equal(user.role.scopes);
+  });
+
+  lab.test('sets user data newuser to false if no lastlogin', async () => {
+    const neverLoggedInUser = {
+      user_id: userId,
+      user_name: emailAddress,
+      user_data: { test: 'data' },
+      role: { scopes: ['test-scope'] }
+    };
+
+    const data = createSessionData('id', neverLoggedInUser, 'eid', []);
+    expect(data.user_data.newuser).to.be.false();
+  });
+
+  lab.test('sets user data last login to null if no lastlogin', async () => {
+    const neverLoggedInUser = {
+      user_id: userId,
+      user_name: emailAddress,
+      user_data: { test: 'data' },
+      role: { scopes: ['test-scope'] }
+    };
+
+    const data = createSessionData('id', neverLoggedInUser, 'eid', []);
+    expect(data.user_data.lastlogin).to.be.null();
+  });
+
+  lab.test('sets user data newuser to true if lastlogin exists', async () => {
+    expect(sessionData.user_data.newuser).to.be.true();
+  });
+
+  lab.test('sets user data last login if lastlogin exists', async () => {
+    expect(sessionData.user_data.lastlogin).to.equal(user.lastlogin);
+  });
+});


### PR DESCRIPTION
Updates the permissions object so that an external user can have a
returns permission.

This may be a primary_user, or a user who has been allocated returns
permission by the primary user.