### PR TITLE
Fix: Shows email validation error

### DIFF
--- a/src/lib/connectors/idm.js
+++ b/src/lib/connectors/idm.js
@@ -79,12 +79,25 @@ function createUserWithoutPassword (emailAddress) {
 }
 
 /**
- * Get user by numeric ID/email address
- * @param {String|Number} numeric ID or string email address
+ * Get user by numeric ID
+ * @param {Number} numeric ID
  * @return {Promise} resolves with user if found
  */
-function getUser (userId) {
-  return client.findOne(userId.toLowerCase());
+const getUser = userId => client.findOne(userId);
+
+/**
+ * Gets the user for the current VML application who has the
+ * given email address.
+ *
+ * @param {String} The user's email address.
+ * @return {Promise} Resolves with an array of users which should
+ * only ever have zero or one users.
+ */
+function getUserByEmail (email) {
+  return client.findMany({
+    user_name: email,
+    application: config.idm.application
+  });
 }
 
 function login (userName, password) {
@@ -113,7 +126,6 @@ function getPasswordResetLink (emailAddress) {
       .then((response) => {
         resolve(response.body);
       }).catch((response) => {
-        //      console.log('rejecting in idm.getPasswordResetLink')
         reject(response);
       });
   });
@@ -121,13 +133,11 @@ function getPasswordResetLink (emailAddress) {
 
 /**
  * Updates user password
- * @param {String} username - user's IDM email address
+ * @param {number} user id - user's ID
  * @param {String} password - new password
  */
-function updatePassword (username, password) {
-  return client.updateOne(username, {
-    password
-  });
+function updatePassword (userId, password) {
+  return client.updateOne(userId, { password });
 }
 
 /**
@@ -173,6 +183,7 @@ module.exports = {
   updatePasswordWithGuid,
   createUserWithoutPassword,
   getUser,
+  getUserByEmail,
   getUserByResetGuid,
   verifyCredentials,
   usersClient,

--- a/src/modules/manage-licences/controller.js
+++ b/src/modules/manage-licences/controller.js
@@ -130,7 +130,7 @@ async function postAddAccess (request, reply, context = {}) {
     }
 
     // Update the idm.user with the crm.entity id
-    const { data: user } = await IDM.getUser(email);
+    const { data: user } = await IDM.getUserByEmail(email);
     await IDM.updateExternalId(user, crmEntityId);
 
     return reply.view('water/manage-licences/manage_licences_added_access', viewContext);

--- a/src/modules/update-password/controller.js
+++ b/src/modules/update-password/controller.js
@@ -60,8 +60,8 @@ async function postSetPassword (request, reply) {
       throw new AuthTokenError();
     }
     // Change password
-    const { username } = request.auth.credentials;
-    const { error } = IDM.updatePassword(username, password);
+    const { user_id: userId } = request.auth.credentials;
+    const { error } = IDM.updatePassword(userId, password);
     if (error) {
       throw error;
     }

--- a/src/modules/view-licences/routes-admin.js
+++ b/src/modules/view-licences/routes-admin.js
@@ -27,8 +27,11 @@ const getLicencesAdmin = {
       },
       formValidator: {
         query: {
-          emailAddress: Joi.string().allow('').email(),
-          licenceNumber: Joi.string().allow('')
+          emailAddress: Joi.string().email().allow(''),
+          licenceNumber: Joi.string().allow(''),
+          sort: Joi.string().valid('licenceNumber', 'name', 'expiryDate').default('licenceNumber'),
+          direction: Joi.number().valid(1, -1).default(1),
+          page: Joi.number().allow('').min(1).default(1)
         }
       }
     }

--- a/src/modules/view-licences/routes.js
+++ b/src/modules/view-licences/routes.js
@@ -212,7 +212,10 @@ module.exports = {
         formValidator: {
           query: {
             emailAddress: Joi.string().allow('').email(),
-            licenceNumber: Joi.string().allow('')
+            licenceNumber: Joi.string().allow(''),
+            sort: Joi.string().valid('licenceNumber', 'name', 'expiryDate').default('licenceNumber'),
+            direction: Joi.number().valid(1, -1).default(1),
+            page: Joi.number().allow('').min(1).default(1)
           }
         }
       }

--- a/src/views/water/view-licences/licences.html
+++ b/src/views/water/view-licences/licences.html
@@ -3,7 +3,6 @@
 
   {{>element-phase-tag}}{{>element-main-nav}}
 
-
   {{#if errors.emailAddress_email }}
   <div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
     <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
@@ -25,7 +24,6 @@
     </ul>
   </div>
   {{/if}}
-
 
   <h1 class="heading-large">{{ pageTitle }}</h1>
 
@@ -50,7 +48,7 @@
 
     {{#if showEmailFilter }}
     <div class="column-two-fifths">
-      <div class="form-group form-group--horizontal {{#if error }}form-group-error{{/if}}">
+      <div class="form-group form-group--horizontal {{#if errors.emailAddress_email }}form-group-error{{/if}}">
         <label class="form-label form-label--bold" for="emailAddress">Search by licence holder</label>
         <span class="form-hint">Enter their registered email address</span>
         <input maxlength="254" type="email" class="form-control form-control--block {{#if error}}form-control-error{{/if}}" name="emailAddress" id="emailAddress" value="{{ query.emailAddress }}" />

--- a/test/modules/view-licences/base.js
+++ b/test/modules/view-licences/base.js
@@ -1,0 +1,117 @@
+const { expect } = require('code');
+const { it, experiment, beforeEach, afterEach } = exports.lab = require('lab').script();
+const sinon = require('sinon');
+const IDM = require('../../../src/lib/connectors/idm');
+const CRM = require('../../../src/lib/connectors/crm');
+const baseController = require('../../../src/modules/view-licences/base');
+
+experiment('view-licences/base', () => {
+  const viewName = 'water/view-licences/licences';
+  let h;
+
+  beforeEach(async () => {
+    sinon.stub(IDM, 'getUserByEmail');
+    sinon.stub(CRM.documents, 'getLicences');
+    h = {
+      view: sinon.spy()
+    };
+  });
+
+  afterEach(async () => {
+    IDM.getUserByEmail.restore();
+    CRM.documents.getLicences.restore();
+  });
+
+  experiment('when the form is invalid', () => {
+    let request;
+
+    beforeEach(async () => {
+      request = {
+        view: {},
+        formError: { email: true }
+      };
+      baseController.getLicences(request, h);
+    });
+
+    it('the view is shown again', async () => {
+      expect(h.view.calledWith(viewName, request.view)).to.be.true();
+    });
+
+    it('the controller does not get the user', async () => {
+      expect(IDM.getUserByEmail.notCalled).to.be.true();
+    });
+
+    it('the controller does not get the licences', async () => {
+      expect(CRM.documents.getLicences.notCalled).to.be.true();
+    });
+  });
+
+  experiment('when the user adds an unknown email address', () => {
+    let request;
+
+    beforeEach(async () => {
+      request = {
+        auth: {
+          credentials: {
+            entity_id: '123'
+          }
+        },
+        view: {},
+        query: {
+          emailAddress: 'test@example.com'
+        }
+      };
+
+      IDM.getUserByEmail.resolves({ data: [] });
+      CRM.documents.getLicences.resolves({
+        data: [],
+        error: null,
+        pagination: {}
+      });
+
+      baseController.getLicences(request, h);
+    });
+
+    it('an attempt is made to get the user by email', async () => {
+      expect(IDM.getUserByEmail.calledWith('test@example.com')).to.be.true();
+    });
+
+    it('an error is added to the view', async () => {
+      expect(request.view.error).to.be.true();
+    });
+  });
+
+  experiment('when the request is valid', async () => {
+    let request;
+
+    beforeEach(async () => {
+      request = {
+        auth: {
+          credentials: {
+            entity_id: '123'
+          }
+        },
+        view: {},
+        query: { page: 1 }
+      };
+
+      CRM.documents.getLicences.resolves({
+        data: [{ id: 1 }],
+        error: null,
+        pagination: { page: 1 }
+      });
+
+      baseController.getLicences(request, h);
+    });
+
+    it('the view is shown using the expected view template', async () => {
+      expect(h.view.firstCall.args[0]).to.equal(viewName);
+    });
+
+    it('the data is added to the response', async () => {
+      const viewContext = h.view.firstCall.args[1];
+      expect(viewContext.licenceData[0].id).to.equal(1);
+      expect(viewContext.pagination.page).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Use the `formError` if the email address is not valid.

Shortcuts the controller handler to prevent processing of bad input and
displays the feedback to the user.

Changes `getUser` to deal with numeric ids. No longer need to lowercase
the value either because this happens in the pre query filter in the
IDM.

Gets the user via the email address and application name to handle
multiple IDM entries for the same email address.

Adds form validation plugin validators which are required so the
formError is not truthy, covering page, sort and direction.