### PR TITLE
Bug: Spacing and text for add licences

### DIFF
--- a/src/lib/sign-in.js
+++ b/src/lib/sign-in.js
@@ -37,8 +37,13 @@ async function getIDMUser (emailAddress) {
  */
 async function auto (request, emailAddress) {
   const user = await getIDMUser(emailAddress);
-  const entityId = await CRM.entities.getOrCreateIndividual(user.user_name);
-  await idm.updateExternalId(user, entityId);
+
+  let entityId = user.external_id;
+
+  if (!entityId) {
+    entityId = await CRM.entities.getOrCreateIndividual(user.user_name);
+    await idm.updateExternalId(user, entityId);
+  }
 
   // Get roles for user
   const { error, data: roles } = await CRM.entityRoles.setParams({entityId}).findMany();

--- a/src/modules/add-licences/controller.js
+++ b/src/modules/add-licences/controller.js
@@ -31,7 +31,7 @@ const {
 async function getLicenceAdd (request, reply) {
   const viewContext = View.contextDefaults(request);
   viewContext.activeNavLink = 'manage';
-  viewContext.pageTitle = 'Which licences do you want to be able to view?';
+  viewContext.pageTitle = 'Which licences do you want to view?';
   return reply.view('water/licences-add/add-licences', viewContext);
 }
 

--- a/src/views/water/licences-add/add-licences.html
+++ b/src/views/water/licences-add/add-licences.html
@@ -85,14 +85,15 @@
         <!-- licence number field -->
         <div class="form-group {{#if error }}form-group-error{{/if}}">
           <label for="licence_no">
-            <span class="form-label-bold">Enter your licence number(s)</span>
+            <p class="form-label-bold">Enter your licence number(s)</p>
+            <p class="form-hint">
+              You can only view water abstraction licences online at the moment.
+              We will let you know when you can also view any impoundment licences you
+              hold.
+            </p>
             <span class="form-hint">
-              You can only view water abstraction licences online at the moment. We will let you know when you can also view any impoundment licences you hold.
-            </span>
-            <br/>
-            <br/>
-            <span class="form-hint">
-              You can separate your licence numbers using spaces, commas, or by entering them on different lines.
+              You can separate your licence numbers using spaces, commas,
+              or by entering them on different lines.
             </span>
           </label>
           <textarea maxlength="8000" class="form-control form-control-3-4" name="licence_no" id="licence_no" rows="5" required >{{ payload.licence_no }}</textarea>


### PR DESCRIPTION
WATER-1302

 - Changes add licences page title
 - Changes the markup to reduce space between paragraphs on the add
licence form

Also in sign in don't get or create an entity if the idm.user record has
an external id.