### PR TITLE
Handles an error when granting licence access

### DIFF
--- a/src/modules/manage-licences/controller.js
+++ b/src/modules/manage-licences/controller.js
@@ -165,7 +165,8 @@ async function postAddAccess (request, reply, context = {}) {
 
     return reply.view('water/manage-licences/manage_licences_added_access', viewContext);
   } catch (err) {
-    reply(err);
+    console.error(err);
+    throw err;
   }
 }
 


### PR DESCRIPTION
Throws the error rather than your the response toolkit. This is probably
a missed upgrade when going from Hapi 16 to 17.