### PR TITLE
Fix: Allows authorised internal users to access returns

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -2,6 +2,10 @@ const SCOPE_INTERNAL = 'internal';
 const SCOPE_ABSTRACTION_REFORM_USER = 'ar_user';
 const SCOPE_ABSTRACTION_REFORM_APPROVER = 'ar_approver';
 
+const ROLE_EXTERNAL_COLLEAGUE = 'user';
+const ROLE_EXTERNAL_COLLEAGUE_RETURNS = 'user_returns';
+const ROLE_EXTERNAL_LICENCE_HOLDER = 'primary_user';
+
 module.exports = {
   scope: {
     allAdmin: [
@@ -12,5 +16,10 @@ module.exports = {
     internal: SCOPE_INTERNAL,
     abstractionReformUser: SCOPE_ABSTRACTION_REFORM_USER,
     abstractionReformApprover: SCOPE_ABSTRACTION_REFORM_APPROVER
+  },
+  externalRoles: {
+    colleague: ROLE_EXTERNAL_COLLEAGUE,
+    colleagueWithReturns: ROLE_EXTERNAL_COLLEAGUE_RETURNS,
+    licenceHolder: ROLE_EXTERNAL_LICENCE_HOLDER
   }
 };

--- a/src/modules/returns/controller.js
+++ b/src/modules/returns/controller.js
@@ -4,7 +4,8 @@ const Boom = require('boom');
 const {
   getLicenceNumbers,
   getReturnData,
-  getReturnsViewData
+  getReturnsViewData,
+  isInternalReturnsUser
 } = require('./helpers');
 
 /**
@@ -50,7 +51,8 @@ const getReturn = async (request, h) => {
   const { licence_ref: licenceNumber } = data.return;
 
   // Load licence from CRM to check user has access
-  const [ documentHeader ] = await getLicenceNumbers(entityId, {system_external_id: licenceNumber});
+  const isInternalReturns = isInternalReturnsUser(request);
+  const [ documentHeader ] = await getLicenceNumbers(entityId, {system_external_id: licenceNumber}, isInternalReturns);
 
   if (!documentHeader) {
     throw Boom.forbidden(`Access denied return ${id} for entity ${entityId}`);

--- a/test/modules/returns/helpers.js
+++ b/test/modules/returns/helpers.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { expect } = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const helpers = require('../../../src/modules/returns/helpers');
+
+lab.experiment('isInternalReturnsUser', () => {
+  lab.test('returns false if the user does not have returns permission', async () => {
+    const request = {
+      permissions: {
+        returns: {
+          read: false
+        }
+      }
+    };
+
+    const isInternalReturnsUser = helpers.isInternalReturnsUser(request);
+    expect(isInternalReturnsUser).to.be.false();
+  });
+
+  lab.test('there is a result for the user with returns', async () => {
+    const request = {
+      permissions: {
+        returns: {
+          read: true
+        }
+      }
+    };
+
+    const isInternalReturnsUser = helpers.isInternalReturnsUser(request);
+    expect(isInternalReturnsUser).to.be.true();
+  });
+});
+
+lab.experiment('getInternalRoles', () => {
+  lab.test('returns the original roles if the user is an internal user', async () => {
+    const isInternalUser = true;
+    const roles = helpers.getInternalRoles(isInternalUser, ['test_role']);
+    expect(roles).to.only.include('test_role');
+  });
+
+  lab.test('returns replaces the original roles with the expected roles if the user is an external user', async () => {
+    const isInternalUser = false;
+    const roles = helpers.getInternalRoles(isInternalUser, ['test_role']);
+    expect(roles).to.only.include(['primary_user', 'user_returns']);
+  });
+});


### PR DESCRIPTION
If the user is an authorised internal user, then do not add roles filter
to the request for returns licence numbers.

Adds constants for external user roles which attempt to use more domain
specific language