### PR TITLE
Fix: Internal user not seeing returns

### DIFF
--- a/src/lib/hapi-plugins/error.js
+++ b/src/lib/hapi-plugins/error.js
@@ -8,7 +8,7 @@
  */
 const { contextDefaults } = require('../view');
 const logger = require('../logger');
-const { get } = require('lodash');
+const { get, pick } = require('lodash');
 
 const errorPlugin = {
   register: (server, options) => {
@@ -25,7 +25,7 @@ const errorPlugin = {
         // Boom errors
         if (!ignore && res.isBoom) {
           // ALWAYS Log the error
-          logger.error(res);
+          logger.error(pick(res, ['error', 'message', 'statusCode', 'stack']));
 
           const { statusCode } = res.output;
 

--- a/src/modules/returns/admin-routes.js
+++ b/src/modules/returns/admin-routes.js
@@ -21,9 +21,7 @@ module.exports = {
         scope: ['returns']
       },
       plugins: {
-        ...getReturn.config.plugins,
         viewContext: {
-          ...getReturn.config.plugins.viewContext,
           activeNavLink: 'view'
         }
       }


### PR DESCRIPTION
When an internal user was requesting to look at a single return, the
route ACL that was copied from the external user was preventing access.

To fix, the internal user route is written to not include that part of
the external route config.