### PR TITLE
Feat: Allow read returns for all internal users

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,6 +1,8 @@
 const SCOPE_INTERNAL = 'internal';
+const SCOPE_INTERNAL_RETURNS = 'returns';
 const SCOPE_ABSTRACTION_REFORM_USER = 'ar_user';
 const SCOPE_ABSTRACTION_REFORM_APPROVER = 'ar_approver';
+const SCOPE_EXTERNAL = 'external';
 
 const ROLE_EXTERNAL_COLLEAGUE = 'user';
 const ROLE_EXTERNAL_COLLEAGUE_RETURNS = 'user_returns';
@@ -11,11 +13,14 @@ module.exports = {
     allAdmin: [
       SCOPE_INTERNAL,
       SCOPE_ABSTRACTION_REFORM_USER,
-      SCOPE_ABSTRACTION_REFORM_APPROVER
+      SCOPE_ABSTRACTION_REFORM_APPROVER,
+      SCOPE_INTERNAL_RETURNS
     ],
     internal: SCOPE_INTERNAL,
+    external: SCOPE_EXTERNAL,
     abstractionReformUser: SCOPE_ABSTRACTION_REFORM_USER,
-    abstractionReformApprover: SCOPE_ABSTRACTION_REFORM_APPROVER
+    abstractionReformApprover: SCOPE_ABSTRACTION_REFORM_APPROVER,
+    returns: SCOPE_INTERNAL_RETURNS
   },
   externalRoles: {
     colleague: ROLE_EXTERNAL_COLLEAGUE,

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -4,6 +4,8 @@
 // they are forgiving to undefined.
 const { size, find, includes, intersection, get, uniq } = require('lodash');
 
+const { scope: scopes, externalRoles } = require('./constants');
+
 /**
  * Permissions module
  *
@@ -47,45 +49,58 @@ const hasMatch = (requiredScopes, userScopes) => {
  * Does the role object have a role property of 'primary_user'?
  * { role: 'primary_user' }
  */
-const isPrimaryUserRole = role => get(role, 'role') === 'primary_user';
+const isPrimaryUserRole = role => get(role, 'role') === externalRoles.licenceHolder;
 
 /**
  * Is this a role with a role value of user_returns.
  * { role: 'user_returns' }
  */
-const isUserReturnsRole = role => get(role, 'role') === 'user_returns';
+const isUserReturnsRole = role => get(role, 'role') === externalRoles.colleagueWithReturns;
 
 /**
  * Checks if there is a scope called 'external'
  *
  * @param scope An array of strings
  */
-const isExternal = scope => includes(scope, 'external');
+const isExternal = scope => includes(scope, scopes.external);
 
-const isVmlAdmin = scope => hasMatch(['internal', 'ar_user', 'ar_approver'], scope);
+const isVmlAdmin = scope => hasMatch(scopes.allAdmin, scope);
 const isPrimaryUser = roles => !!find(roles, isPrimaryUserRole);
 const isUserReturnsUser = roles => !!find(roles, isUserReturnsRole);
 
 const canReadLicence = entityId => !!entityId;
-const canEditAbstractionReform = scope => hasMatch(['ar_user', 'ar_approver'], scope);
+const canEditAbstractionReform = scope => hasMatch([
+  scopes.abstractionReformUser,
+  scopes.abstractionReformApprover
+], scope);
 
-const canApproveAbstractionReform = scope => includes(scope, 'ar_approver');
+const canApproveAbstractionReform = scope => includes(scope, scopes.abstractionReformApprover);
 
 const canEditLicence = (scope, roles) => {
   return isExternal(scope) && size(roles) === 1 && isPrimaryUser(roles);
 };
 
 const canViewMutlipleLicences = (scope = [], roles = []) => {
-  return isExternal(scope) && countRoles(roles, ['user', 'primary_user']) > 1;
+  return isExternal(scope) && countRoles(roles, [externalRoles.colleague, externalRoles.licenceHolder]) > 1;
 };
 
-const canPerformReturns = (scope = [], roles = []) => {
-  return isExternal(scope) &&
-    (isPrimaryUser(roles) || isUserReturnsUser(roles));
+/**
+ * Users who can edit returns:
+ *
+ * Licence Holders
+ * Colleagues with returns access granted
+ * Internal users with the returns scope
+ */
+const canEditReturns = (scope = [], roles = []) => {
+  return isExternal(scope)
+    ? isPrimaryUser(roles) || isUserReturnsUser(roles)
+    : hasMatch(scope, [scopes.returns]);
 };
 
-const canViewInternalReturns = (scope = []) => {
-  return scope.includes('internal') && scope.includes('returns');
+const canReadReturns = (scope = [], roles = []) => {
+  return isVmlAdmin(scope) ||
+    isPrimaryUser(roles) ||
+    isUserReturnsUser(roles);
 };
 
 /**
@@ -100,14 +115,14 @@ const getPermissions = (credentials = {}) => {
     licences: {
       read: canReadLicence(entityId),
       edit: canEditLicence(scope, roles),
-      multi: canViewMutlipleLicences(scope, roles),
-      returns: canPerformReturns(scope, roles)
+      multi: canViewMutlipleLicences(scope, roles)
     },
     admin: {
       defra: isVmlAdmin(scope)
     },
     returns: {
-      read: canViewInternalReturns(scope)
+      read: canReadReturns(scope, roles),
+      edit: canEditReturns(scope, roles)
     },
     ar: {
       read: canEditAbstractionReform(scope),

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -71,7 +71,7 @@ function viewContextDefaults (request) {
         url: '/licences'
       });
     }
-    if (request.permissions && request.permissions.licences.returns) {
+    if (request.permissions && request.permissions.returns.read) {
       viewContext.mainNavLinks.push({
         id: 'returns',
         text: 'View returns',

--- a/src/modules/returns/admin-routes.js
+++ b/src/modules/returns/admin-routes.js
@@ -7,7 +7,7 @@ module.exports = {
     config: {
       ...getReturnsForLicence.config,
       auth: {
-        scope: ['returns']
+        scope: ['internal']
       }
     }
   },
@@ -18,7 +18,7 @@ module.exports = {
     config: {
       ...getReturn.config,
       auth: {
-        scope: ['returns']
+        scope: ['internal']
       },
       plugins: {
         viewContext: {

--- a/src/modules/returns/external-routes.js
+++ b/src/modules/returns/external-routes.js
@@ -57,7 +57,7 @@ module.exports = {
       },
       plugins: {
         hapiRouteAcl: {
-          permissions: ['licences:returns']
+          permissions: ['returns:read']
         },
         viewContext: {
           activeNavLink: 'returns'

--- a/src/modules/view-licences/controller.js
+++ b/src/modules/view-licences/controller.js
@@ -69,7 +69,7 @@ async function getLicenceDetail (request, reply) {
       gaugingStations
     } = await loadLicenceData(entityId, documentHeaderId);
 
-    const canViewReturns = get(request.permissions, `companies.${documentHeader.company_entity_id}.licences.returns`) ||
+    const canViewReturns = get(request.permissions, `companies.${documentHeader.company_entity_id}.returns.read`) ||
     get(request.permissions, 'returns.read');
 
     documentHeader.verifications = await CRM.getDocumentVerifications(documentHeaderId);

--- a/test/lib/permissions.js
+++ b/test/lib/permissions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const { experiment, beforeEach, test } = exports.lab = Lab.script();
 const { expect } = require('code');
 const { isString } = require('lodash');
 
@@ -15,242 +15,315 @@ const getCredentials = (scope = [], roles = [], entityId = null) => ({
   entity_id: entityId
 });
 
-lab.experiment('getPermissions::internal user', () => {
+experiment('getPermissions::internal user', () => {
   let internalPermissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['internal'], [], 'entity-id');
     internalPermissions = await getPermissions(credentials);
   });
 
-  lab.test('can read licences', async () => {
+  test('can read licences', async () => {
     expect(internalPermissions.licences.read).to.be.true();
   });
 
-  lab.test('cannot edit licences', async () => {
+  test('cannot edit licences', async () => {
     expect(internalPermissions.licences.edit).to.be.false();
   });
 
-  lab.test('cannot perform returns', async () => {
-    expect(internalPermissions.licences.returns).to.be.false();
+  test('can read returns', async () => {
+    expect(internalPermissions.returns.read).to.be.true();
   });
 
-  lab.test('cannot be multi licence (agent)', async () => {
+  test('cannot edit returns', async () => {
+    expect(internalPermissions.returns.edit).to.be.false();
+  });
+
+  test('cannot be multi licence (agent)', async () => {
     expect(internalPermissions.licences.multi).to.be.false();
   });
 
-  lab.test('has admin permission', async () => {
+  test('has admin permission', async () => {
     expect(internalPermissions.admin.defra).to.be.true();
   });
 });
 
-lab.experiment('getPermissions::primary user', () => {
+experiment('getPermissions::primary user', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['external'], ['primary_user'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 
-  lab.test('can read licences', async () => {
+  test('can read licences', async () => {
     expect(permissions.licences.read).to.be.true();
   });
 
-  lab.test('can edit licences', async () => {
+  test('can edit licences', async () => {
     expect(permissions.licences.edit).to.be.true();
   });
 
-  lab.test('cannot be multi licence (agent)', async () => {
+  test('cannot be multi licence (agent)', async () => {
     expect(permissions.licences.multi).to.be.false();
   });
 
-  lab.test('does not have admin permission', async () => {
+  test('does not have admin permission', async () => {
     expect(permissions.admin.defra).to.be.false();
   });
 
-  lab.test('can perform returns', async () => {
-    expect(permissions.licences.returns).to.be.true();
+  test('can read returns', async () => {
+    expect(permissions.returns.read).to.be.true();
+  });
+
+  test('can edit returns', async () => {
+    expect(permissions.returns.edit).to.be.true();
   });
 });
 
-lab.experiment('getPermissions::agent', () => {
+experiment('getPermissions::agent', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['external'], ['user'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 
-  lab.test('user can read licences', async () => {
+  test('user can read licences', async () => {
     expect(permissions.licences.read).to.be.true();
   });
 
-  lab.test('user can edit licences', async () => {
+  test('user can edit licences', async () => {
     expect(permissions.licences.edit).to.be.false();
   });
 
-  lab.test('cannot perform returns', async () => {
-    expect(permissions.licences.returns).to.be.false();
+  test('cannot read returns', async () => {
+    expect(permissions.returns.read).to.be.false();
   });
 
-  lab.test('user does not have admin permission', async () => {
+  test('cannot edit returns', async () => {
+    expect(permissions.returns.edit).to.be.false();
+  });
+
+  test('user does not have admin permission', async () => {
     expect(permissions.admin.defra).to.be.false();
   });
 });
 
-lab.experiment('getPermissions::multi licence user', () => {
-  lab.test('user can be multi licence (agent)', async () => {
+experiment('getPermissions::multi licence user', () => {
+  test('user can be multi licence (agent)', async () => {
     const credentials = getCredentials(['external'], ['primary_user', 'user'], 'entity-id');
     const permissions = await getPermissions(credentials);
     expect(permissions.licences.multi).to.be.true();
   });
 });
 
-lab.experiment('getPermissions::agent with data returns', () => {
+experiment('getPermissions::agent with data returns', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['external'], ['user', 'user_returns'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 
-  lab.test('user can read licences', async () => {
+  test('user can read licences', async () => {
     expect(permissions.licences.read).to.be.true();
   });
 
-  lab.test('user can edit licences', async () => {
+  test('user can edit licences', async () => {
     expect(permissions.licences.edit).to.be.false();
   });
 
-  lab.test('user can be multi licence', async () => {
+  test('user can be multi licence', async () => {
     expect(permissions.licences.multi).to.be.false();
   });
 
-  lab.test('user does not have admin permission', async () => {
+  test('user does not have admin permission', async () => {
     expect(permissions.admin.defra).to.be.false();
   });
 
-  lab.test('user has returns permission on licences', async () => {
-    expect(permissions.licences.returns).to.be.true();
+  test('can read returns', async () => {
+    expect(permissions.returns.read).to.be.true();
+  });
+
+  test('can edit returns', async () => {
+    expect(permissions.returns.edit).to.be.true();
   });
 });
 
-lab.experiment('getPermissions::no entity id', () => {
-  lab.test('sets licence.read to false for external', async () => {
+experiment('getPermissions::no entity id', () => {
+  test('sets licence.read to false for external', async () => {
     const credentials = getCredentials(['external']);
     const permissions = await getPermissions(credentials);
     expect(permissions.licences.read).to.be.false();
   });
 
-  lab.test('sets licence.read to false for internal', async () => {
+  test('sets licence.read to false for internal', async () => {
     const credentials = getCredentials(['internal']);
     const permissions = await getPermissions(credentials);
     expect(permissions.licences.read).to.be.false();
   });
 });
 
-lab.experiment('getPermissions::no credentials', () => {
+experiment('getPermissions::no credentials', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     permissions = await getPermissions();
   });
 
-  lab.test('user cannot read licences', async () => {
+  test('user cannot read licences', async () => {
     expect(permissions.licences.read).to.be.false();
   });
 
-  lab.test('user cannot edit licences', async () => {
+  test('user cannot edit licences', async () => {
     expect(permissions.licences.edit).to.be.false();
   });
 
-  lab.test('user cannot be multi licence (agent)', async () => {
+  test('user cannot be multi licence (agent)', async () => {
     expect(permissions.licences.multi).to.be.false();
   });
 
-  lab.test('user does not have admin permission', async () => {
+  test('user does not have admin permission', async () => {
     expect(permissions.admin.defra).to.be.false();
   });
 
-  lab.test('cannot perform returns', async () => {
-    expect(permissions.licences.returns).to.be.false();
+  test('cannot read returns', async () => {
+    expect(permissions.returns.read).to.be.false();
+  });
+
+  test('cannot edit returns', async () => {
+    expect(permissions.returns.edit).to.be.false();
   });
 });
 
-lab.experiment('getPermissions::ar_user', () => {
+experiment('getPermissions::ar_user', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['ar_user'], ['admin'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 
-  lab.test('can read licences', async () => {
+  test('can read licences', async () => {
     expect(permissions.licences.read).to.be.true();
   });
 
-  lab.test('cannot edit licences', async () => {
+  test('cannot edit licences', async () => {
     expect(permissions.licences.edit).to.be.false();
   });
 
-  lab.test('cannot be multi licence (agent)', async () => {
+  test('cannot be multi licence (agent)', async () => {
     expect(permissions.licences.multi).to.be.false();
   });
 
-  lab.test('has admin permission', async () => {
+  test('has admin permission', async () => {
     expect(permissions.admin.defra).to.be.true();
   });
 
-  lab.test('can read abstraction reform', async () => {
+  test('can read abstraction reform', async () => {
     expect(permissions.ar.read).to.be.true();
   });
 
-  lab.test('can edit abstraction reform', async () => {
+  test('can edit abstraction reform', async () => {
     expect(permissions.ar.edit).to.be.true();
   });
 
-  lab.test('cannot perform returns', async () => {
-    expect(permissions.licences.returns).to.be.false();
+  test('can read returns', async () => {
+    expect(permissions.returns.read).to.be.true();
+  });
+
+  test('cannot edit returns', async () => {
+    expect(permissions.returns.edit).to.be.false();
   });
 });
 
-lab.experiment('getPermissions::ar_approver', () => {
+experiment('getPermissions::ar_approver', () => {
   let permissions;
 
-  lab.beforeEach(async () => {
+  beforeEach(async () => {
     const credentials = getCredentials(['ar_approver'], ['admin'], 'entity-id');
     permissions = await getPermissions(credentials);
   });
 
-  lab.test('can read licences', async () => {
+  test('can read licences', async () => {
     expect(permissions.licences.read).to.be.true();
   });
 
-  lab.test('cannot edit licences', async () => {
+  test('cannot edit licences', async () => {
     expect(permissions.licences.edit).to.be.false();
   });
 
-  lab.test('cannot be multi licence (agent)', async () => {
+  test('cannot be multi licence (agent)', async () => {
     expect(permissions.licences.multi).to.be.false();
   });
 
-  lab.test('has admin permission', async () => {
+  test('has admin permission', async () => {
     expect(permissions.admin.defra).to.be.true();
   });
 
-  lab.test('can read abstraction reform', async () => {
+  test('can read abstraction reform', async () => {
     expect(permissions.ar.read).to.be.true();
   });
 
-  lab.test('can edit abstraction reform', async () => {
+  test('can edit abstraction reform', async () => {
     expect(permissions.ar.edit).to.be.true();
   });
 
-  lab.test('can approve abstraction reform', async () => {
+  test('can approve abstraction reform', async () => {
     expect(permissions.ar.approve).to.be.true();
   });
 
-  lab.test('cannot perform returns', async () => {
-    expect(permissions.licences.returns).to.be.false();
+  test('can read returns', async () => {
+    expect(permissions.returns.read).to.be.true();
+  });
+
+  test('cannot edit returns', async () => {
+    expect(permissions.returns.edit).to.be.false();
+  });
+});
+
+experiment('getPermissions::internal returns user', () => {
+  let permissions;
+
+  beforeEach(async () => {
+    const credentials = getCredentials(['returns'], ['admin'], 'entity-id');
+    permissions = await getPermissions(credentials);
+  });
+
+  test('can read licences', async () => {
+    expect(permissions.licences.read).to.be.true();
+  });
+
+  test('cannot edit licences', async () => {
+    expect(permissions.licences.edit).to.be.false();
+  });
+
+  test('cannot be multi licence (agent)', async () => {
+    expect(permissions.licences.multi).to.be.false();
+  });
+
+  test('has admin permission', async () => {
+    expect(permissions.admin.defra).to.be.true();
+  });
+
+  test('can read abstraction reform', async () => {
+    expect(permissions.ar.read).to.be.false();
+  });
+
+  test('can edit abstraction reform', async () => {
+    expect(permissions.ar.edit).to.be.false();
+  });
+
+  test('can approve abstraction reform', async () => {
+    expect(permissions.ar.approve).to.be.false();
+  });
+
+  test('can read returns', async () => {
+    expect(permissions.returns.read).to.be.true();
+  });
+
+  test('cannot edit returns', async () => {
+    expect(permissions.returns.edit).to.be.true();
   });
 });

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -1,8 +1,8 @@
-'use strict'
+'use strict';
 
-const Lab = require('lab')
-const lab = exports.lab = Lab.script()
-const { expect } = require('code')
+const Lab = require('lab');
+const { experiment, test } = exports.lab = Lab.script();
+const { expect } = require('code');
 
 const view = require('../../src/lib/view');
 
@@ -18,7 +18,8 @@ const getBaseRequest = () => ({
   url: {},
   permissions: {
     admin: {},
-    licences: {}
+    licences: {},
+    returns: {}
   },
   auth: {
     credentials: {}
@@ -26,19 +27,17 @@ const getBaseRequest = () => ({
   info: {}
 });
 
-lab.experiment('lib/view.contextDefaults', () => {
-
-  lab.test('isAuthenticated is false when no sid in state', async () => {
+experiment('lib/view.contextDefaults', () => {
+  test('isAuthenticated is false when no sid in state', async () => {
     const request = getBaseRequest();
     const viewContext = view.contextDefaults(request);
     expect(viewContext.isAuthenticated).to.be.false();
   });
 
-  lab.test('isAuthenticated is true when the sid is in state', async () => {
+  test('isAuthenticated is true when the sid is in state', async () => {
     const request = getBaseRequest();
     request.state.sid = { sid: 'test-sid' };
     const viewContext = view.contextDefaults(request);
     expect(viewContext.isAuthenticated).to.be.true();
   });
 });
-


### PR DESCRIPTION
Changes the permissions granted to a user for the `internal` and
`returns` roles.

Having `internal` allows a user to view returns.

Having `returns` allows a user to save returns.