### PR TITLE
Fix: Adds a new npm asset build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Web app for Water Abstraction Permit service",
   "main": "index.js",
   "scripts": {
-    "heroku-prebuild": "npm install --only=dev",
-    "heroku-postbuild": "gulp clean && gulp copy-govuk-files && gulp install-govuk-files && gulp copy-static-assets && gulp sass",
+    "install-assets": "gulp build",
     "test": "./node_modules/lab/bin/lab -t 55 -m 0 -r lcov -o lcov.info -r console -o stdout",
     "test-cov-html": "lab -r html -o coverage.html",
     "docs": "jsdoc -c conf.jsdoc.json && cd ./out && serve -o -p 3011",


### PR DESCRIPTION
Adds a new npm script that builds the local assets calling gulp.

This can then be called from the deploy script meaning that the project
can define it's own version of gulp locally rather than relying on the
globally installed version on the target machine.