### PR TITLE
Fix: Don't validate password length on sign in route

### DIFF
--- a/src/modules/auth/routes.js
+++ b/src/modules/auth/routes.js
@@ -49,7 +49,7 @@ module.exports = {
         formValidator: {
           payload: {
             user_id: Joi.string().email().required(),
-            password: Joi.string().required().min(8)
+            password: Joi.string().required()
           }
         }
       }


### PR DESCRIPTION
Allow the user to enter any length password and allow it through to be
validated by the idm rather than exiting early in the UI.