### PR TITLE
Allow internal staff to view returns for non-current licence version.…

### DIFF
--- a/src/lib/hapi-plugins/permissions.js
+++ b/src/lib/hapi-plugins/permissions.js
@@ -1,24 +1,7 @@
 /**
  * Plugin to decorate request with current user's permissions
  */
-const { getPermissions, getCompanyPermissions } = require('../permissions');
-const Boom = require('boom');
-const { get, isBoolean } = require('lodash');
-
-/**
- * Checks whether the user has a particular permission
- * if the permission string is invalid an error is thrown
- * @param {String} permission - the permission string, e.g. admin.defra
- * @param {Object} permissions - the permissions object
- * @return {Boolean}
- */
-const hasPermission = (permission, permissions) => {
-  const isGranted = get(permissions, permission);
-  if (!isBoolean(isGranted)) {
-    throw Boom.badImplementation(`Attempt to check invalid permission ${permission}`);
-  }
-  return isGranted;
-};
+const { getPermissions, getCompanyPermissions, hasPermission } = require('../permissions');
 
 const permissionsPlugin = {
 

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -2,8 +2,8 @@
 
 // Using lodash functions over some native functions because
 // they are forgiving to undefined.
-const { size, find, includes, intersection, get, uniq } = require('lodash');
-
+const { size, find, includes, intersection, get, uniq, isBoolean } = require('lodash');
+const Boom = require('boom');
 const { scope: scopes, externalRoles } = require('./constants');
 
 /**
@@ -159,7 +159,23 @@ const getCompanyPermissions = (credentials = {}) => {
   }, {});
 };
 
+/**
+ * Checks whether the user has a particular permission
+ * if the permission string is invalid an error is thrown
+ * @param {String} permission - the permission string, e.g. admin.defra
+ * @param {Object} permissions - the permissions object
+ * @return {Boolean}
+ */
+const hasPermission = (permission, permissions) => {
+  const isGranted = get(permissions, permission);
+  if (!isBoolean(isGranted)) {
+    throw Boom.badImplementation(`Attempt to check invalid permission ${permission}`);
+  }
+  return isGranted;
+};
+
 module.exports = {
   getPermissions,
-  getCompanyPermissions
+  getCompanyPermissions,
+  hasPermission
 };

--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -52,7 +52,7 @@ const getAmounts = async (request, h) => {
   }
 
   // Check date/roles
-  if (!canEdit(request, data)) {
+  if (!canEdit(request.permissions, data)) {
     throw Boom.unauthorized(`Access denied to submit return ${returnId} for entity ${entityId}`);
   }
 
@@ -305,7 +305,6 @@ const postSingleTotal = async (request, h) => {
     saveSessionData(request, d);
 
     return h.redirect(getScopedPath(request, '/return/basis'));
-
   }
 
   return h.view('water/returns/internal/form', {
@@ -344,10 +343,8 @@ const postBasis = async (request, h) => {
     const d = applyBasis(data, getValues(form));
     saveSessionData(request, d);
 
-
     const path = get(d, 'reading.totalFlag') ? '/return/confirm' : '/return/quantities';
     return h.redirect(getScopedPath(request, path));
-
   }
 
   return h.view('water/returns/internal/form', {

--- a/src/modules/returns/controllers/view.js
+++ b/src/modules/returns/controllers/view.js
@@ -69,7 +69,7 @@ const getReturn = async (request, h) => {
     return: data,
     pageTitle: `Abstraction return for ${licenceNumber}`,
     documentHeader,
-    canEdit: canEdit(request, data),
+    canEdit: canEdit(request.permissions, data),
     showVersions
   };
   return h.view('water/returns/return', view);

--- a/src/modules/returns/lib/helpers.js
+++ b/src/modules/returns/lib/helpers.js
@@ -4,6 +4,8 @@ const moment = require('moment');
 const { documents } = require('../../../lib/connectors/crm');
 const { returns, versions } = require('../../../lib/connectors/returns');
 const { externalRoles } = require('../../../lib/constants');
+const { hasPermission } = require('../../../lib/permissions');
+const config = require('../../../../config');
 
 /**
  * Gets licences from the CRM that can be viewed by the supplied entity ID
@@ -29,18 +31,32 @@ const getLicenceNumbers = async (entityId, filter = {}, isInternal) => {
  * @param {Array} list of licence numbers to get returns data for
  * @return {Promise} resolves with returns
  */
-const getLicenceReturns = async (licenceNumbers, page = 1) => {
+const getLicenceReturns = async (licenceNumbers, page = 1, isInternal = false) => {
+  const { testMode } = config;
+
   const filter = {
     regime: 'water',
     licence_type: 'abstraction',
     licence_ref: {
       $in: licenceNumbers
     },
-    'metadata->>isCurrent': 'true',
     start_date: {
       $gte: '2008-04-01'
     }
   };
+
+  // External users can only view returns for the current version of a licence
+  if (!isInternal) {
+    filter['metadata->>isCurrent'] = 'true';
+  }
+
+  // External users on production-like environments can only view returns where
+  // return cycle is in the past
+  if (!isInternal && !testMode) {
+    filter.end_date = {
+      $lte: moment().format('YYYY-MM-DD')
+    };
+  }
 
   const sort = {
     start_date: -1,
@@ -154,19 +170,22 @@ const getReturnTotal = (ret) => {
  * Whether the user of the current request can edit the supplied return row
  * @param {Object} request - the HAPI HTTP request
  * @param {Object} return - the return row from the return service or water service model
+ * @param {String} [today] - allows today's date to be set for test purposes, defaults to current timestamp
  * @return {Boolean}
  */
-const canEdit = (request, ret) => {
+const canEdit = (permissions, ret, today = null) => {
+  const { testMode } = config;
   const endDate = ret.endDate || ret.end_date;
   const { status } = ret;
   const isAfterSummer2018 = moment(endDate).isSameOrAfter('2018-10-31');
-  const canSubmit = request.permissions.hasPermission('returns.submit');
-  const canEdit = request.permissions.hasPermission('returns.edit');
+  const canSubmit = hasPermission('returns.submit', permissions);
+  const canEdit = hasPermission('returns.edit', permissions);
+  const isPast = moment(today).isSameOrAfter(endDate);
 
   return isAfterSummer2018 &&
     (
       (canEdit) ||
-      (canSubmit && (status === 'due'))
+      (canSubmit && (status === 'due') && (testMode || isPast))
     );
 };
 
@@ -190,7 +209,7 @@ const returnIsReceived = (ret) => {
  */
 const addEditableFlag = (returns, request) => {
   return returns.map(row => {
-    const isEditable = canEdit(request, row);
+    const isEditable = canEdit(request.permissions, row);
     const isReceived = returnIsReceived(row);
     const isClickable = isEditable || isReceived;
     return {
@@ -233,7 +252,7 @@ const getReturnsViewData = async (request) => {
   };
 
   if (licenceNumbers.length) {
-    const { data, pagination } = await getLicenceReturns(licenceNumbers, page);
+    const { data, pagination } = await getLicenceReturns(licenceNumbers, page, isInternal);
     const returns = groupReturnsByYear(mergeReturnsAndLicenceNames(addEditableFlag(data, request), documents));
 
     view.pagination = pagination;
@@ -270,8 +289,6 @@ module.exports = {
   getLatestVersion,
   hasGallons,
   getReturnsViewData,
-  // isInternalReturnsUser,
-  // isInternalUser,
   getInternalRoles,
   getReturnTotal,
   getScopedPath,

--- a/src/modules/returns/lib/helpers.js
+++ b/src/modules/returns/lib/helpers.js
@@ -27,11 +27,12 @@ const getLicenceNumbers = async (entityId, filter = {}, isInternal) => {
 };
 
 /**
- * Get the returns for a list of licence numbers
- * @param {Array} list of licence numbers to get returns data for
- * @return {Promise} resolves with returns
+ * Gets the filter to use for retrieving licences from returns service
+ * @param {Array} licenceNumbers
+ * @param {Boolean} isInternal
+ * @return {Object} filter
  */
-const getLicenceReturns = async (licenceNumbers, page = 1, isInternal = false) => {
+const getLicenceReturnsFilter = (licenceNumbers, isInternal) => {
   const { testMode } = config;
 
   const filter = {
@@ -57,6 +58,17 @@ const getLicenceReturns = async (licenceNumbers, page = 1, isInternal = false) =
       $lte: moment().format('YYYY-MM-DD')
     };
   }
+
+  return filter;
+};
+
+/**
+ * Get the returns for a list of licence numbers
+ * @param {Array} list of licence numbers to get returns data for
+ * @return {Promise} resolves with returns
+ */
+const getLicenceReturns = async (licenceNumbers, page = 1, isInternal = false) => {
+  const filter = getLicenceReturnsFilter(licenceNumbers, isInternal);
 
   const sort = {
     start_date: -1,

--- a/test/modules/returns/helpers.js
+++ b/test/modules/returns/helpers.js
@@ -1,10 +1,11 @@
 'use strict';
-
+const moment = require('moment');
 const { expect } = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 
 const helpers = require('../../../src/modules/returns/lib/helpers');
+const config = require('../../../config');
 
 lab.experiment('getInternalRoles', () => {
   lab.test('returns the original roles if the user is an internal user', async () => {
@@ -17,5 +18,80 @@ lab.experiment('getInternalRoles', () => {
     const isInternalUser = false;
     const roles = helpers.getInternalRoles(isInternalUser, ['test_role']);
     expect(roles).to.only.include(['primary_user', 'user_returns']);
+  });
+});
+
+lab.experiment('canEdit', () => {
+  const internalUser = {
+    returns: {
+      read: true,
+      edit: true,
+      submit: false
+    }
+  };
+
+  const externalUser = {
+    returns: {
+      read: true,
+      submit: true,
+      edit: false
+    }
+  };
+
+  const pre2018Return = {
+    end_date: '2018-10-30',
+    status: 'due'
+  };
+
+  const post2018Return = {
+    end_date: '2018-10-31',
+    status: 'due'
+  };
+
+  const post2018CompletedReturn = {
+    end_date: '2019-03-31',
+    status: 'completed'
+  };
+
+  const futureReturn = {
+    end_date: moment().add(1, 'years').format('YYYY-MM-DD')
+  };
+
+  lab.test('Internal user cannot edit return if before summer 2018 cycle', async () => {
+    expect(helpers.canEdit(internalUser, pre2018Return)).to.equal(false);
+  });
+
+  lab.test('Internal user can edit return if after summer 2018 cycle', async () => {
+    expect(helpers.canEdit(internalUser, post2018Return)).to.equal(true);
+  });
+
+  lab.test('Internal user can edit completed return if after summer 2018 cycle', async () => {
+    expect(helpers.canEdit(internalUser, post2018CompletedReturn)).to.equal(true);
+  });
+
+  lab.test('External user cannot edit return if before summer 2018 cycle', async () => {
+    expect(helpers.canEdit(externalUser, pre2018Return)).to.equal(false);
+  });
+
+  lab.test('External user can edit return if after summer 2018 cycle and in the past', async () => {
+    expect(helpers.canEdit(externalUser, post2018Return, '2018-10-31')).to.equal(true);
+  });
+
+  lab.test('External user cannot edit return if after summer 2018 cycle and in the future in production', async () => {
+    const testMode = config.testMode;
+    config.testMode = false;
+    expect(helpers.canEdit(externalUser, post2018Return, '2018-10-30')).to.equal(false);
+    config.testMode = testMode;
+  });
+
+  lab.test('External user can edit return if after summer 2018 cycle and in test environments', async () => {
+    const testMode = config.testMode;
+    config.testMode = true;
+    expect(helpers.canEdit(externalUser, post2018Return, '2018-10-30')).to.equal(true);
+    config.testMode = testMode;
+  });
+
+  lab.test('External user cannot edit completed returns', async () => {
+    expect(helpers.canEdit(externalUser, post2018CompletedReturn, '2018-10-31')).to.equal(false);
   });
 });


### PR DESCRIPTION
…  Hide future returns from external users on test environments, add tests.