### PR TITLE
Feat: Use user type specific survey identifiers

### DIFF
--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -1,5 +1,12 @@
 const { get } = require('lodash');
 
+const getSurveyType = (isAuthenticated, isDefraAdmin) => {
+  if (isAuthenticated) {
+    return isDefraAdmin ? 'internal' : 'external';
+  }
+  return 'anonymous';
+};
+
 function viewContextDefaults (request) {
   var viewContext = {};
 
@@ -119,6 +126,10 @@ function viewContextDefaults (request) {
 
   viewContext.env = process.env.NODEENV;
   viewContext.crownCopyrightMessage = '© Crown copyright';
+  viewContext.surveyType = getSurveyType(
+    viewContext.isAuthenticated,
+    get(viewContext, 'permissions.admin.defra', false)
+  );
 
   return viewContext;
 }

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -36,13 +36,14 @@ function getSignin (request, reply) {
  * @param {Object} reply - the HAPI response toolkit
  */
 async function getSignout (request, h) {
+  const params = `?u=${request.permissions.admin.defra ? 'i' : 'e'}`;
   try {
     await request.sessionStore.destroy();
     request.cookieAuth.clear();
   } catch (error) {
     request.log('error', error);
   }
-  return h.redirect('/signed-out');
+  return h.redirect(`/signed-out${params}`);
 }
 
 /**
@@ -52,6 +53,9 @@ async function getSignout (request, h) {
  */
 async function getSignedOut (request, h) {
   const viewContext = View.contextDefaults(request);
+  const surveyType = { i: 'internal', e: 'external' };
+
+  viewContext.surveyType = surveyType[request.query.u] || 'anonymous';
   viewContext.pageTitle = 'You are signed out';
   return h.view('water/auth/signed-out', viewContext);
 }

--- a/src/views/partials/feedback-survey.html
+++ b/src/views/partials/feedback-survey.html
@@ -1,6 +1,17 @@
-<iframe id="ss-embed-frame" onload="window.parent.parent.scrollTo(0,0)"
-  src="https://www.smartsurvey.co.uk/s/FYWJN/"
-  style="width:100%;height:800px;border:0px;padding-bottom:4px;"
-  frameborder="0">
-   <a href="https://www.smartsurvey.co.uk/s/FYWJN/">Please take our survey</a>
-</iframe>
+{{#equal surveyType 'internal'}}
+<script id="ss-embed-419108">(function(d,w)
+{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=419108';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
+)(document,window);</script>
+{{/equal}}
+
+{{#equal surveyType 'external'}}
+<script id="ss-embed-416960">(function(d,w)
+{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=416960';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
+)(document,window);</script>
+{{/equal}}
+
+{{#equal surveyType 'anonymous'}}
+<script id="ss-embed-517384">(function(d,w)
+{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=517384';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
+)(document,window);</script>
+{{/equal}}

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -19,7 +19,8 @@ const getBaseRequest = () => ({
   permissions: {
     admin: {},
     licences: {},
-    returns: {}
+    returns: {},
+    ar: {}
   },
   auth: {
     credentials: {}
@@ -39,5 +40,29 @@ experiment('lib/view.contextDefaults', () => {
     request.state.sid = { sid: 'test-sid' };
     const viewContext = view.contextDefaults(request);
     expect(viewContext.isAuthenticated).to.be.true();
+  });
+
+  test('surveyType is anonymous for a logged out user', async () => {
+    const request = getBaseRequest();
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.surveyType).to.equal('anonymous');
+  });
+
+  test('surveyType is external for a logged in vml user', async () => {
+    const request = getBaseRequest();
+    request.state.sid = { sid: 'test-sid' };
+    request.permissions.admin.defra = false;
+
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.surveyType).to.equal('external');
+  });
+
+  test('surveyType is internal for a logged in admin user', async () => {
+    const request = getBaseRequest();
+    request.state.sid = { sid: 'test-sid' };
+    request.permissions.admin.defra = true;
+
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.surveyType).to.equal('internal');
   });
 });

--- a/test/modules/auth/controller.js
+++ b/test/modules/auth/controller.js
@@ -14,7 +14,13 @@ lab.experiment('getSignout', () => {
   lab.beforeEach(async () => {
     request = {
       sessionStore: { destroy: sinon.stub().resolves(true) },
-      cookieAuth: { clear: sinon.spy() }
+      cookieAuth: { clear: sinon.spy() },
+      permissions: {
+        admin: {
+          defra: false
+        }
+      },
+      params: {}
     };
 
     h = { redirect: sinon.spy() };
@@ -24,7 +30,7 @@ lab.experiment('getSignout', () => {
 
   lab.test('redirects to the signed-out route', async () => {
     const redirectTo = h.redirect.lastCall.args[0];
-    expect(redirectTo).to.equal('/signed-out');
+    expect(redirectTo).to.equal('/signed-out?u=e');
   });
 
   lab.test('the session is destroyed', async () => {
@@ -42,7 +48,8 @@ lab.experiment('getSignedOut', () => {
   lab.beforeEach(async () => {
     sinon.stub(View, 'contextDefaults').returns({});
     const request = {
-      log: sinon.spy()
+      log: sinon.spy(),
+      query: { u: 'e' }
     };
     h = { view: sinon.spy() };
     await controller.getSignedOut(request, h);
@@ -55,5 +62,10 @@ lab.experiment('getSignedOut', () => {
   lab.test('sets the page title', async () => {
     const viewContext = h.view.lastCall.args[1];
     expect(viewContext.pageTitle).to.equal('You are signed out');
+  });
+
+  lab.test('sets the surveyType', async () => {
+    const viewContext = h.view.lastCall.args[1];
+    expect(viewContext.surveyType).to.equal('external');
   });
 });


### PR DESCRIPTION
Survey participants are now split into three groups:

 - External
 - Internal
 - Anonymous

The appropriate survey id will be used if the user type can be
identified.

Also when the user signs out, a new query param will be used when making
the request to `/signed-out` so that the correct survey is shown.