### PR TITLE
Feat: Meter readings

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const config = require('./config');
 const { acl, ...plugins } = require('./src/lib/hapi-plugins');
 const { getPermissions: permissionsFunc } = require('./src/lib/permissions.js');
 const routes = require('./src/modules/routes');
+const returnsPlugin = require('./src/modules/returns/plugin.js');
 
 // Initialise logger
 const logger = require('./src/lib/logger');
@@ -61,6 +62,8 @@ async function start () {
       }
     });
     await server.register(Object.values(plugins));
+
+    await server.register({ plugin: returnsPlugin });
 
     // Set up auth strategies
     server.auth.strategy('standard', 'cookie', {

--- a/src/assets/sass/application.scss
+++ b/src/assets/sass/application.scss
@@ -39,6 +39,7 @@ $path: "/public/images/";
 @import "blocks/unit-selector";
 @import "blocks/space";
 @import "blocks/meta";
+@import "blocks/forms";
 
 * {
 family: "nta", Arial, sans-serif;
@@ -533,20 +534,17 @@ nav.tabs {
   }
 }
 
-
 .link-back {
   &--space-above {
     margin-top: 45px;
   }
 }
+
 .heading-large {
   &--tight-above {
     margin-top: 15px;
   }
 }
-
-
-
 
 /* Returns versions list */
 .version {
@@ -557,17 +555,4 @@ nav.tabs {
 .this-version {
   border-color: $link-colour;
 }
-.spaceless {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-}
 
-
-/* returns form fields */
-.form-control-small {
-  @media screen and (min-width: 641px) {
-    width: 20rem;
-  }
-}

--- a/src/assets/sass/blocks/_forms.scss
+++ b/src/assets/sass/blocks/_forms.scss
@@ -1,0 +1,16 @@
+
+/* returns form fields */
+.form-control--small {
+  @media screen and (min-width: 641px) {
+    width: 20rem;
+  }
+}
+
+.form-control--reading {
+  text-align: right;
+  font-family: monospace;
+
+  @media screen and (min-width: 641px) {
+    width: 16rem;
+  }
+}

--- a/src/assets/sass/blocks/_space.scss
+++ b/src/assets/sass/blocks/_space.scss
@@ -12,3 +12,10 @@
 .clustered {
   margin-bottom: 0;
 }
+
+.spaceless {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}

--- a/src/lib/forms/fields/checkbox.js
+++ b/src/lib/forms/fields/checkbox.js
@@ -1,0 +1,19 @@
+const factory = (name, opts = {}, value) => {
+  const defaults = {
+    label: '',
+    widget: 'checkbox',
+    checked: false
+  };
+  const options = {
+    ...defaults,
+    ...opts
+  };
+  return {
+    name,
+    value,
+    options,
+    errors: []
+  };
+};
+
+module.exports = factory;

--- a/src/lib/forms/fields/index.js
+++ b/src/lib/forms/fields/index.js
@@ -3,11 +3,13 @@ const date = require('./date');
 const hidden = require('./hidden');
 const radio = require('./radio');
 const text = require('./text');
+const checkbox = require('./checkbox');
 
 module.exports = {
   button,
   date,
   hidden,
   radio,
-  text
+  text,
+  checkbox
 };

--- a/src/lib/forms/fields/text.js
+++ b/src/lib/forms/fields/text.js
@@ -4,7 +4,8 @@ const textFactory = (name, opts = {}, value) => {
     widget: 'text',
     required: true,
     type: 'text',
-    controlClass: 'form-control'
+    controlClass: 'form-control',
+    autoComplete: true
   };
   const options = {
     ...defaults,

--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -14,8 +14,7 @@ const {
   basisForm, basisSchema,
   quantitiesForm, quantitiesSchema,
   meterDetailsForm, meterDetailsSchema,
-  meterUnitsForm, meterUnitsSchema,
-  meterReadingsForm, meterReadingsSchema
+  meterUnitsForm, meterReadingsForm, meterReadingsSchema
 } = require('../forms/');
 
 const { returns } = require('../../../lib/connectors/water');
@@ -245,10 +244,7 @@ const getMultipleMeters = async (request, h) => {
 const getUnits = async (request, h) => {
   const data = getSessionData(request);
   const view = await getViewData(request, data);
-
-  const units = get(data, 'reading.units');
-
-  const form = setValues(unitsForm(request), { units });
+  const form = unitsForm(request, data);
 
   return h.view('water/returns/internal/form', {
     ...view,
@@ -482,7 +478,7 @@ const getMeterUnits = async (request, h) => {
 const postMeterUnits = async (request, h) => {
   const data = getSessionData(request);
   const view = await getViewData(request, data);
-  const form = handleRequest(meterUnitsForm(request, data), request, meterUnitsSchema);
+  const form = handleRequest(meterUnitsForm(request, data), request);
 
   if (form.isValid) {
     const updated = applyMeterUnits(data, getValues(form));

--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -5,7 +5,6 @@
  */
 const { set, get } = require('lodash');
 const Boom = require('boom');
-const { getWaterLicence } = require('../../../lib/connectors/crm/documents');
 const { handleRequest, setValues, getValues } = require('../../../lib/forms');
 
 const {
@@ -25,29 +24,11 @@ const {
   applyMeterUnits, applyMeterReadings, applyMethod } = require('../lib/return-helpers');
 
 const {
-  getSessionData,
   saveSessionData,
   deleteSessionData,
   submitReturnData } = require('../lib/session-helpers');
 
-const { getLicenceNumbers, getReturnTotal, getScopedPath, canEdit } = require('../lib/helpers');
-
-/**
- * Get common view data used by many controllers
- * @param {Object} HAPI request instance
- * @param {Object} data - the return model
- * @return {Promise} resolves with view data
- */
-const getViewData = async (request, data) => {
-  const documentHeader = await getWaterLicence(data.licenceNumber);
-  const isInternal = request.permissions.hasPermission('admin.defra');
-  return {
-    ...request.view,
-    documentHeader,
-    data,
-    activeNavLink: isInternal ? 'view' : 'returns'
-  };
-};
+const { getViewData, getLicenceNumbers, getReturnTotal, getScopedPath, canEdit } = require('../lib/helpers');
 
 /**
  * Render form to display whether amounts / nil return for this cycle
@@ -90,10 +71,7 @@ const getAmounts = async (request, h) => {
  * @param {String} request.query.returnId - the return to edit
  */
 const postAmounts = async (request, h) => {
-  const data = getSessionData(request);
-
-  const view = await getViewData(request, data);
-
+  const { view, data } = request.returns;
   const form = handleRequest(setValues(amountsForm(request), data), request);
 
   if (form.isValid) {
@@ -118,15 +96,12 @@ const postAmounts = async (request, h) => {
  * Confirmation screen for nil return
  */
 const getNilReturn = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
-  const form = confirmForm(request);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/nil-return', {
     ...view,
     return: data,
-    form
+    form: confirmForm(request)
   });
 };
 
@@ -134,9 +109,7 @@ const getNilReturn = async (request, h) => {
  * Confirmation screen for nil return
  */
 const postNilReturn = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
+  const { data, view } = request.returns;
   const form = handleRequest(confirmForm(request), request);
 
   if (form.isValid) {
@@ -162,13 +135,11 @@ const postNilReturn = async (request, h) => {
  * @todo link to view return
  */
 const getSubmitted = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { data, view, isInternal } = request.returns;
 
   // Clear session
   deleteSessionData(request);
 
-  const isInternal = request.permissions.hasPermission('admin.defra');
   const returnUrl = `${isInternal ? '/admin' : ''}/returns/return?id=${data.returnId} `;
 
   return h.view('water/returns/internal/submitted', {
@@ -184,13 +155,11 @@ const getSubmitted = async (request, h) => {
  * whether user is submitting meter readings or other
  */
 const getMethod = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-  const form = methodForm(request, data);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: methodForm(request, data),
     return: data
   });
 };
@@ -200,9 +169,7 @@ const getMethod = async (request, h) => {
  * whether user is submitting meter readings or other
  */
 const postMethod = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
+  const { data, view } = request.returns;
   const form = handleRequest(methodForm(request), request);
 
   if (form.isValid) {
@@ -229,12 +196,9 @@ const postMethod = async (request, h) => {
  * Message about multiple meters not being supported
  */
 const getMultipleMeters = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
   return h.view('water/returns/internal/multiple-meters', {
-    ...view,
-    return: data
+    ...request.returns.view,
+    return: request.returns.data
   });
 };
 
@@ -242,13 +206,11 @@ const getMultipleMeters = async (request, h) => {
  * Form to choose units
  */
 const getUnits = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-  const form = unitsForm(request, data);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: unitsForm(request, data),
     return: data
   });
 };
@@ -257,9 +219,7 @@ const getUnits = async (request, h) => {
  * Post handler for units form
  */
 const postUnits = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
+  const { data, view, isInternal } = request.returns;
   const form = handleRequest(unitsForm(request), request);
 
   if (form.isValid) {
@@ -269,7 +229,6 @@ const postUnits = async (request, h) => {
     saveSessionData(request, data);
 
     // Only internal staff have screen for single total
-    const isInternal = request.permissions.hasPermission('admin.defra');
     const path = isInternal ? '/return/single-total' : '/return/basis';
 
     return h.redirect(getScopedPath(request, path));
@@ -286,14 +245,11 @@ const postUnits = async (request, h) => {
  * Form to choose whether single figure or multiple amounts
  */
 const getSingleTotal = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
-  const form = singleTotalForm(request);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: singleTotalForm(request),
     return: data
   });
 };
@@ -302,8 +258,7 @@ const getSingleTotal = async (request, h) => {
  * Post handler for single total
  */
 const postSingleTotal = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { data, view } = request.returns;
 
   const form = handleRequest(singleTotalForm(request), request, singleTotalSchema);
 
@@ -330,14 +285,11 @@ const postSingleTotal = async (request, h) => {
  * What is the basis for the return - amounts/pump/herd
  */
 const getBasis = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
-  const form = basisForm(request);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: basisForm(request),
     return: data
   });
 };
@@ -346,9 +298,7 @@ const getBasis = async (request, h) => {
  * Post handler for basis form
  */
 const postBasis = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
+  const { data, view } = request.returns;
   const form = handleRequest(basisForm(request), request, basisSchema);
 
   if (form.isValid) {
@@ -370,21 +320,17 @@ const postBasis = async (request, h) => {
  * Screen for user to enter quantities
  */
 const getQuantities = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
-  const form = quantitiesForm(request, data);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: quantitiesForm(request, data),
     return: data
   });
 };
 
 const postQuantities = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { data, view } = request.returns;
 
   const schema = quantitiesSchema(data);
 
@@ -408,15 +354,12 @@ const postQuantities = async (request, h) => {
  * Confirm screen for user to check amounts before submission
  */
 const getConfirm = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-
-  const form = confirmForm(request, `/return/confirm`);
+  const { data, view } = request.returns;
 
   return h.view('water/returns/internal/confirm', {
     ...view,
     return: data,
-    form,
+    form: confirmForm(request, `/return/confirm`),
     total: getReturnTotal(data)
   });
 };
@@ -425,29 +368,23 @@ const getConfirm = async (request, h) => {
  * Confirm return
  */
 const postConfirm = async (request, h) => {
-  const data = getSessionData(request);
-
   // Post return
-  await submitReturnData(data, request);
+  await submitReturnData(request.returns.data, request);
 
   return h.redirect(getScopedPath(request, '/return/submitted'));
 };
 
 const getMeterDetails = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-  const form = meterDetailsForm(request, data);
-
+  const { view, data } = request.returns;
   return h.view('water/returns/meter-details', {
     ...view,
-    form,
+    form: meterDetailsForm(request, data),
     return: data
   });
 };
 
 const postMeterDetails = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { view, data } = request.returns;
   const form = handleRequest(meterDetailsForm(request, data), request, meterDetailsSchema);
 
   if (form.isValid) {
@@ -464,20 +401,17 @@ const postMeterDetails = async (request, h) => {
 };
 
 const getMeterUnits = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-  const form = meterUnitsForm(request, data);
+  const { view, data } = request.returns;
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form,
+    form: meterUnitsForm(request, data),
     return: data
   });
 };
 
 const postMeterUnits = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { view, data } = request.returns;
   const form = handleRequest(meterUnitsForm(request, data), request);
 
   if (form.isValid) {
@@ -494,20 +428,17 @@ const postMeterUnits = async (request, h) => {
 };
 
 const getMeterReadings = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
-  const form = meterReadingsForm(request, data);
+  const { view, data } = request.returns;
 
   return h.view('water/returns/meter-readings', {
     ...view,
-    form,
+    form: meterReadingsForm(request, data),
     return: data
   });
 };
 
 const postMeterReadings = async (request, h) => {
-  const data = getSessionData(request);
-  const view = await getViewData(request, data);
+  const { view, data } = request.returns;
   const form = handleRequest(meterReadingsForm(request, data), request, meterReadingsSchema(data));
 
   if (form.isValid) {

--- a/src/modules/returns/forms/index.js
+++ b/src/modules/returns/forms/index.js
@@ -2,7 +2,7 @@ const { singleTotalForm, singleTotalSchema } = require('./single-total');
 const { basisForm, basisSchema } = require('./basis');
 const { quantitiesForm, quantitiesSchema } = require('./quantities');
 const { meterDetailsForm, meterDetailsSchema } = require('./meter-details');
-const { meterUnitsForm, meterUnitsSchema } = require('./meter-units');
+const meterUnitsForm = require('./meter-units');
 const { meterReadingsForm, meterReadingsSchema } = require('./meter-readings');
 
 module.exports = {
@@ -19,7 +19,6 @@ module.exports = {
   meterDetailsForm,
   meterDetailsSchema,
   meterUnitsForm,
-  meterUnitsSchema,
   meterReadingsForm,
   meterReadingsSchema
 };

--- a/src/modules/returns/forms/index.js
+++ b/src/modules/returns/forms/index.js
@@ -1,6 +1,9 @@
 const { singleTotalForm, singleTotalSchema } = require('./single-total');
 const { basisForm, basisSchema } = require('./basis');
 const { quantitiesForm, quantitiesSchema } = require('./quantities');
+const { meterDetailsForm, meterDetailsSchema } = require('./meter-details');
+const { meterUnitsForm, meterUnitsSchema } = require('./meter-units');
+const { meterReadingsForm, meterReadingsSchema } = require('./meter-readings');
 
 module.exports = {
   amountsForm: require('./amounts'),
@@ -12,5 +15,11 @@ module.exports = {
   basisForm,
   basisSchema,
   quantitiesForm,
-  quantitiesSchema
+  quantitiesSchema,
+  meterDetailsForm,
+  meterDetailsSchema,
+  meterUnitsForm,
+  meterUnitsSchema,
+  meterReadingsForm,
+  meterReadingsSchema
 };

--- a/src/modules/returns/forms/meter-details.js
+++ b/src/modules/returns/forms/meter-details.js
@@ -1,0 +1,62 @@
+const Joi = require('joi');
+const { formFactory, fields, setValues } = require('../../../lib/forms');
+const { getMeter } = require('../lib/return-helpers');
+
+const getError = message => ({ summary: message, message });
+
+const form = (request, data) => {
+  const { csrfToken } = request.view;
+
+  const isInternal = request.permissions.hasPermission('admin.defra');
+  const action = `${isInternal ? '/admin' : ''}/return/meter/details`;
+
+  const f = formFactory(action);
+  const meter = getMeter(data);
+
+  f.fields.push(fields.text('manufacturer', {
+    label: 'Manufacturer',
+    errors: {
+      'any.required': getError('Select a manufacturer'),
+      'any.empty': getError('Select a manufacturer')
+    }
+  }, ''));
+
+  f.fields.push(fields.text('serialNumber', {
+    label: 'Serial number',
+    errors: {
+      'any.required': getError('Select a serial number'),
+      'any.empty': getError('Select a serial number')
+    }
+  }, ''));
+
+  f.fields.push(fields.text('startReading', {
+    label: 'Meter start reading',
+    errors: {
+      'number.base': getError('Enter a meter start reading'),
+      'any.required': getError('Enter a meter start reading'),
+      'number.positive': getError('This number should be positive')
+    }
+  }, ''));
+
+  f.fields.push(fields.checkbox('isMultiplier', {
+    label: 'This meter has a ×10 display',
+    checked: meter.multiplier === 10
+  }, 'multiply'));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+
+  return setValues(f, meter);
+};
+
+const schema = {
+  manufacturer: Joi.string().required(),
+  serialNumber: Joi.string().required(),
+  startReading: Joi.number().positive().required(),
+  isMultiplier: Joi.boolean().truthy('multiply').falsy('').optional(),
+  csrf_token: Joi.string().guid().required()
+};
+
+module.exports = {
+  meterDetailsForm: form,
+  meterDetailsSchema: schema
+};

--- a/src/modules/returns/forms/meter-details.js
+++ b/src/modules/returns/forms/meter-details.js
@@ -2,7 +2,30 @@ const Joi = require('joi');
 const { formFactory, fields, setValues } = require('../../../lib/forms');
 const { getMeter } = require('../lib/return-helpers');
 
-const getError = message => ({ summary: message, message });
+const textFieldManufacturer = fields.text('manufacturer', {
+  label: 'Manufacturer',
+  errors: {
+    'any.required': { message: 'Select a manufacturer' },
+    'any.empty': { message: 'Select a manufacturer' }
+  }
+});
+
+const textFieldSerialNumber = fields.text('serialNumber', {
+  label: 'Serial number',
+  errors: {
+    'any.required': { message: 'Select a serial number' },
+    'any.empty': { message: 'Select a serial number' }
+  }
+});
+
+const textFieldStartReading = fields.text('startReading', {
+  label: 'Meter start reading',
+  errors: {
+    'number.base': { message: 'Enter a meter start reading' },
+    'any.required': { message: 'Enter a meter start reading' },
+    'number.positive': { message: 'This number should be positive' }
+  }
+});
 
 const form = (request, data) => {
   const { csrfToken } = request.view;
@@ -13,35 +36,15 @@ const form = (request, data) => {
   const f = formFactory(action);
   const meter = getMeter(data);
 
-  f.fields.push(fields.text('manufacturer', {
-    label: 'Manufacturer',
-    errors: {
-      'any.required': getError('Select a manufacturer'),
-      'any.empty': getError('Select a manufacturer')
-    }
-  }, ''));
-
-  f.fields.push(fields.text('serialNumber', {
-    label: 'Serial number',
-    errors: {
-      'any.required': getError('Select a serial number'),
-      'any.empty': getError('Select a serial number')
-    }
-  }, ''));
-
-  f.fields.push(fields.text('startReading', {
-    label: 'Meter start reading',
-    errors: {
-      'number.base': getError('Enter a meter start reading'),
-      'any.required': getError('Enter a meter start reading'),
-      'number.positive': getError('This number should be positive')
-    }
-  }, ''));
+  f.fields.push(textFieldManufacturer);
+  f.fields.push(textFieldSerialNumber);
+  f.fields.push(textFieldStartReading);
 
   f.fields.push(fields.checkbox('isMultiplier', {
     label: 'This meter has a ×10 display',
     checked: meter.multiplier === 10
   }, 'multiply'));
+
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
   f.fields.push(fields.button(null, { label: 'Continue' }));
 

--- a/src/modules/returns/forms/meter-readings.js
+++ b/src/modules/returns/forms/meter-readings.js
@@ -1,0 +1,111 @@
+const Joi = require('joi');
+const { formFactory, fields, setValues } = require('../../../lib/forms');
+const { getMeter, getFormLines, getLineName, getLineLabel } = require('../lib/return-helpers');
+const { get } = require('lodash');
+
+const form = (request, data) => {
+  const { csrfToken } = request.view;
+
+  const isInternal = request.permissions.hasPermission('admin.defra');
+  const action = `${isInternal ? '/admin' : ''}/return/meter/readings`;
+
+  const f = formFactory(action);
+
+  const lines = getFormLines(data);
+
+  for (let line of lines) {
+    const name = getLineName(line);
+    const label = getLineLabel(line);
+    f.fields.push(fields.text(name, {
+      label,
+      autoComplete: false,
+      mapper: 'numberMapper',
+      type: 'number',
+      controlClass: 'form-control form-control--reading',
+      errors: {
+        'number.min': {
+          message: 'Reading must be equal to or greater than the previous reading'
+        },
+        'number.startReading': {
+          message: 'Reading must be equal to or greater than the start reading'
+        }
+      }
+    }));
+  }
+
+  f.fields.push(fields.button());
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  const readings = getMeter(data).readings || {};
+  return setValues(f, readings);
+};
+
+const getMeterStartReadingValidator = startReading => {
+  return Joi.number().allow(null).min(startReading).error(() => {
+    return { type: 'number.startReading' };
+  });
+};
+
+/**
+ * Creates a validator for the line at the given index.
+ *
+ * The lines are in date order so the first validator only
+ * validates that the value is either empty or, greater than or equal
+ * to the meter start reading.
+ *
+ * For all the rest of the lines, the value is validated to ensure
+ * that the value is null, or greater than or equal to the previous
+ * readings and the meter start reading.
+ */
+const getReadingValidator = (startReading, lines, index) => {
+  const startReadingMin = getMeterStartReadingValidator(startReading);
+
+  if (index === 0) {
+    return startReadingMin;
+  }
+
+  let validator = Joi.number().allow(null);
+
+  // get the preceeding lines
+  lines.slice(0, index).forEach(line => {
+    const name = getLineName(line);
+    validator = validator.when(name, {
+      // If the target value is entered and is numeric
+      is: Joi.number().strict().required(),
+
+      // ensure this value is at the same the value
+      then: Joi.number().allow(null).min(Joi.ref(name)),
+
+      // if the target value is null, then just validate against
+      // the meter start reading.
+      otherwise: startReadingMin
+    });
+  });
+
+  return validator;
+};
+
+const schema = (data) => {
+  let schema = {
+    csrf_token: Joi.string().guid().required()
+  };
+
+  const lines = getFormLines(data);
+  const startReading = get(data, 'meters[0].startReading', 0);
+
+  schema = lines.reduce((acc, line, currentIndex) => {
+    const name = getLineName(line);
+    const obj = {
+      ...acc,
+      [name]: getReadingValidator(startReading, lines, currentIndex)
+    };
+    return obj;
+  }, schema);
+
+  return schema;
+};
+
+module.exports = {
+  meterReadingsForm: form,
+  meterReadingsSchema: schema
+};

--- a/src/modules/returns/forms/meter-readings.js
+++ b/src/modules/returns/forms/meter-readings.js
@@ -3,6 +3,26 @@ const { formFactory, fields, setValues } = require('../../../lib/forms');
 const { getMeter, getFormLines, getLineName, getLineLabel } = require('../lib/return-helpers');
 const { get } = require('lodash');
 
+const getLineTextInput = line => {
+  const name = getLineName(line);
+  const label = getLineLabel(line);
+  return fields.text(name, {
+    label,
+    autoComplete: false,
+    mapper: 'numberMapper',
+    type: 'number',
+    controlClass: 'form-control form-control--reading',
+    errors: {
+      'number.min': {
+        message: 'Reading must be equal to or greater than the previous reading'
+      },
+      'number.startReading': {
+        message: 'Reading must be equal to or greater than the start reading'
+      }
+    }
+  });
+};
+
 const form = (request, data) => {
   const { csrfToken } = request.view;
 
@@ -13,25 +33,8 @@ const form = (request, data) => {
 
   const lines = getFormLines(data);
 
-  for (let line of lines) {
-    const name = getLineName(line);
-    const label = getLineLabel(line);
-    f.fields.push(fields.text(name, {
-      label,
-      autoComplete: false,
-      mapper: 'numberMapper',
-      type: 'number',
-      controlClass: 'form-control form-control--reading',
-      errors: {
-        'number.min': {
-          message: 'Reading must be equal to or greater than the previous reading'
-        },
-        'number.startReading': {
-          message: 'Reading must be equal to or greater than the start reading'
-        }
-      }
-    }));
-  }
+  // add a text field for each required meter reading
+  lines.forEach(line => f.fields.push(getLineTextInput(line)));
 
   f.fields.push(fields.button());
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));

--- a/src/modules/returns/forms/meter-units.js
+++ b/src/modules/returns/forms/meter-units.js
@@ -1,0 +1,43 @@
+const Joi = require('joi');
+const { setValues, formFactory, fields } = require('../../../lib/forms');
+
+const choices = [
+  { value: 'm³', label: 'Cubic metres' },
+  { value: 'l', label: 'Litres' },
+  { value: 'Ml', label: 'Megalitres' },
+  { value: 'gal', label: 'Gallons' }
+];
+
+const form = (request, data) => {
+  const { csrfToken } = request.view;
+  const isInternal = request.permissions.hasPermission('admin.defra');
+  const action = `${isInternal ? '/admin' : ''}/return/meter/units`;
+
+  const f = formFactory(action);
+
+  f.fields.push(fields.radio('units', {
+    label: 'What units does your meter use?',
+    errors: {
+      'any.required': {
+        message: 'Select a unit of measurement',
+        summary: 'Select a unit of measurement'
+      }
+    },
+    choices
+  }));
+
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return setValues(f, data.reading);
+};
+
+const schema = {
+  units: Joi.string().valid(choices.map(choice => choice.value)).required(),
+  csrf_token: Joi.string().guid().required()
+};
+
+module.exports = {
+  meterUnitsForm: form,
+  meterUnitsSchema: schema
+};

--- a/src/modules/returns/forms/meter-units.js
+++ b/src/modules/returns/forms/meter-units.js
@@ -1,43 +1,8 @@
-const Joi = require('joi');
-const { setValues, formFactory, fields } = require('../../../lib/forms');
+const factory = require('./units-factory');
 
-const choices = [
-  { value: 'm³', label: 'Cubic metres' },
-  { value: 'l', label: 'Litres' },
-  { value: 'Ml', label: 'Megalitres' },
-  { value: 'gal', label: 'Gallons' }
-];
+const form = factory.create({
+  labelText: 'What units does your meter use?',
+  actionUrl: '/return/meter/units'
+});
 
-const form = (request, data) => {
-  const { csrfToken } = request.view;
-  const isInternal = request.permissions.hasPermission('admin.defra');
-  const action = `${isInternal ? '/admin' : ''}/return/meter/units`;
-
-  const f = formFactory(action);
-
-  f.fields.push(fields.radio('units', {
-    label: 'What units does your meter use?',
-    errors: {
-      'any.required': {
-        message: 'Select a unit of measurement',
-        summary: 'Select a unit of measurement'
-      }
-    },
-    choices
-  }));
-
-  f.fields.push(fields.button(null, { label: 'Continue' }));
-  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
-
-  return setValues(f, data.reading);
-};
-
-const schema = {
-  units: Joi.string().valid(choices.map(choice => choice.value)).required(),
-  csrf_token: Joi.string().guid().required()
-};
-
-module.exports = {
-  meterUnitsForm: form,
-  meterUnitsSchema: schema
-};
+module.exports = form;

--- a/src/modules/returns/forms/method.js
+++ b/src/modules/returns/forms/method.js
@@ -1,9 +1,11 @@
+const { get } = require('lodash');
 const { formFactory, fields } = require('../../../lib/forms');
 
-const methodForm = (request) => {
+const methodForm = (request, data) => {
   const { csrfToken } = request.view;
   const isInternal = request.permissions.hasPermission('admin.defra');
   const action = `${isInternal ? '/admin' : ''}/return/method`;
+  const method = get(data, 'reading.method');
 
   const f = formFactory(action);
 
@@ -18,7 +20,7 @@ const methodForm = (request) => {
       { value: 'oneMeter', label: 'Readings from one meter' },
       { value: 'multipleMeters', label: 'Readings from more than one meter' },
       { value: 'abstractionVolumes', label: 'Abstraction volumes' }
-    ]}));
+    ]}, method));
 
   f.fields.push(fields.button(null, { label: 'Continue' }));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));

--- a/src/modules/returns/forms/single-total.js
+++ b/src/modules/returns/forms/single-total.js
@@ -24,7 +24,7 @@ const form = (request) => {
           fields.text('total', {
             label: 'Enter total amount',
             type: 'number',
-            controlClass: 'form-control form-control-small',
+            controlClass: 'form-control form-control--small',
             errors: {
               'number.base': {
                 message: 'Enter a total figure'

--- a/src/modules/returns/forms/units-factory.js
+++ b/src/modules/returns/forms/units-factory.js
@@ -1,0 +1,43 @@
+const { get } = require('lodash');
+const { setValues, formFactory, fields } = require('../../../lib/forms');
+
+const choices = [
+  { value: 'm³', label: 'Cubic metres' },
+  { value: 'l', label: 'Litres' },
+  { value: 'Ml', label: 'Megalitres' },
+  { value: 'gal', label: 'Gallons' }
+];
+
+const getUnitsRadioButtons = label => {
+  return fields.radio('units', {
+    label,
+    errors: {
+      'any.required': {
+        message: 'Select a unit of measurement'
+      }
+    },
+    choices
+  });
+};
+
+const create = (options = {}) => {
+  const { labelText, actionUrl } = options;
+
+  const unitsForm = (request, data) => {
+    const { csrfToken } = request.view;
+    const isInternal = request.permissions.hasPermission('admin.defra');
+    const action = `${isInternal ? '/admin' : ''}${actionUrl}`;
+    const f = formFactory(action);
+
+    f.fields.push(getUnitsRadioButtons(labelText));
+    f.fields.push(fields.button(null, { label: 'Continue' }));
+    f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+    const values = get(data, 'reading', {});
+    return setValues(f, values);
+  };
+
+  return unitsForm;
+};
+
+module.exports = { create };

--- a/src/modules/returns/forms/units.js
+++ b/src/modules/returns/forms/units.js
@@ -1,31 +1,8 @@
-const { formFactory, fields } = require('../../../lib/forms');
+const factory = require('./units-factory');
 
-const unitsForm = (request) => {
-  const { csrfToken } = request.view;
+const form = factory.create({
+  labelText: 'What is the unit of measurement?',
+  actionUrl: '/return/units'
+});
 
-  const isInternal = request.permissions.hasPermission('admin.defra');
-  const action = `${isInternal ? '/admin' : ''}/return/units`;
-
-  const f = formFactory(action);
-
-  f.fields.push(fields.radio('units', {
-    label: 'What is the unit of measurement?',
-    errors: {
-      'any.required': {
-        message: 'Select a unit of measurement'
-      }
-    },
-    choices: [
-      { value: 'm³', label: 'Cubic metres' },
-      { value: 'l', label: 'Litres' },
-      { value: 'Ml', label: 'Megalitres' },
-      { value: 'gal', label: 'Gallons' }
-    ]}));
-
-  f.fields.push(fields.button(null, { label: 'Continue' }));
-  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
-
-  return f;
-};
-
-module.exports = unitsForm;
+module.exports = form;

--- a/src/modules/returns/lib/helpers.js
+++ b/src/modules/returns/lib/helpers.js
@@ -6,6 +6,7 @@ const { returns, versions } = require('../../../lib/connectors/returns');
 const { externalRoles } = require('../../../lib/constants');
 const { hasPermission } = require('../../../lib/permissions');
 const config = require('../../../../config');
+const { getWaterLicence } = require('../../../lib/connectors/crm/documents');
 
 /**
  * Gets licences from the CRM that can be viewed by the supplied entity ID
@@ -293,6 +294,23 @@ const getScopedPath = (request, path) => {
   return isInternal ? `/admin${path}` : path;
 };
 
+/**
+ * Get common view data used by many controllers
+ * @param {Object} HAPI request instance
+ * @param {Object} data - the return model
+ * @return {Promise} resolves with view data
+ */
+const getViewData = async (request, data) => {
+  const documentHeader = await getWaterLicence(data.licenceNumber);
+  const isInternal = request.permissions.hasPermission('admin.defra');
+  return {
+    ...request.view,
+    documentHeader,
+    data,
+    activeNavLink: isInternal ? 'view' : 'returns'
+  };
+};
+
 module.exports = {
   getLicenceNumbers,
   getLicenceReturns,
@@ -304,5 +322,6 @@ module.exports = {
   getInternalRoles,
   getReturnTotal,
   getScopedPath,
-  canEdit
+  canEdit,
+  getViewData
 };

--- a/src/modules/returns/lib/session-helpers.js
+++ b/src/modules/returns/lib/session-helpers.js
@@ -1,7 +1,6 @@
 const Boom = require('boom');
 const { returns } = require('../../../lib/connectors/water');
 const { applyUserDetails, applyStatus } = require('../lib/return-helpers');
-const { isInternalUser } = require('./helpers');
 
 /**
  * Gets the key to use for storing return data in user session

--- a/src/modules/returns/plugin.js
+++ b/src/modules/returns/plugin.js
@@ -1,0 +1,30 @@
+const { getSessionData } = require('./lib/session-helpers');
+const { getViewData } = require('./lib/helpers');
+
+const returnsPlugin = {
+  register: (server, options) => {
+    server.ext({
+      type: 'onPreHandler',
+      method: async (request, reply) => {
+        if (request.route.settings.plugins.returns) {
+          const data = getSessionData(request);
+          const view = await getViewData(request, data);
+
+          request.returns = {
+            data,
+            view,
+            isInternal: request.permissions.hasPermission('admin.defra')
+          };
+        }
+        return reply.continue;
+      }
+    });
+  },
+
+  pkg: {
+    name: 'returnsPlugin',
+    version: '2.0.0'
+  }
+};
+
+module.exports = returnsPlugin;

--- a/src/modules/returns/routes/edit-internal.js
+++ b/src/modules/returns/routes/edit-internal.js
@@ -18,7 +18,8 @@ const createMeterRoute = (method, path, description) => {
       auth: { scope: returns },
       description,
       plugins: {
-        viewContext: { activeNavLink: 'returns' }
+        viewContext: { activeNavLink: 'returns' },
+        returns: true
       }
     }
   };
@@ -76,7 +77,8 @@ module.exports = {
             csrf_token: VALID_GUID,
             isNil: Joi.string().required().valid('Yes', 'No')
           }
-        }
+        },
+        returns: true
       }
     }
   },
@@ -94,7 +96,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - submit nil',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -112,7 +115,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - nil submitted',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -129,7 +133,8 @@ module.exports = {
       plugins: {
         viewContext: {
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -147,7 +152,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - how are you reporting your return?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -165,7 +171,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - how are you reporting your return?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -183,7 +190,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - how are you reporting your return?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -201,7 +209,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - what is the unit of measurement?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -219,7 +228,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - what is the unit of measurement?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -237,7 +247,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - is it a single amount?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -255,7 +266,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - is it a single amount?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -273,7 +285,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - are you using estimates?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -291,7 +304,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - are you using estimates?',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -309,7 +323,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - enter amounts',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -327,7 +342,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - enter amounts',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },
@@ -346,7 +362,8 @@ module.exports = {
           pageTitle: 'Abstraction return - check the information before submitting',
           activeNavLink: 'returns',
           showMeta: true
-        }
+        },
+        returns: true
       }
     }
   },
@@ -364,7 +381,8 @@ module.exports = {
         viewContext: {
           pageTitle: 'Abstraction return - check the information before submitting',
           activeNavLink: 'returns'
-        }
+        },
+        returns: true
       }
     }
   },

--- a/src/modules/returns/routes/edit-internal.js
+++ b/src/modules/returns/routes/edit-internal.js
@@ -3,6 +3,29 @@ const controller = require('../controllers/edit');
 const constants = require('../../../lib/constants');
 const returns = constants.scope.returns;
 const { VALID_GUID } = require('../../../lib/validators');
+const { upperFirst } = require('lodash');
+
+const getHandlerName = (method, path, pathExclude) => {
+  return method.toLowerCase() + path.replace(pathExclude, '').split('/').map(upperFirst).join('');
+};
+
+const createMeterRoute = (method, path, description) => {
+  return {
+    method,
+    path,
+    handler: controller[getHandlerName(method, path, '/admin/return/')],
+    options: {
+      auth: { scope: returns },
+      description,
+      plugins: {
+        viewContext: { activeNavLink: 'returns' }
+      }
+    }
+  };
+};
+
+const createGetMeterRoute = createMeterRoute.bind(null, 'GET');
+const createPostMeterRoute = createMeterRoute.bind(null, 'POST');
 
 module.exports = {
   getAmounts: {
@@ -344,6 +367,36 @@ module.exports = {
         }
       }
     }
-  }
+  },
+
+  getMeterDetails: createGetMeterRoute(
+    '/admin/return/meter/details',
+    'Shows the view allowing an admin user to enter meter details'
+  ),
+
+  postMeterDetails: createPostMeterRoute(
+    '/admin/return/meter/details',
+    'POST handler for meter details'
+  ),
+
+  getMeterUnits: createGetMeterRoute(
+    '/admin/return/meter/units',
+    'Shows the view allowing an admin user to enter meter units'
+  ),
+
+  postMeterUnits: createPostMeterRoute(
+    '/admin/return/meter/units',
+    'POST handler for meter units'
+  ),
+
+  getMeterReadings: createGetMeterRoute(
+    '/admin/return/meter/readings',
+    'Shows the view allowing an admin user to enter meter readings'
+  ),
+
+  postMeterReadings: createPostMeterRoute(
+    '/admin/return/meter/readings',
+    'POST handler for meter readings'
+  )
 
 };

--- a/src/modules/returns/routes/edit.js
+++ b/src/modules/returns/routes/edit.js
@@ -4,6 +4,46 @@ const constants = require('../../../lib/constants');
 const external = constants.scope.external;
 const { VALID_GUID } = require('../../../lib/validators');
 
+const createGetMeterRoute = (path, handler, description) => ({
+  method: 'GET',
+  path,
+  handler,
+  options: {
+    auth: {
+      scope: external
+    },
+    description,
+    plugins: {
+      viewContext: {
+        activeNavLink: 'returns'
+      },
+      hapiRouteAcl: {
+        permissions: ['returns:submit']
+      }
+    }
+  }
+});
+
+const createPostMeterRoute = (path, handler, description) => ({
+  method: 'POST',
+  path,
+  handler,
+  options: {
+    auth: {
+      scope: external
+    },
+    description,
+    plugins: {
+      viewContext: {
+        activeNavLink: 'returns'
+      },
+      hapiRouteAcl: {
+        permissions: ['returns:submit']
+      }
+    }
+  }
+});
+
 module.exports = {
   getAmounts: {
     method: 'GET',
@@ -356,6 +396,41 @@ module.exports = {
         }
       }
     }
-  }
+  },
 
+  getMeterDetails: createGetMeterRoute(
+    '/return/meter/details',
+    controller.getMeterDetails,
+    'Shows the view allowing a user to enter meter details'
+  ),
+
+  postMeterDetails: createPostMeterRoute(
+    '/return/meter/details',
+    controller.postMeterDetails,
+    'POST handler for meter details'
+  ),
+
+  getMeterUnits: createGetMeterRoute(
+    '/return/meter/units',
+    controller.getMeterUnits,
+    'Shows the view allowing to select the meter units'
+  ),
+
+  postMeterUnits: createPostMeterRoute(
+    '/return/meter/units',
+    controller.postMeterUnits,
+    'POST handler for meter units'
+  ),
+
+  getMeterReadings: createGetMeterRoute(
+    '/return/meter/readings',
+    controller.getMeterReadings,
+    'Shows the view to capture the users meter readings'
+  ),
+
+  postMeterReadings: createPostMeterRoute(
+    '/return/meter/readings',
+    controller.postMeterReadings,
+    'POST handler for meter readings'
+  )
 };

--- a/src/modules/returns/routes/edit.js
+++ b/src/modules/returns/routes/edit.js
@@ -4,8 +4,8 @@ const constants = require('../../../lib/constants');
 const external = constants.scope.external;
 const { VALID_GUID } = require('../../../lib/validators');
 
-const createGetMeterRoute = (path, handler, description) => ({
-  method: 'GET',
+const createMeterRoute = (method, path, handler, description) => ({
+  method,
   path,
   handler,
   options: {
@@ -24,25 +24,8 @@ const createGetMeterRoute = (path, handler, description) => ({
   }
 });
 
-const createPostMeterRoute = (path, handler, description) => ({
-  method: 'POST',
-  path,
-  handler,
-  options: {
-    auth: {
-      scope: external
-    },
-    description,
-    plugins: {
-      viewContext: {
-        activeNavLink: 'returns'
-      },
-      hapiRouteAcl: {
-        permissions: ['returns:submit']
-      }
-    }
-  }
-});
+const createGetMeterRoute = createMeterRoute.bind(null, 'GET');
+const createPostMeterRoute = createMeterRoute.bind(null, 'POST');
 
 module.exports = {
   getAmounts: {

--- a/src/views/partials/form-checkbox.html
+++ b/src/views/partials/form-checkbox.html
@@ -1,0 +1,6 @@
+<div class="form-group {{#if errors }}form-group-error{{/if}}">
+  <div class="multiple-choice">
+    <input id="{{value}}" name="{{name}}" type="checkbox" value="{{value}}" {{#if options.checked}}checked{{/if}} />
+    <label for="{{value}}">{{options.label}}</label>
+  </div>
+</div>

--- a/src/views/partials/form-checkbox.html
+++ b/src/views/partials/form-checkbox.html
@@ -1,6 +1,6 @@
 <div class="form-group {{#if errors }}form-group-error{{/if}}">
   <div class="multiple-choice">
-    <input id="{{value}}" name="{{name}}" type="checkbox" value="{{value}}" {{#if options.checked}}checked{{/if}} />
-    <label for="{{value}}">{{options.label}}</label>
+    <input id="{{name}}" name="{{name}}" type="checkbox" value="{{value}}" {{#if options.checked}}checked{{/if}} />
+    <label for="{{name}}">{{options.label}}</label>
   </div>
 </div>

--- a/src/views/partials/form-errors.html
+++ b/src/views/partials/form-errors.html
@@ -1,19 +1,20 @@
 {{#if errors }}
-<div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-  <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
 
-    <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
-      There is a problem
-    </h2>
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There is a problem
+      </h2>
 
+      <ul class="error-summary-list">
+        {{#each errors}}
+        <li><a href="#{{ name }}">{{ summary }}</a></li>
+        {{/each}}
+      </ul>
 
-    <ul class="error-summary-list">
-      {{#each errors}}
-      <li><a href="#{{ name }}">{{ summary }}</a></li>
-      {{/each}}
-    </ul>
-
+    </div>
   </div>
 </div>
 {{/if}}

--- a/src/views/partials/form-text.html
+++ b/src/views/partials/form-text.html
@@ -20,7 +20,7 @@
   {{#if options.multiline }}
   <textarea {{#if options.rows }}rows={{ options.rows }}{{/if}} class="{{ options.controlClass }}" id="{{ name }}" type="{{ options.type }}" name="{{ name }}">{{ value }}</textarea>
   {{else}}
-  <input class="{{ options.controlClass }}" id="{{ name }}" type="{{ options.type }}" name="{{ name }}" value="{{ value }}">
+  <input class="{{ options.controlClass }}" id="{{ name }}" type="{{ options.type }}" name="{{ name }}" value="{{ value }}" {{#unless options.autoComplete}}autocomplete="off"{{/unless}} />
   {{/if}}
 
   <span class="form-suffix">

--- a/src/views/partials/form-widget.html
+++ b/src/views/partials/form-widget.html
@@ -11,3 +11,6 @@
 {{#equal this.options.widget 'text'}}
   {{>form-text this form=form }}
 {{/equal}}
+{{#equal this.options.widget 'checkbox'}}
+  {{>form-checkbox this form=form }}
+{{/equal}}

--- a/src/views/water/returns/meter-details.html
+++ b/src/views/water/returns/meter-details.html
@@ -1,0 +1,31 @@
+{{> styles}}
+<main id="content" tabindex="-1">
+  {{>element-phase-tag}}
+  {{>element-main-nav}}
+
+  {{>form-errors form }}
+
+  {{>return-header }}
+
+  <h3 class="heading-medium">Tell us about your meter</h3>
+
+  {{>form-header form }}
+
+    {{>form-widget form.fields.[0] form=form}}
+    {{>form-widget form.fields.[1] form=form}}
+    {{>form-widget form.fields.[2] form=form}}
+
+    <p class="text">
+      Some meters are marked with ×10. You should enter the actual figure
+      that you see on the display. You do not need to multiply the volume by 10.
+    </p>
+
+    {{>form-widget form.fields.[3] form=form}}
+    {{>form-widget form.fields.[4] form=form}}
+    {{>form-widget form.fields.[5] form=form}}
+
+  {{>form-footer }}
+</main>
+
+{{> footerjs}}
+{{> debug}}

--- a/src/views/water/returns/meter-readings.html
+++ b/src/views/water/returns/meter-readings.html
@@ -1,0 +1,24 @@
+{{> styles}}
+<main id="content" tabindex="-1">
+  {{>element-phase-tag}}
+  {{>element-main-nav}}
+
+  {{>form-errors form }}
+
+  {{>return-header }}
+
+  <h3 class="heading-medium">Meter readings</h3>
+
+  <p class="text">Enter readings for the end of each {{ return.frequency }}</p>
+
+  <div class="panel panel-border-wide">
+    <p class="spaceless">Meter {{ return.meters.0.serialNumber }}</p>
+    <p class="spaceless">Initial reading {{ return.meters.0.startReading }}</p>
+  </div>
+
+  {{>form form }}
+
+</main>
+
+{{> footerjs}}
+{{> debug}}

--- a/test/modules/returns/forms/meter-readings.js
+++ b/test/modules/returns/forms/meter-readings.js
@@ -1,0 +1,82 @@
+const Joi = require('joi');
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+const { meterReadingsSchema } = require('../../../../src/modules/returns/forms/meter-readings');
+
+const data = {
+  meters: [{
+    startReading: 10
+  }],
+  lines: [
+    { startDate: '2017-01-01', endDate: '2017-01-31', timePeriod: 'month', quantity: null },
+    { startDate: '2017-02-01', endDate: '2017-02-28', timePeriod: 'month', quantity: null },
+    { startDate: '2017-03-01', endDate: '2017-03-30', timePeriod: 'month', quantity: null },
+    { startDate: '2017-04-01', endDate: '2017-04-30', timePeriod: 'month', quantity: null }
+  ]
+};
+
+const createFormValues = (jan, feb, mar, apr) => ({
+  '2017-01-01_2017-01-31': jan,
+  '2017-02-01_2017-02-28': feb,
+  '2017-03-01_2017-03-30': mar,
+  '2017-04-01_2017-04-30': apr,
+  csrf_token: '4a95f0e2-4861-49ef-af95-0a269fae982c'
+});
+
+experiment('meterReadingsSchema', () => {
+  test('is valid for all null values', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(null, null, null, null);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.be.null();
+  });
+
+  test('is valid for incrementing numbers', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(11, 12, 13, 14);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.be.null();
+  });
+
+  test('is valid for equal numbers', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(10, 10, 10, 10);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.be.null();
+  });
+
+  test('handles null in between numeric readings', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(10, 20, null, 30);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.be.null();
+  });
+
+  test('handles multiple nulls in between numeric readings', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(null, null, null, 30);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.be.null();
+  });
+
+  test('not valid if first reading is less than start reading', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(5, 20, 30, 40);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.not.be.null();
+  });
+
+  test('not valid if a reading is lower than an earlier reading', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(20, 30, 10, 40);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.not.be.null();
+  });
+
+  test('not valid if a reading at end is lower', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(20, 30, null, 10);
+    const result = Joi.validate(formValues, schema);
+    expect(result.error).to.not.be.null();
+  });
+});


### PR DESCRIPTION
 - Adds meter details form
 - Adds meter unit forms
 - Adds meter readings form
 - Allow autocomplete to be disabled on text fields
 - Adds internal admin routes for meter readings
 - Adds a function to apply the meter readings to return lines
 - Retain the meter readings in addition to the calculated return lines.
 - Validate meters readings are >= previous reading
 - Validate meters readings are >= start reading
 - Allow the external user to enter return data
 - Save the meter data using the meters key of the returns model.