### PR TITLE
Fix: WATER-1450 validation logic

### DIFF
--- a/src/modules/returns/forms/meter-readings.js
+++ b/src/modules/returns/forms/meter-readings.js
@@ -77,7 +77,7 @@ const getReadingValidator = (startReading, lines, index) => {
       is: Joi.number().strict().required(),
 
       // ensure this value is at the same the value
-      then: Joi.number().allow(null).min(Joi.ref(name)),
+      then: Joi.number().required().allow(null).min(Joi.ref(name)),
 
       // if the target value is null, then just validate against
       // the meter start reading.

--- a/test/modules/returns/forms/meter-readings.js
+++ b/test/modules/returns/forms/meter-readings.js
@@ -27,56 +27,70 @@ experiment('meterReadingsSchema', () => {
   test('is valid for all null values', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(null, null, null, null);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('is valid for incrementing numbers', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(11, 12, 13, 14);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('is valid for equal numbers', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(10, 10, 10, 10);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('handles null in between numeric readings', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(10, 20, null, 30);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('handles multiple nulls in between numeric readings', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(null, null, null, 30);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('not valid if first reading is less than start reading', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(5, 20, 30, 40);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 
   test('not valid if a reading is lower than an earlier reading', async () => {
     const schema = meterReadingsSchema(data);
-    const formValues = createFormValues(20, 30, 10, 40);
-    const result = Joi.validate(formValues, schema);
+    const formValues = createFormValues(20, 20, 20, 10);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
+    expect(result.error).to.not.be.null();
+  });
+
+  test('not valid if last reading is lower than an earlier reading using larger numbers', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(20000, 20000, 20000, 10000);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
+    expect(result.error).to.not.be.null();
+  });
+
+  test.only('not valid if a reading is lower than an earlier reading using larger numbers', async () => {
+    const schema = meterReadingsSchema(data);
+    const formValues = createFormValues(2000000000, 3000000000, 1000000000, 2000000000);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 
   test('not valid if a reading at end is lower', async () => {
     const schema = meterReadingsSchema(data);
     const formValues = createFormValues(20, 30, null, 10);
-    const result = Joi.validate(formValues, schema);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 });


### PR DESCRIPTION
Fixes an issue reported where, when using large numbers, the meter
reading validation was not working and was allowing a user to enter a
reading that was lower than an earlier reading.