### PR TITLE
Fix: Survey was scrolling down the page on signout

### DIFF
--- a/src/views/partials/feedback-survey.html
+++ b/src/views/partials/feedback-survey.html
@@ -1,17 +1,11 @@
 {{#equal surveyType 'internal'}}
-<script id="ss-embed-419108">(function(d,w)
-{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=419108';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
-)(document,window);</script>
+<iframe id="ss-embed-frame-419108" src="https://www.smartsurvey.co.uk/s/1CCYT/" style="width:100%;height:800px;border:0px;padding-bottom:4px;" frameborder="0"></iframe>
 {{/equal}}
 
 {{#equal surveyType 'external'}}
-<script id="ss-embed-416960">(function(d,w)
-{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=416960';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
-)(document,window);</script>
+<iframe id="ss-embed-frame-416960" src="https://www.smartsurvey.co.uk/s/FYWJN/" style="width:100%;height:800px;border:0px;padding-bottom:4px;" frameborder="0"></iframe>
 {{/equal}}
 
 {{#equal surveyType 'anonymous'}}
-<script id="ss-embed-517384">(function(d,w)
-{var s,ss;ss=d.createElement('script');ss.type='text/javascript';ss.async=true;ss.src=('https:'==d.location.protocol?'https://':'http://')+'www.smartsurvey.co.uk/s/r/embed.aspx?i=371736&c=517384';s=d.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ss, s);}
-)(document,window);</script>
+<iframe id="ss-embed-frame-517384" src="https://www.smartsurvey.co.uk/s/AEIMT/" style="width:100%;height:800px;border:0px;padding-bottom:4px;" frameborder="0"></iframe>
 {{/equal}}


### PR DESCRIPTION
The smart survey was being added using a script tag. The iframe that is
rendered as a result contained a `onload` handler to scroll the user to
the bottom of the survey.

To fix, the iframe, without the onlonad hander is used in place of the
script tag.