### PR TITLE
Fix: Corrects meter reading validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "install-assets": "gulp build",
     "test": "./node_modules/lab/bin/lab -t 55 -m 0 -r lcov -o lcov.info -r console -o stdout",
+    "test:only": "./node_modules/lab/bin/lab",
     "test-cov-html": "lab -r html -o coverage.html",
     "docs": "jsdoc -c conf.jsdoc.json && cd ./out && serve -o -p 3011",
     "lint": "./node_modules/.bin/eslint ./src/**/*.js --fix",

--- a/src/lib/forms/index.js
+++ b/src/lib/forms/index.js
@@ -227,5 +227,6 @@ module.exports = {
   formFactory,
   handleRequest,
   fields,
-  schemaFactory
+  schemaFactory,
+  importData
 };

--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -5,7 +5,7 @@
  */
 const { set, get } = require('lodash');
 const Boom = require('boom');
-const { handleRequest, setValues, getValues } = require('../../../lib/forms');
+const { importData, handleRequest, setValues, getValues } = require('../../../lib/forms');
 
 const {
   amountsForm, methodForm, confirmForm, unitsForm,
@@ -439,7 +439,17 @@ const getMeterReadings = async (request, h) => {
 
 const postMeterReadings = async (request, h) => {
   const { view, data } = request.returns;
-  const form = handleRequest(meterReadingsForm(request, data), request, meterReadingsSchema(data));
+
+  const readingsForm = meterReadingsForm(request, data);
+
+  // Get the internal repreentation of the data to pass to the schema
+  // which needs the current user input in order to generate the
+  // schema to cater for checking if the readings are not lower than
+  // previous readings.
+  const internalData = importData(readingsForm, request.payload);
+  const schema = meterReadingsSchema(data, internalData);
+
+  const form = handleRequest(readingsForm, request, schema);
 
   if (form.isValid) {
     const updated = applyMeterReadings(data, getValues(form));

--- a/test/lib/sign-in.js
+++ b/test/lib/sign-in.js
@@ -27,7 +27,7 @@ lab.experiment('sign-in.createSessionData', () => {
       user_name: emailAddress,
       user_data: { test: 'data' },
       role: { scopes: ['test-scope'] },
-      lastlogin: 'last-login'
+      last_login: 'last-login'
     };
 
     sessionData = createSessionData(sessionId, user, entityId, roles);
@@ -68,7 +68,7 @@ lab.experiment('sign-in.createSessionData', () => {
   });
 
   lab.test('adds the last login value from the user', async () => {
-    expect(sessionData.lastlogin).to.equal(user.lastlogin);
+    expect(sessionData.lastlogin).to.equal(user.last_login);
   });
 
   lab.test('adds the roles', async () => {
@@ -79,7 +79,7 @@ lab.experiment('sign-in.createSessionData', () => {
     expect(sessionData.scope).to.equal(user.role.scopes);
   });
 
-  lab.test('sets user data newuser to false if no lastlogin', async () => {
+  lab.test('sets user data newuser to true if no lastlogin', async () => {
     const neverLoggedInUser = {
       user_id: userId,
       user_name: emailAddress,
@@ -88,7 +88,7 @@ lab.experiment('sign-in.createSessionData', () => {
     };
 
     const data = createSessionData('id', neverLoggedInUser, 'eid', []);
-    expect(data.user_data.newuser).to.be.false();
+    expect(data.user_data.newuser).to.be.true();
   });
 
   lab.test('sets user data last login to null if no lastlogin', async () => {
@@ -103,11 +103,11 @@ lab.experiment('sign-in.createSessionData', () => {
     expect(data.user_data.lastlogin).to.be.null();
   });
 
-  lab.test('sets user data newuser to true if lastlogin exists', async () => {
-    expect(sessionData.user_data.newuser).to.be.true();
+  lab.test('sets user data newuser to false if lastlogin exists', async () => {
+    expect(sessionData.user_data.newuser).to.be.false();
   });
 
   lab.test('sets user data last login if lastlogin exists', async () => {
-    expect(sessionData.user_data.lastlogin).to.equal(user.lastlogin);
+    expect(sessionData.user_data.lastlogin).to.equal(user.last_login);
   });
 });

--- a/test/modules/returns/forms/meter-readings.js
+++ b/test/modules/returns/forms/meter-readings.js
@@ -25,71 +25,71 @@ const createFormValues = (jan, feb, mar, apr) => ({
 
 experiment('meterReadingsSchema', () => {
   test('is valid for all null values', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(null, null, null, null);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('is valid for incrementing numbers', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(11, 12, 13, 14);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('is valid for equal numbers', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(10, 10, 10, 10);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('handles null in between numeric readings', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(10, 20, null, 30);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('handles multiple nulls in between numeric readings', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(null, null, null, 30);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.be.null();
   });
 
   test('not valid if first reading is less than start reading', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(5, 20, 30, 40);
+    const schema = meterReadingsSchema(data, formValues);
+    const result = Joi.validate(formValues, schema, { abortEarly: false });
+    expect(result.error).to.not.be.null();
+  });
+
+  test('not valid if all readings are less than start reading', async () => {
+    const formValues = createFormValues(5, 5, 5, 5);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 
   test('not valid if a reading is lower than an earlier reading', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(20, 20, 20, 10);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 
-  test('not valid if last reading is lower than an earlier reading using larger numbers', async () => {
-    const schema = meterReadingsSchema(data);
-    const formValues = createFormValues(20000, 20000, 20000, 10000);
-    const result = Joi.validate(formValues, schema, { abortEarly: false });
-    expect(result.error).to.not.be.null();
-  });
-
-  test.only('not valid if a reading is lower than an earlier reading using larger numbers', async () => {
-    const schema = meterReadingsSchema(data);
-    const formValues = createFormValues(2000000000, 3000000000, 1000000000, 2000000000);
+  test('not valid if a reading is lower than an earlier reading using larger numbers', async () => {
+    const formValues = createFormValues(2000000000, 3000000000, 2000000001, 4000000000);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });
 
   test('not valid if a reading at end is lower', async () => {
-    const schema = meterReadingsSchema(data);
     const formValues = createFormValues(20, 30, null, 10);
+    const schema = meterReadingsSchema(data, formValues);
     const result = Joi.validate(formValues, schema, { abortEarly: false });
     expect(result.error).to.not.be.null();
   });


### PR DESCRIPTION
WATER-1502

Fixes a bug with the validation of meter readings by changing the
validation schema to be created based on the values that are submitted.

The schema function now has to receive the data in order to create the
rules to enforce that a non null value is:

1) Greater than the meter start reading
2) Greater than the most recent non null reading