### PR TITLE
Feat: Adds purpose alias when showing returns

### DIFF
--- a/src/views/water/returns/licence.html
+++ b/src/views/water/returns/licence.html
@@ -62,7 +62,7 @@
           <div class="table-row medium-space {{# notEqual received_date null }}clickable{{/notEqual }}">                                    <!-- a data row starts -->
 
             <div class="table-cell">
-              <h3 class="context">
+              <h4 class="context">
                 Return period
               </h4>
 
@@ -94,7 +94,8 @@
               {{#if isClickable }}
                 <span class="sr-only">for
                   {{#each metadata.purposes }}
-                  {{ tertiary.description }}
+                  {{titleCase alias}}
+                  {{#unless alias}}{{titleCase tertiary.description}}{{/unless}}
                   {{/each }}
                   at {{{ titleCase metadata.description  }}}
                  </span>
@@ -108,7 +109,8 @@
                 Purpose
               </h4>
               {{#each metadata.purposes }}
-              {{ tertiary.description }}
+              {{titleCase alias}}
+              {{#unless alias}}{{titleCase tertiary.description}}{{/unless}}
               {{/each }}
             </div>
             <div class="table-cell">

--- a/test/modules/returns/helpers.js
+++ b/test/modules/returns/helpers.js
@@ -1,5 +1,4 @@
 'use strict';
-const moment = require('moment');
 const { expect } = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
@@ -53,10 +52,6 @@ lab.experiment('canEdit', () => {
     status: 'completed'
   };
 
-  const futureReturn = {
-    end_date: moment().add(1, 'years').format('YYYY-MM-DD')
-  };
-
   lab.test('Internal user cannot edit return if before summer 2018 cycle', async () => {
     expect(helpers.canEdit(internalUser, pre2018Return)).to.equal(false);
   });
@@ -79,16 +74,22 @@ lab.experiment('canEdit', () => {
 
   lab.test('External user cannot edit return if after summer 2018 cycle and in the future in production', async () => {
     const testMode = config.testMode;
+    const showFutureReturns = config.returns.showFutureReturns;
     config.testMode = false;
+    config.returns.showFutureReturns = false;
     expect(helpers.canEdit(externalUser, post2018Return, '2018-10-30')).to.equal(false);
     config.testMode = testMode;
+    config.returns.showFutureReturns = showFutureReturns;
   });
 
   lab.test('External user can edit return if after summer 2018 cycle and in test environments', async () => {
     const testMode = config.testMode;
+    const showFutureReturns = config.returns.showFutureReturns;
     config.testMode = true;
+    config.returns.showFutureReturns = true;
     expect(helpers.canEdit(externalUser, post2018Return, '2018-10-30')).to.equal(true);
     config.testMode = testMode;
+    config.returns.showFutureReturns = showFutureReturns;
   });
 
   lab.test('External user cannot edit completed returns', async () => {


### PR DESCRIPTION
WATER-1392

If the purpose alias is available then it is shown, otherwise show the
description of the tertiary purpose.