### PR TITLE
Fix: Prevent NaN being shown for empty totals

### DIFF
--- a/src/lib/unit-conversion.js
+++ b/src/lib/unit-conversion.js
@@ -1,3 +1,5 @@
+const { isNil } = require('lodash');
+
 class InvalidUnitError extends Error {
   constructor (...args) {
     super(...args);
@@ -13,11 +15,7 @@ class InvalidUnitError extends Error {
  * @return {Number|null} converted value
  */
 const converter = (value, unit, multipliers) => {
-  if (value === null) {
-    return null;
-  }
-
-  if (unit === null) {
+  if (isNil(value) || isNil(unit)) {
     return null;
   }
 

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -327,8 +327,6 @@ handlebars.registerHelper('join', function (values, separator = ',') {
 });
 
 handlebars.registerHelper('encode', function (value) {
-  console.log(value);
-  console.log(encodeURIComponent(value.hash.value));
   return encodeURIComponent(value.hash.value);
 });
 
@@ -408,32 +406,21 @@ handlebars.registerHelper('isLastDayOfMonth', function (date, options) {
 });
 
 handlebars.registerHelper('formatDate', function (dateInput) {
-  console.log('formatDate');
-
-  console.log(dateInput);
   var date = moment(dateInput, 'DD/MM/YYYY');
-  console.log(date);
   var isFutureDate = moment().isBefore(date);
   if (isFutureDate) {
     date.subtract('year', 100);
   }
-  console.log('Future date:' + isFutureDate);
-
   return date.isValid() ? date.format('D MMMM YYYY') : dateInput;
 });
 
-handlebars.registerHelper('formatSortableDate', function (dateInput) {
-  const date = moment(dateInput, 'YYYYMMDD');
-  return date.isValid() ? date.format('D MMMM YYYY') : dateInput;
-});
+const changeDateFormatting = (dateInput, inputFormat, outputFormat = 'D MMMM YYYY') => {
+  const date = moment(dateInput, inputFormat);
+  return date.isValid() ? date.format(outputFormat) : dateInput;
+};
 
-handlebars.registerHelper('formatTS', function (dateInput) {
-  console.log('formatDate');
-
-  console.log(dateInput);
-  var date = moment(dateInput, 'YYYY-MM-DD');
-  return date.isValid() ? date.format('D MMMM YYYY') : dateInput;
-});
+handlebars.registerHelper('formatSortableDate', dateInput => changeDateFormatting(dateInput, 'YYYYMMDD'));
+handlebars.registerHelper('formatTS', dateInput => changeDateFormatting(dateInput, 'YYYY-MM-DD'));
 
 handlebars.registerHelper('formatToDate', function (dateInput, defaultValue) {
   if (dateInput === null) {

--- a/src/views/partials/return-quantities-table.html
+++ b/src/views/partials/return-quantities-table.html
@@ -1,148 +1,138 @@
 <div class="grid-row">
 
   {{#equal return.reading.method 'oneMeter' }}
-    <div class="column-full">
+  <div class="column-full">
   {{else}}
-    <div class="{{#equal return.reading.units 'm³' }}column-two-thirds{{ else }}column-full{{/equal}}">
+  <div class="{{#equal return.reading.units 'm³' }}column-two-thirds{{ else }}column-full{{/equal}}">
   {{/equal}}
 
   {{#equal return.reading.method 'oneMeter' }}
-  <div class="panel panel-border-wide">
-    <dl class="meta">
-      <dt class="meta__label">
-        Meter manufacturer
-      </dt>
-      <dd class="meta__description">
-        {{ return.meters.0.manufacturer }}
-      </dd>
-      <dt class="meta__label">
-        Serial number
-      </dt>
-      <dd class="meta__description">
-        {{ return.meters.0.serialNumber }}
-      </dd>
+    <div class="panel panel-border-wide">
+      <dl class="meta">
         <dt class="meta__label">
-          Start reading
+          Meter manufacturer
         </dt>
         <dd class="meta__description">
-          {{ formatQuantity return.meters.0.startReading }}
-            {{#equal return.reading.units 'gal' }}gallons{{/equal}}
-            {{#equal return.reading.units 'l' }}litres{{/equal}}
-            {{#equal return.reading.units 'Ml' }}megalitres{{/equal}}
-            {{#equal return.reading.units 'm³' }}cubic metres{{/equal}}
+          {{ return.meters.0.manufacturer }}
+        </dd>
+        <dt class="meta__label">
+          Serial number
+        </dt>
+        <dd class="meta__description">
+          {{ return.meters.0.serialNumber }}
+        </dd>
+        <dt class="meta__label">
+        Start reading
+        </dt>
+        <dd class="meta__description">
+        {{ formatQuantity return.meters.0.startReading }}
+        {{#equal return.reading.units 'gal' }}gallons{{/equal}}
+        {{#equal return.reading.units 'l' }}litres{{/equal}}
+        {{#equal return.reading.units 'Ml' }}megalitres{{/equal}}
+        {{#equal return.reading.units 'm³' }}cubic metres{{/equal}}
         </dd>
       </dl>
     </div>
     {{/equal}}
 
-
     <div class="table medium-space table-return-quantities">                                          <!-- a table -->
+      <div class="table-row table-head">                                      <!-- the table head -->
+        <div class="table-cell bold-small column-33">
+          {{#equal return.lines.0.timePeriod 'day' }}Day{{/equal}}
+          {{#equal return.lines.0.timePeriod 'week' }}Week ending{{/equal}}
+          {{#equal return.lines.0.timePeriod 'month' }}Month{{/equal}}
+          {{#equal return.lines.0.timePeriod 'year' }}Year{{/equal}}
+        </div>
 
-            <div class="table-row table-head">                                      <!-- the table head -->
-              <div class="table-cell bold-small column-33">
-                {{#equal return.lines.0.timePeriod 'day' }}Day{{/equal}}
-                {{#equal return.lines.0.timePeriod 'week' }}Week ending{{/equal}}
-                {{#equal return.lines.0.timePeriod 'month' }}Month{{/equal}}
-                {{#equal return.lines.0.timePeriod 'year' }}Year{{/equal}}
-              </div>
+        {{#equal return.reading.method 'oneMeter' }}
+        <div class="table-cell bold-small column-33 numbers">Reading</div>
+        {{/equal}}
 
+        <div class="table-cell bold-small column-33 numbers">
+          {{#equal return.reading.units 'gal' }}Gallons{{/equal}}
+          {{#equal return.reading.units 'l' }}Litres{{/equal}}
+          {{#equal return.reading.units 'Ml' }}Megalitres{{/equal}}
+          {{#equal return.reading.units 'm³' }}Cubic metres{{/equal}}
+        </div>
+        {{#notEqual return.reading.units 'm³' }}
+        <div class="table-cell bold-small column-33 numbers">Cubic metres</div>
+        {{/notEqual}}
+      </div>
 
-              {{#equal return.reading.method 'oneMeter' }}
-              <div class="table-cell bold-small column-33 numbers">Reading</div>
-              {{/equal}}
+      {{#each lines }}
+      <div class="table-row medium-space">                                    <!-- a data row starts -->
+        <div class="table-cell">
+          <h3>
+            {{#equal timePeriod 'day' }}
+            {{ formatISODate startDate format='D MMMM' }}
+            {{/equal}}
 
-              <div class="table-cell bold-small column-33 numbers">
-                {{#equal return.reading.units 'gal' }}Gallons{{/equal}}
-                {{#equal return.reading.units 'l' }}Litres{{/equal}}
-                {{#equal return.reading.units 'Ml' }}Megalitres{{/equal}}
-                {{#equal return.reading.units 'm³' }}Cubic metres{{/equal}}
-              </div>
-              {{#notEqual return.reading.units 'm³' }}
-              <div class="table-cell bold-small column-33 numbers">
-                Cubic metres
-              </div>
-              {{/notEqual}}
+            {{#equal timePeriod 'week' }}
+            {{ formatISODate endDate format='D MMMM' }}
+            {{/equal}}
 
-            </div>
+            {{#equal timePeriod 'month' }}
+            {{ formatISODate startDate format='MMMM' }}
+            {{/equal}}
 
+            {{#equal timePeriod 'year' }}
+            {{ formatISODate startDate format='D MMMM YYYY' }} -
+            {{ formatISODate endDate format='D MMMM YYYY' }}
+            {{/equal}}
+          </h3>
+        </div>
 
+        {{#equal ../return.reading.method 'oneMeter' }}
+        <div class="table-cell numbers">
+          <h4 class="context">Reading</h4>
+          {{ formatQuantity this.endReading }}
+        </div>
+        {{/equal}}
 
-            {{#each lines }}
-            <div class="table-row medium-space">                                    <!-- a data row starts -->
+        <div class="table-cell numbers">
+          <h4 class="context">
+            {{#equal ../return.reading.units 'gal' }}Gallons{{/equal}}
+            {{#equal ../return.reading.units 'l' }}Litres{{/equal}}
+            {{#equal ../return.reading.units 'Ml' }}Megalitres{{/equal}}
+            {{#equal ../return.reading.units 'm³' }}Cubic metres{{/equal}}
+          </h4>
 
-              <div class="table-cell">
-                <h3>
-                {{#equal timePeriod 'day' }}
-                  {{ formatISODate startDate format='D MMMM' }}
-                {{/equal}}
+          {{ formatQuantity quantity }}
+        </div>
 
-                {{#equal timePeriod 'week' }}
-                  {{ formatISODate endDate format='D MMMM' }}
-                {{/equal}}
+        {{#notEqual ../return.reading.units 'm³' }}
+        <div class="table-cell numbers">
+          <h4 class="context">Cubic metres</h4>
+          {{ formatQuantity (convertToCubicMetres this.quantity unit=../return.reading.units)  }}
+        </div>
+        {{/notEqual}}
 
-                {{#equal timePeriod 'month' }}
-                  {{ formatISODate startDate format='MMMM' }}
-                {{/equal}}
-                {{#equal timePeriod 'year' }}
-                  {{ formatISODate startDate format='D MMMM YYYY' }} -
-                  {{ formatISODate endDate format='D MMMM YYYY' }}
-                {{/equal}}
-                </h3>
-              </div>
+      </div>
+      {{/each}}
 
-              {{#equal ../return.reading.method 'oneMeter' }}
-              <div class="table-cell numbers">
-                <h4 class="context">Reading</h4>
-                {{ formatQuantity this.endReading }}
-              </div>
-              {{/equal}}
-
-
-              <div class="table-cell numbers">
-                <h4 class="context">
-                  {{#equal ../return.reading.units 'gal' }}Gallons{{/equal}}
-                  {{#equal ../return.reading.units 'l' }}Litres{{/equal}}
-                  {{#equal ../return.reading.units 'Ml' }}Megalitres{{/equal}}
-                  {{#equal ../return.reading.units 'm³' }}Cubic metres{{/equal}}
-                </h4>
-                {{ formatQuantity quantity }}
-              </div>
-
-              {{#notEqual ../return.reading.units 'm³' }}
-              <div class="table-cell numbers">
-                <h4 class="context">Cubic metres</h4>
-                {{ formatQuantity (convertToCubicMetres this.quantity unit=../return.reading.units)  }}
-              </div>
-              {{/notEqual}}
-
-            </div>
-            {{/each}}
-
-            <div class="table-row medium-space table-foot">
-              <div class="table-cell">
-                <h3>Total</h3>
-              </div>
-               {{#equal return.reading.method 'oneMeter' }}
-               <div class="table-cell numbers table-cell--desktop"></div>
-               {{/equal}}
-              <div class="table-cell numbers">
-                <h4 class="context">
-                  {{#equal return.reading.units 'gal' }}Gallons{{/equal}}
-                  {{#equal return.reading.units 'l' }}Litres{{/equal}}
-                  {{#equal return.reading.units 'Ml' }}Megalitres{{/equal}}
-                  {{#equal return.reading.units 'm³' }}Cubic metres{{/equal}}
-                </h4>
-                {{ formatQuantity total }}
-              </div>
-              {{#notEqual return.reading.units 'm³' }}
-              <div class="table-cell numbers">
-                <h4 class="context">Cubic metres</h4>
-                {{ formatQuantity (convertToCubicMetres total unit=return.reading.units )}}
-              </div>
-              {{/notEqual}}
-            </div>
-          </div>
-
-
+      <div class="table-row medium-space table-foot">
+        <div class="table-cell">
+          <h3>Total</h3>
+        </div>
+        {{#equal return.reading.method 'oneMeter' }}
+        <div class="table-cell numbers table-cell--desktop"></div>
+        {{/equal}}
+        <div class="table-cell numbers">
+          <h4 class="context">
+            {{#equal return.reading.units 'gal' }}Gallons{{/equal}}
+            {{#equal return.reading.units 'l' }}Litres{{/equal}}
+            {{#equal return.reading.units 'Ml' }}Megalitres{{/equal}}
+            {{#equal return.reading.units 'm³' }}Cubic metres{{/equal}}
+          </h4>
+          {{ formatQuantity total }}
+        </div>
+        {{#notEqual return.reading.units 'm³' }}
+        <div class="table-cell numbers">
+          <h4 class="context">Cubic metres</h4>
+          {{ formatQuantity (convertToCubicMetres total unit=return.reading.units )}}
+        </div>
+        {{/notEqual}}
+      </div>
+    </div>
   </div>
 </div>

--- a/test/lib/unit-conversion.js
+++ b/test/lib/unit-conversion.js
@@ -26,6 +26,13 @@ lab.experiment('Test unit conversion helpers', () => {
     Code.expect(convertToCubicMetres(null, 'gal')).to.equal(null);
   });
 
+  lab.test('convertToCubicMetres should return null if undefined value given', async () => {
+    Code.expect(convertToCubicMetres(undefined, 'm³')).to.equal(null);
+    Code.expect(convertToCubicMetres(undefined, 'l')).to.equal(null);
+    Code.expect(convertToCubicMetres(undefined, 'Ml')).to.equal(null);
+    Code.expect(convertToCubicMetres(undefined, 'gal')).to.equal(null);
+  });
+
   lab.test('convertToUserUnit should convert known units', async () => {
     Code.expect(convertToUserUnit(100, 'm³')).to.equal(100);
     Code.expect(convertToUserUnit(100, 'l')).to.equal(100000);

--- a/test/views/index.js
+++ b/test/views/index.js
@@ -1,50 +1,71 @@
-'use strict'
+'use strict';
 
-const Lab = require('lab')
-const lab = exports.lab = Lab.script()
+const Lab = require('lab');
+const { experiment, test } = exports.lab = Lab.script();
+const { expect } = require('code');
 
-const Code = require('code')
-// const rewire = require('rewire');
+const views = require('../../src/views/index.js');
 
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.engines).to.be.a.object();
+  });
+});
 
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.relativeTo).to.be.a.string();
+  });
+});
 
-const views = require('../../src/views/index.js')
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.layoutPath).to.be.a.string();
+  });
+});
 
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.layout).to.be.a.string();
+  });
+});
 
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.partialsPath).to.be.a.string();
+  });
+});
 
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.engines).to.be.a.object()
-})
-})
+experiment('Page does not exist', () => {
+  test('a test', async () => {
+    expect(views.context).to.be.a.object();
+  });
+});
 
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.relativeTo).to.be.a.string()
-})
-})
+experiment('formatTS', () => {
+  test('if a valid date is passed in it formats the date to the format D MMMM YYYY', async () => {
+    const formatTS = views.engines.html.helpers.formatTS;
+    const output = formatTS('2018-01-01');
+    expect(output).to.equal('1 January 2018');
+  });
 
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.layoutPath).to.be.a.string()
-})
-})
+  test('if an invalid date is passed in it returns the input', async () => {
+    const formatTS = views.engines.html.helpers.formatTS;
+    const output = formatTS('not-a-date');
+    expect(output).to.equal('not-a-date');
+  });
+});
 
+experiment('formatSortableDate', () => {
+  test('if a valid date is passed in it formats the date to the format D MMMM YYYY', async () => {
+    const formatSortableDate = views.engines.html.helpers.formatSortableDate;
+    const output = formatSortableDate('20180101');
+    expect(output).to.equal('1 January 2018');
+  });
 
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.layout).to.be.a.string()
-})
-})
-
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.partialsPath).to.be.a.string()
-})
-})
-
-lab.experiment('Page does not exist', () => {
-  lab.test('a test', async () => {
-  Code.expect(views.context).to.be.a.object()
-})
-})
+  test('if an invalid date is passed in it returns the input', async () => {
+    const formatSortableDate = views.engines.html.helpers.formatSortableDate;
+    const output = formatSortableDate('not-a-date');
+    expect(output).to.equal('not-a-date');
+  });
+});


### PR DESCRIPTION
WATER-1595

If a user entered no values then the total was calculated as `NaN`.

This was happening in a conversion function when `undefined` was passed.
So this fix returns `null` instead for `null` or `undefined` values.

Also tidies indentation of return-quantities-table to aid navigation.