### PR TITLE
Fix: Fixes returns back navigation

### DIFF
--- a/config.js
+++ b/config.js
@@ -79,7 +79,7 @@ module.exports = {
     frameSrc: ['self', 'www.smartsurvey.co.uk'],
     scriptSrc: ['self', '*.google-analytics.com', '*.googletagmanager.com'],
     fontSrc: ['self', 'assets.publishing.service.gov.uk', 'data:'],
-    imgSrc: ['self', '*.google-analytics.com'],
+    imgSrc: ['self', '*.google-analytics.com', '*.googletagmanager.com'],
     connectSrc: '*.google-analytics.com',
     reportOnly: true,
     reportUri: '/csp/report'

--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -46,7 +46,7 @@ const {
   deleteSessionData,
   submitReturnData } = require('../lib/session-helpers');
 
-const { getViewData, getLicenceNumbers, getReturnTotal, getScopedPath, canEdit } = require('../lib/helpers');
+const { getViewData, getLicenceNumbers, getReturnTotal, canEdit } = require('../lib/helpers');
 
 /**
  * Render form to display whether amounts / nil return for this cycle
@@ -191,7 +191,7 @@ const getMethod = async (request, h) => {
  */
 const postMethod = async (request, h) => {
   const { data, view } = request.returns;
-  const form = handleRequest(methodForm(request), request);
+  const form = handleRequest(methodForm(request, data), request);
 
   if (form.isValid) {
     const { method } = getValues(form);
@@ -227,7 +227,7 @@ const getUnits = async (request, h) => {
  */
 const postUnits = async (request, h) => {
   const { data, view } = request.returns;
-  const form = handleRequest(unitsForm(request), request);
+  const form = handleRequest(unitsForm(request, data), request);
 
   if (form.isValid) {
     // Persist chosen units to session
@@ -253,7 +253,7 @@ const getSingleTotal = async (request, h) => {
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form: singleTotalForm(request),
+    form: singleTotalForm(request, data),
     return: data,
     back: getPreviousPath(STEP_SINGLE_TOTAL, request, data)
   });
@@ -265,7 +265,7 @@ const getSingleTotal = async (request, h) => {
 const postSingleTotal = async (request, h) => {
   const { data, view } = request.returns;
 
-  const form = handleRequest(singleTotalForm(request), request, singleTotalSchema);
+  const form = handleRequest(singleTotalForm(request, data), request, singleTotalSchema);
 
   if (form.isValid) {
     // Persist to session
@@ -294,7 +294,7 @@ const getBasis = async (request, h) => {
 
   return h.view('water/returns/internal/form', {
     ...view,
-    form: basisForm(request),
+    form: basisForm(request, data),
     return: data,
     back: getPreviousPath(STEP_BASIS, request, data)
   });
@@ -305,7 +305,7 @@ const getBasis = async (request, h) => {
  */
 const postBasis = async (request, h) => {
   const { data, view } = request.returns;
-  const form = handleRequest(basisForm(request), request, basisSchema);
+  const form = handleRequest(basisForm(request, data), request, basisSchema);
 
   if (form.isValid) {
     const d = applyBasis(data, getValues(form));

--- a/src/modules/returns/forms/basis.js
+++ b/src/modules/returns/forms/basis.js
@@ -15,7 +15,7 @@ const mapModelToForm = (data) => {
   };
 };
 
-const form = (request) => {
+const form = (request, data) => {
   const { csrfToken } = request.view;
 
   const action = getPath(STEP_BASIS, request);
@@ -30,24 +30,15 @@ const form = (request) => {
       }
     },
     choices: [
-
-      { value: 'measured',
-        label: 'Yes'
-      },
-      {
-        value: 'estimated',
-        label: 'No'
-      }
-
+      { value: 'measured', label: 'Yes' },
+      { value: 'estimated', label: 'No' }
     ]}));
 
   f.fields.push(fields.button(null, { label: 'Continue' }));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
 
   // Populate state from session
-  const data = request.sessionStore.get('internalReturnFlow');
   const values = mapModelToForm(data);
-
   return setValues(f, values);
 };
 

--- a/src/modules/returns/forms/single-total.js
+++ b/src/modules/returns/forms/single-total.js
@@ -3,7 +3,7 @@ const { get } = require('lodash');
 const { formFactory, fields, setValues } = require('../../../lib/forms');
 const { STEP_SINGLE_TOTAL, getPath } = require('../lib/flow-helpers');
 
-const form = (request) => {
+const form = (request, data) => {
   const { csrfToken } = request.view;
 
   const action = getPath(STEP_SINGLE_TOTAL, request);
@@ -43,8 +43,6 @@ const form = (request) => {
   f.fields.push(fields.button(null, { label: 'Continue' }));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
 
-  // Populate state from session
-  const data = request.sessionStore.get('internalReturnFlow');
   const isSingleTotal = get(data, 'reading.totalFlag');
   const total = get(data, 'reading.total');
 

--- a/src/public/javascripts/application.js
+++ b/src/public/javascripts/application.js
@@ -50,7 +50,8 @@ $(function () {
   });
 
   // Back link uses browser history
-  $('.link-back').on('click', function (ev) {
+  // Can be overridden by adding the data-no-js attribute
+  $('.link-back:not([data-no-js])').on('click', function (ev) {
     window.history.back();
     ev.preventDefault();
     return false;

--- a/src/views/water/returns/internal/confirm.html
+++ b/src/views/water/returns/internal/confirm.html
@@ -2,7 +2,7 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-  <a href="{{ back }}" class="link-back link-back--space-above">Back</a>
+  <a href="{{ back }}" data-no-js class="link-back link-back--space-above">Back</a>
 
   {{>return-header }}
 

--- a/src/views/water/returns/internal/form.html
+++ b/src/views/water/returns/internal/form.html
@@ -4,7 +4,7 @@
 
   {{>form-errors form }}
 
-  <a href="{{ back }}" class="link-back link-back--space-above">Back</a>
+  <a data-no-js href="{{ back }}" class="link-back link-back--space-above">Back</a>
 
   {{>return-header }}
 

--- a/src/views/water/returns/internal/nil-return.html
+++ b/src/views/water/returns/internal/nil-return.html
@@ -2,11 +2,9 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-  <a href="{{ back }}" class="link-back link-back--space-above">Back</a>
-
+  <a data-no-js href="{{ back }}" class="link-back link-back--space-above">Back</a>
 
   {{>return-header }}
-
 
   <h3 class="heading-large">Nil return</h3>
 
@@ -14,8 +12,5 @@
 
 </main>
 
-
 {{> footerjs}}
-
-
 {{> debug}}

--- a/src/views/water/returns/licence.html
+++ b/src/views/water/returns/licence.html
@@ -3,7 +3,7 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-  <a class="link-back link-back--space-above" href="{{#if isAdmin }}/admin{{/if}}/licences/{{ document.document_id }}">Licence number {{ document.system_external_id }}</a>
+  <a data-no-js class="link-back link-back--space-above" href="{{#if isAdmin }}/admin{{/if}}/licences/{{ document.document_id }}">Licence number {{ document.system_external_id }}</a>
 
   {{#if document.document_name }}
   <h1 class="heading-large heading-large--tight-above">

--- a/src/views/water/returns/meter-details.html
+++ b/src/views/water/returns/meter-details.html
@@ -3,7 +3,7 @@
   {{>element-phase-tag}}
   {{>element-main-nav}}
 
-  <a href="{{ back }}" class="link-back link-back--space-above">Back</a>
+  <a data-no-js href="{{ back }}" class="link-back link-back--space-above">Back</a>
 
   {{>form-errors form }}
 

--- a/src/views/water/returns/meter-readings.html
+++ b/src/views/water/returns/meter-readings.html
@@ -3,7 +3,7 @@
   {{>element-phase-tag}}
   {{>element-main-nav}}
 
-  <a href="{{ back }}" class="link-back link-back--space-above">Back</a>
+  <a data-no-js href="{{ back }}" class="link-back link-back--space-above">Back</a>
 
   {{>form-errors form }}
 


### PR DESCRIPTION
WATER-1605
WATER-1606

Removes the JavaScript takeover on the back link which caused a history
back rather than a full refresh that pulled the new data from the
session.

To do this, an optional data attribute can be applied to elements marked
up with the `back-link` class to prevent this link being selected by
JQuery.

Update the basic and single total form objects to receive data rather
than pull from session themselves.

Also added to CSP header config to handle the images served by google.