### PR TITLE
Fix: Cookie too large for user with many roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -126,7 +126,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -526,7 +525,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1711,12 +1710,6 @@
       "resolved": "https://registry.npmjs.org/comma-number/-/comma-number-2.0.0.tgz",
       "integrity": "sha1-JN+oPOlY1oqdIa9I4g5S3AcnBL0="
     },
-    "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -1866,6 +1859,18 @@
       "requires": {
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        }
       }
     },
     "cryptiles": {
@@ -3454,7 +3459,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3588,8 +3593,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3607,13 +3611,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3626,18 +3628,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3740,8 +3739,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3751,7 +3749,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3764,20 +3761,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3794,7 +3788,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3873,8 +3866,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3884,7 +3876,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3960,8 +3951,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3991,7 +3981,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4009,7 +3998,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4048,13 +4036,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -4068,6 +4054,14 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
       }
     },
     "ftp": {
@@ -4300,7 +4294,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4754,6 +4748,11 @@
         "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4774,6 +4773,14 @@
           "requires": {
             "commander": "~2.17.1",
             "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.17.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+              "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+              "dev": true
+            }
           }
         }
       }
@@ -4951,7 +4958,10 @@
         "cryptiles": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw=="
+          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
+          "requires": {
+            "boom": "7.x.x"
+          }
         },
         "heavy": {
           "version": "6.1.2",
@@ -4971,7 +4981,21 @@
         "iron": {
           "version": "5.0.6",
           "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw=="
+          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
+          "requires": {
+            "b64": "4.x.x",
+            "boom": "7.x.x",
+            "cryptiles": "4.x.x",
+            "hoek": "6.x.x"
+          }
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "requires": {
+            "punycode": "2.x.x"
+          }
         },
         "joi": {
           "version": "14.0.4",
@@ -4979,6 +5003,7 @@
           "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
           "requires": {
             "hoek": "6.x.x",
+            "isemail": "3.x.x",
             "topo": "3.x.x"
           }
         },
@@ -5026,6 +5051,11 @@
             "joi": "14.x.x"
           }
         },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
         "shot": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
@@ -5047,7 +5077,15 @@
         "statehood": {
           "version": "6.0.8",
           "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.8.tgz",
-          "integrity": "sha512-/uk2Iq5VXCAGmYnRTjez6gDfU8fROm1Um5WH2C9aNCdG7DAqD94dqZgeuqXrvVFnfDqxAtorUBLUtD9El/uJ6w=="
+          "integrity": "sha512-/uk2Iq5VXCAGmYnRTjez6gDfU8fROm1Um5WH2C9aNCdG7DAqD94dqZgeuqXrvVFnfDqxAtorUBLUtD9El/uJ6w==",
+          "requires": {
+            "boom": "7.x.x",
+            "bounce": "1.x.x",
+            "cryptiles": "4.x.x",
+            "hoek": "6.x.x",
+            "iron": "5.x.x",
+            "joi": "14.x.x"
+          }
         },
         "subtext": {
           "version": "6.0.11",
@@ -5148,7 +5186,7 @@
       "dev": true
     },
     "hapi-pg-rest-api": {
-      "version": "git+https://github.com/DEFRA/hapi-pg-rest-api.git#62a58c01b3bf3e54898ccc6ff5db557021c74bec",
+      "version": "git+https://github.com/DEFRA/hapi-pg-rest-api.git#e7c4c3b041aed93d6c57cebfe14d561578b63cf3",
       "from": "git+https://github.com/DEFRA/hapi-pg-rest-api.git",
       "requires": {
         "joi": "^13.1.2",
@@ -6472,7 +6510,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -6823,8 +6861,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -7821,7 +7858,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -9131,6 +9168,20 @@
             "wrap-ansi": "^2.0.0"
           }
         },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -9406,8 +9457,7 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
@@ -9416,6 +9466,14 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            }
           }
         }
       }
@@ -10709,7 +10767,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11156,6 +11214,22 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "tryit": {
@@ -11572,7 +11646,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11675,28 +11749,51 @@
       }
     },
     "vision": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vision/-/vision-5.3.3.tgz",
-      "integrity": "sha512-ijMMQYHqscXc9jyr2hoN3xNRNVzLb/vwiQ5MV5kQeJX+5r9hNSyWPUDZzA8PP3yJc3OWArtJDt2CioE3vWiuPQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/vision/-/vision-5.4.3.tgz",
+      "integrity": "sha512-4uVrdAKSjNF3WVf1Mjq//SfMclUgpHJtk0EBESyLFcZmrqJjUQ08DyCsRYqw31qEFK3bVm8UO9BlfodRwuyETg==",
       "requires": {
         "boom": "7.x.x",
-        "hoek": "5.x.x",
+        "hoek": "6.x.x",
         "items": "2.x.x",
-        "joi": "13.x.x"
+        "joi": "14.x.x"
       },
       "dependencies": {
-        "boom": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
-          "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
+        "hoek": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.3.tgz",
+          "integrity": "sha512-TU6RyZ/XaQCTWRLrdqZZtZqwxUVr6PDMfi6MlWNURZ7A6czanQqX4pFE1mdOUQR9FdPCsZ0UzL8jI/izZ+eBSQ=="
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
           "requires": {
-            "hoek": "5.x.x"
+            "punycode": "2.x.x"
           }
         },
-        "hoek": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        "joi": {
+          "version": "14.1.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.1.0.tgz",
+          "integrity": "sha512-oJDBwllD6VjSMquuv56W0fQlegJdsr8+905zuEQhnE/eTSh5GYUHlwn/UATnlDepuXZF8BnxggdxqQTYrtit6Q==",
+          "requires": {
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "topo": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         }
       }
     },
@@ -11753,9 +11850,9 @@
       "optional": true
     },
     "winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
+      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "shallow-diff": "0.0.5",
     "title-case": "^2.1.1",
     "url-join": "^4.0.0",
-    "vision": "^5.3.3",
+    "vision": "^5.4.3",
     "winston": "^2.4.3",
     "yar": "^8.1.2"
   },

--- a/src/lib/sign-in.js
+++ b/src/lib/sign-in.js
@@ -6,7 +6,7 @@ const { createGUID } = require('./helpers');
 const { usersClient } = require('./connectors/idm');
 const config = require('../../config');
 const idm = require('./connectors/idm');
-const { get } = require('lodash');
+const { pick, get } = require('lodash');
 
 /**
  * Loads user data from IDM
@@ -77,7 +77,7 @@ const createSessionData = (sessionId, user, entityId, entityRoles) => {
     entity_id: entityId,
     user_data: user.user_data || {},
     lastlogin: user.last_login,
-    roles: entityRoles,
+    roles: mapRoles(entityRoles),
     scope: get(user, 'role.scopes', [])
   };
 
@@ -85,6 +85,18 @@ const createSessionData = (sessionId, user, entityId, entityRoles) => {
   session.user_data.newuser = session.user_data.lastlogin === null;
 
   return session;
+};
+
+/**
+ * Returns a minimal set of the entity roles data.
+ *
+ * This is in place as a quick fix to handle the cookie being too large and
+ * therefore rejected by the browser.
+ *
+ * The real fix here is to load the roles data dynamically.
+ */
+const mapRoles = (entityRoles = []) => {
+  return entityRoles.map(role => pick(role, 'role', 'company_entity_id'));
 };
 
 module.exports = {

--- a/test/lib/sign-in.js
+++ b/test/lib/sign-in.js
@@ -3,8 +3,20 @@
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const { expect } = require('code');
+const uuid = require('uuid/v4');
+const moment = require('moment');
 
 const { createSessionData } = require('../../src/lib/sign-in');
+
+const getTestEntityRole = (role, companyId = uuid()) => ({
+  role,
+  company_entity_id: companyId,
+  entity_role_id: uuid(),
+  entity_id: uuid(),
+  regime_entity_id: uuid(),
+  created_at: moment().toISOString(),
+  created_by: uuid()
+});
 
 lab.experiment('sign-in.createSessionData', () => {
   let sessionData;
@@ -20,7 +32,12 @@ lab.experiment('sign-in.createSessionData', () => {
     userId = 'user-id';
     entityId = 'entity-id';
     emailAddress = 'unit-test@example.com';
-    roles = [{ role: 'admin' }];
+    roles = [
+      getTestEntityRole('user', 'comp-1'),
+      getTestEntityRole('user_returns', 'comp-1'),
+      getTestEntityRole('user', 'comp-2'),
+      getTestEntityRole('user_returns', 'comp-2')
+    ];
 
     user = {
       user_id: userId,
@@ -72,7 +89,12 @@ lab.experiment('sign-in.createSessionData', () => {
   });
 
   lab.test('adds the roles', async () => {
-    expect(sessionData.roles).to.equal(roles);
+    expect(sessionData.roles).to.equal([
+      { role: 'user', company_entity_id: 'comp-1' },
+      { role: 'user_returns', company_entity_id: 'comp-1' },
+      { role: 'user', company_entity_id: 'comp-2' },
+      { role: 'user_returns', company_entity_id: 'comp-2' }
+    ]);
   });
 
   lab.test('adds the scopes from the user', async () => {


### PR DESCRIPTION
WATER-1730

When an agent becomes responsible for many licences, they in turn have
more items in the entity_roles array found when signing in.

This data is all serialized into the cookie, and once the user hits
three/four role pairs (user, user_returns) the amount of data being
added to the cookie for a given domain is too large. (Including GA as
well).

Therefore this quick fix maps the entity_roles picking out only the
necessary data. E.g. for 4 roles the length of the session data went
from ~4000 to ~1000 bytes.

There is a technical improvement story coming soon to only store a
session id in the cookie. But this approach is fast to implement and
will hopefully unlock users sooner.