### PR TITLE
Fix: Check for verified licences using verification_id

### DIFF
--- a/src/lib/connectors/crm.js
+++ b/src/lib/connectors/crm.js
@@ -33,8 +33,7 @@ async function getOutstandingLicenceRequests (entityId) {
 
   // Find licences with this ID
   const {error, data} = await crmDocuments.findMany({
-    verification_id: verificationId,
-    verified: null
+    verification_id: verificationId
   });
   if (error) {
     throw error;
@@ -187,8 +186,8 @@ async function verify (entityId, verificationCode) {
 
   // Update document headers
   const res3 = await crmDocuments.updateMany(
-    {document_id: {$in: documentIds}, company_entity_id: null, verified: null},
-    {verification_id: verificationId, company_entity_id: companyEntityId, verified: 1}
+    {document_id: {$in: documentIds}, company_entity_id: null},
+    {verification_id: verificationId, company_entity_id: companyEntityId}
   );
   if (res3.error) {
     throw res3.error;
@@ -234,7 +233,7 @@ async function getDocumentVerifications (documentId) {
 }
 
 function removeDuplicates (arr, key) {
-  if (!(arr instanceof Array) || key && typeof key !== 'string') {
+  if (!(arr instanceof Array) || (key && typeof key !== 'string')) {
     return false;
   }
 

--- a/src/lib/connectors/crm/documents.js
+++ b/src/lib/connectors/crm/documents.js
@@ -47,7 +47,7 @@ const unregisteredLicenceQuery = (key, value) => {
     [key]: {
       $or: value
     },
-    verification_id: null,
+    company_entity_id: null,
     'metadata->IsCurrent': {
       $ne: 'false'
     }

--- a/src/lib/connectors/crm/documents.js
+++ b/src/lib/connectors/crm/documents.js
@@ -53,7 +53,6 @@ client.getUnregisteredLicences = function (licenceNumbers) {
     system_external_id: {
       $or: licenceNumbers
     },
-    verified: null,
     verification_id: null,
     'metadata->IsCurrent': {
       $ne: 'false'
@@ -77,7 +76,6 @@ client.getUnregisteredLicencesByIds = function (documentIds) {
     document_id: {
       $or: documentIds
     },
-    verified: null,
     verification_id: null,
     'metadata->IsCurrent': {
       $ne: 'false'

--- a/src/lib/connectors/crm/documents.js
+++ b/src/lib/connectors/crm/documents.js
@@ -42,22 +42,18 @@ client.getLicenceCount = async function (entityId) {
   return totalRows;
 };
 
-/**
- * Get a list of unclaimed licences for use in reg process
- * @param {Array} licenceNumbers - list of licence numbers to claim
- * @return {Promise} resolves with list of licences from CRM
- */
-client.getUnregisteredLicences = function (licenceNumbers) {
-  // Get unverified licences from DB
-  return this.findMany({
-    system_external_id: {
-      $or: licenceNumbers
+const unregisteredLicenceQuery = (key, value) => {
+  const query = {
+    [key]: {
+      $or: value
     },
     verification_id: null,
     'metadata->IsCurrent': {
       $ne: 'false'
     }
-  }, {
+  };
+
+  return client.findMany(query, {
     system_external_id: +1
   }, {
     page: 1,
@@ -67,25 +63,22 @@ client.getUnregisteredLicences = function (licenceNumbers) {
 
 /**
  * Get a list of unclaimed licences for use in reg process
+ * @param {Array} licenceNumbers - list of licence numbers to claim
+ * @return {Promise} resolves with list of licences from CRM
+ */
+client.getUnregisteredLicences = function (licenceNumbers) {
+  // Get unverified licences from DB
+  return unregisteredLicenceQuery('system_external_id', licenceNumbers);
+};
+
+/**
+ * Get a list of unclaimed licences for use in reg process
  * @param {Array} documentIds - list of document header IDs to claim
  * @return {Promise} resolves with list of licences from CRM
  */
 client.getUnregisteredLicencesByIds = function (documentIds) {
   // Get unverified licences from DB
-  return this.findMany({
-    document_id: {
-      $or: documentIds
-    },
-    verification_id: null,
-    'metadata->IsCurrent': {
-      $ne: 'false'
-    }
-  }, {
-    system_external_id: +1
-  }, {
-    page: 1,
-    perPage: 300
-  });
+  return unregisteredLicenceQuery('document_id', documentIds);
 };
 
 /**

--- a/src/modules/add-licences/controller.js
+++ b/src/modules/add-licences/controller.js
@@ -183,8 +183,7 @@ async function postLicenceSelect (request, reply) {
     if (companyEntityId) {
       // Licences already in account
       const { data: existingLicences, error } = await CRM.documents.findMany({
-        company_entity_id: companyEntityId,
-        verified: 1
+        company_entity_id: companyEntityId
       });
       if (error) {
         throw error;
@@ -192,7 +191,6 @@ async function postLicenceSelect (request, reply) {
       // Licences being added now
       const { data: selectedLicences, error: error2 } = await CRM.documents.findMany({
         document_id: { $or: documentIds },
-        verified: null,
         verification_id: null
       });
       if (error2) {
@@ -204,7 +202,6 @@ async function postLicenceSelect (request, reply) {
         const similar = checkNewLicenceSimilarity(selectedLicences, existingLicences);
         if (similar) {
           const { error: error3 } = await CRM.documents.updateMany({ document_id: { $or: documentIds } }, {
-            verified: 1,
             company_entity_id: companyEntityId
           });
 
@@ -320,7 +317,11 @@ async function postAddressSelect (request, reply) {
     await Notify.sendSecurityCode(data, verification.verification_code);
 
     // Get all licences - this is needed to determine whether to display link back to dashboard
-    const { error: err2, data: licences } = await CRM.documents.findMany({ verified: 1, entity_id: entityId });
+    const { error: err2, data: licences } = await CRM.documents.findMany({
+      verification_id: { $ne: null },
+      entity_id: entityId
+    });
+
     if (err2) {
       throw err2;
     }

--- a/src/modules/add-licences/controller.js
+++ b/src/modules/add-licences/controller.js
@@ -191,7 +191,7 @@ async function postLicenceSelect (request, reply) {
       // Licences being added now
       const { data: selectedLicences, error: error2 } = await CRM.documents.findMany({
         document_id: { $or: documentIds },
-        verification_id: null
+        company_entity_id: null
       });
       if (error2) {
         throw error2;
@@ -318,7 +318,7 @@ async function postAddressSelect (request, reply) {
 
     // Get all licences - this is needed to determine whether to display link back to dashboard
     const { error: err2, data: licences } = await CRM.documents.findMany({
-      verification_id: { $ne: null },
+      company_entity_id: { $ne: null },
       entity_id: entityId
     });
 

--- a/src/views/water/view-licences/licence.html
+++ b/src/views/water/view-licences/licence.html
@@ -3,7 +3,7 @@
   {{>element-phase-tag}}{{>element-main-nav}}
 
 {{#if isAdmin }}
-  {{#unless crmData.verification_id}}
+  {{#unless crmData.company_entity_id}}
     {{#if crmData.verifications}}
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/src/views/water/view-licences/licence.html
+++ b/src/views/water/view-licences/licence.html
@@ -3,8 +3,7 @@
   {{>element-phase-tag}}{{>element-main-nav}}
 
 {{#if isAdmin }}
-  {{#equal crmData.verified 1}}
-  {{else}}
+  {{#unless crmData.verification_id}}
     {{#if crmData.verifications}}
     <div class="grid-row">
         <div class="column-two-thirds">
@@ -25,10 +24,8 @@
       </div>
     </div>
     {{/if}}
-  {{/equal}}
+  {{/unless}}
 {{/if}}
-
-
 
   {{#if crmData.document_name }}
   <h1 class="heading-large">


### PR DESCRIPTION
Fixes an issue where unverified licences were identified using a
verified flag which was just duplicated data.

This flag has been removed from the CRM now so this change updates the
UI layer accordingly.

WATER-1753