### PR TITLE
Fix: Allow multiple return flow sessions

### DIFF
--- a/src/modules/returns/lib/session-helpers.js
+++ b/src/modules/returns/lib/session-helpers.js
@@ -9,8 +9,9 @@ const logger = require('../../../lib/logger');
  * @return {String}
  */
 const getSessionKey = (request) => {
+  const { returnId } = request.query;
   const isInternal = request.permissions.hasPermission('admin.defra');
-  return `${isInternal ? 'internal' : 'external'}ReturnFlow`;
+  return `${isInternal ? 'internal' : 'external'}ReturnFlow:${returnId}`;
 };
 
 /**

--- a/test/modules/returns/lib/session-helpers.js
+++ b/test/modules/returns/lib/session-helpers.js
@@ -1,0 +1,106 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+const sinon = require('sinon');
+
+const sessionHelpers = require('../../../../src/modules/returns/lib/session-helpers.js');
+
+const getTestRequest = (returnId, isInternal) => {
+  return {
+    permissions: {
+      hasPermission: () => isInternal
+    },
+    query: {
+      returnId
+    },
+    sessionStore: {
+      get: sinon.stub().returns(),
+      set: sinon.spy(),
+      delete: sinon.spy()
+    }
+  };
+};
+
+experiment('getSessionData', () => {
+  test('for an internal user, the correct key is used', async () => {
+    const returnId = '123';
+    const savedData = { returnId };
+    const request = getTestRequest(returnId, true);
+
+    request.sessionStore.get.returns(savedData);
+
+    const data = sessionHelpers.getSessionData(request);
+    const passedKey = request.sessionStore.get.args[0][0];
+
+    expect(passedKey).to.equal('internalReturnFlow:123');
+    expect(data).to.equal(savedData);
+  });
+
+  test('for an external user, the correct key is used', async () => {
+    const returnId = '987';
+    const savedData = { returnId };
+    const request = getTestRequest(returnId, false);
+
+    request.sessionStore.get.returns(savedData);
+
+    const data = sessionHelpers.getSessionData(request);
+    const passedKey = request.sessionStore.get.args[0][0];
+
+    expect(passedKey).to.equal('externalReturnFlow:987');
+    expect(data).to.equal(savedData);
+  });
+
+  test('throws an error if no data for the key', async () => {
+    const returnId = '123';
+    const request = getTestRequest(returnId, false);
+
+    expect(() => {
+      sessionHelpers.getSessionData(request);
+    }).to.throw();
+  });
+});
+
+experiment('saveSessionData', () => {
+  test('for an internal user, the correct key is used', async () => {
+    const returnId = '123';
+    const data = { returnId };
+    const request = getTestRequest(returnId, true);
+
+    sessionHelpers.saveSessionData(request, data);
+
+    const passedKey = request.sessionStore.set.args[0][0];
+    expect(passedKey).to.equal('internalReturnFlow:123');
+  });
+
+  test('for an external user, the correct key is used', async () => {
+    const returnId = '987';
+    const data = { returnId };
+    const request = getTestRequest(returnId, false);
+
+    sessionHelpers.saveSessionData(request, data);
+
+    const passedKey = request.sessionStore.set.args[0][0];
+    expect(passedKey).to.equal('externalReturnFlow:987');
+  });
+});
+
+experiment('deleteSessionData', () => {
+  test('for an internal user, the correct key is used', async () => {
+    const returnId = '123';
+    const request = getTestRequest(returnId, true);
+
+    sessionHelpers.deleteSessionData(request);
+
+    const passedKey = request.sessionStore.delete.args[0][0];
+    expect(passedKey).to.equal('internalReturnFlow:123');
+  });
+
+  test('for an external user, the correct key is used', async () => {
+    const returnId = '123';
+    const request = getTestRequest(returnId, false);
+
+    sessionHelpers.deleteSessionData(request);
+
+    const passedKey = request.sessionStore.delete.args[0][0];
+    expect(passedKey).to.equal('externalReturnFlow:123');
+  });
+});


### PR DESCRIPTION
WATER-1741

Separates return flows in session by adding the return id to the session
key.

This means that a user can have a tab open for each return submission if
required.

This was in response to a water-abstraction-service error caused by an
invalid payload being submitted if the user started a new flow whilst
working on another. Starting a new flow destroyed the session data for
the others.