### PR TITLE
Feat: Use accessible autocomplete for long selects

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,9 +87,41 @@ gulp.task('copy-static-assets-orig', () => {
     .pipe(gulp.dest(paths.public));
 });
 
+/**
+ * Copies assets from the sources to the public/javascripts folder.
+ *
+ * These assets are not combined with other scripts to allow some scripts
+ * to be used in one page without the application.js having to increase for
+ * all pages.
+ */
+gulp.task('copy-static-javascript', () => {
+  return gulp
+    .src([
+      'node_modules/accessible-autocomplete/dist/accessible-autocomplete.min.js'
+    ])
+    .pipe(gulp.dest(paths.public + '/javascripts'));
+});
+
+/**
+ * Copies assets from the sources to the public/stylesheets folder.
+ *
+ * These assets are not combined with other stylesheers to allow some stylesheers
+ * to be used in one page without the application.css having to increase for
+ * all pages.
+ */
+gulp.task('copy-static-styles', () => {
+  return gulp
+    .src([
+      'node_modules/accessible-autocomplete/dist/accessible-autocomplete.min.css'
+    ])
+    .pipe(gulp.dest(paths.public + '/stylesheets'));
+});
+
 gulp.task('copy-static-assets', gulp.series(
   'copy-static-assets-orig',
   'combine-minify-js',
+  'copy-static-javascript',
+  'copy-static-styles',
   done => done()
 ));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -189,6 +189,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "accessible-autocomplete": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz",
+      "integrity": "sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==",
+      "requires": {
+        "preact": "^8.3.1"
+      }
     },
     "acorn": {
       "version": "5.4.1",
@@ -9102,6 +9110,11 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.3.tgz",
       "integrity": "sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg=="
+    },
+    "preact": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.4.2.tgz",
+      "integrity": "sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^4.1.1",
+    "accessible-autocomplete": "^1.6.2",
     "airbrake-js": "^1.5.0",
     "ajv": "^6.6.2",
     "async-waterfall": "^0.1.5",

--- a/src/lib/view-engine/filters/form.js
+++ b/src/lib/view-engine/filters/form.js
@@ -272,7 +272,10 @@ const mapFormDropdownField = (field) => {
     hint: {
       text: field.options.hint
     },
-    items
+    items,
+    formGroup: {
+      classes: 'govuk-body'
+    }
   };
 
   // console.log(find(options, { selected: true }));

--- a/src/views/nunjucks/abstraction-reform/add-data.njk
+++ b/src/views/nunjucks/abstraction-reform/add-data.njk
@@ -68,3 +68,24 @@
 
 
 {% endblock %}
+
+{% block bodyEnd %}
+<script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+<link href="/public/stylesheets/accessible-autocomplete.min.css" rel="stylesheet" />
+<script nonce={{nonces.script}}>
+  var selects = document.querySelectorAll('select');
+  var selectsLength = selects.length;
+  var index = 0;
+  var currentSelect;
+
+  for (index; index < selectsLength; index += 1) {
+    currentSelect = selects[index];
+    
+    if (currentSelect.getElementsByTagName('option').length > 200) {
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: currentSelect
+      });
+    }
+  } 
+</script>
+{% endblock %}

--- a/src/views/nunjucks/abstraction-reform/edit-data.njk
+++ b/src/views/nunjucks/abstraction-reform/edit-data.njk
@@ -4,9 +4,6 @@
 {% from "forms/footer.njk" import formFooter %}
 {% from "forms/widget.njk" import formWidget %}
 
-
-
-
 {% block content %}
 
   {{ formErrorSummary(form) }}
@@ -28,9 +25,6 @@
     </div>
   </div>
 
-
-
-
 {% endblock %}
 
 {% block bodyEnd %}
@@ -39,5 +33,22 @@
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
 <script src="/public/javascripts/json-forms-toggle.js"></script>
+<script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+<link href="/public/stylesheets/accessible-autocomplete.min.css" rel="stylesheet" />
+<script nonce={{nonces.script}}>
+  var selects = document.querySelectorAll('select');
+  var selectsLength = selects.length;
+  var index = 0;
+  var currentSelect;
 
+  for (index; index < selectsLength; index += 1) {
+    currentSelect = selects[index];
+    
+    if (currentSelect.getElementsByTagName('option').length > 200) {
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: currentSelect
+      });
+    }
+  } 
+</script>
 {% endblock %}


### PR DESCRIPTION
When a select element contains more than 200 items and the user permits
client side JS, the select is replaced with an accessible autocomplete
component.

Adds the govuk-body class to the form-group that contains the select to
allow the style to cascade into the list of options that replace the
select options.