### PR TITLE
Fix: Fixes an issue with mutated schema definitions

### DIFF
--- a/src/modules/abstraction-reform/controllers/wr22.js
+++ b/src/modules/abstraction-reform/controllers/wr22.js
@@ -14,7 +14,7 @@ const {
   addActionFactory, editActionFactory, persistActions, getSchema
 } = wr22Helpers;
 
-const { wr22 } = require('../lib/schema');
+const { getWR22 } = require('../lib/schema');
 
 const { deleteForm } = require('../forms/delete');
 
@@ -56,9 +56,10 @@ const pre = async (request, h) => {
 const getSelectSchema = async (request, h) => {
   const { documentId } = request.params;
 
-  const form = request.form || selectSchemaForm(request, wr22);
+  const wr22Schema = getWR22();
+  const form = request.form || selectSchemaForm(request, wr22Schema);
 
-  const categories = getSchemaCategories(wr22);
+  const categories = getSchemaCategories(wr22Schema);
 
   const view = {
     categories,
@@ -80,7 +81,8 @@ const getSelectSchema = async (request, h) => {
 const postSelectSchema = async (request, h) => {
   const { documentId } = request.params;
 
-  const form = handleRequest(selectSchemaForm(request, wr22), request);
+  const wr22Schema = getWR22();
+  const form = handleRequest(selectSchemaForm(request, wr22Schema), request);
 
   // If validation errors in form, redisplay with error message
   if (!form.isValid) {

--- a/src/modules/abstraction-reform/lib/helpers.js
+++ b/src/modules/abstraction-reform/lib/helpers.js
@@ -1,7 +1,7 @@
 const deepMap = require('deep-map');
 const { pickBy, isArray, isObject, mapValues, pick, setWith, find } = require('lodash');
 const { getPurposes, getPoints, getConditions, getCurrentVersion, getCurrentVersionParty, getCurrentVersionAddress } = require('./licence-helpers');
-const { wr22 } = require('./schema');
+const { getWR22 } = require('./schema');
 
 /**
  * Returns obj with non-scalar values removed
@@ -92,7 +92,7 @@ const prepareItem = (licence, finalState, getter = x => x) => {
  */
 const mapARItem = (item) => {
   const { schema: schemaName } = item;
-  const schema = find(wr22, { id: schemaName });
+  const schema = find(getWR22(), { id: schemaName });
   return {
     id: item.id,
     schema: schemaName,

--- a/src/modules/abstraction-reform/lib/schema.js
+++ b/src/modules/abstraction-reform/lib/schema.js
@@ -1,3 +1,4 @@
+const { cloneDeep } = require('lodash');
 
 module.exports = {
 
@@ -5,14 +6,16 @@ module.exports = {
    * An array of the JSON schema used for WR22 conditions
    * @type {Array}
    */
-  wr22: [
-    require('../schema/wr22/2.1.json'),
-    require('../schema/wr22/2.2.json'),
-    require('../schema/wr22/2.3.json'),
-    require('../schema/wr22/2.4.json'),
-    require('../schema/wr22/2.5.json'),
-    require('../schema/wr22/2.6.json'),
-    require('../schema/wr22/2.7.json'),
-    require('../schema/wr22/2.8.json')
-  ]
+  getWR22 () {
+    return [
+      require('../schema/wr22/2.1.json'),
+      require('../schema/wr22/2.2.json'),
+      require('../schema/wr22/2.3.json'),
+      require('../schema/wr22/2.4.json'),
+      require('../schema/wr22/2.5.json'),
+      require('../schema/wr22/2.6.json'),
+      require('../schema/wr22/2.7.json'),
+      require('../schema/wr22/2.8.json')
+    ].map(cloneDeep);
+  }
 };

--- a/src/modules/abstraction-reform/lib/wr22-helpers.js
+++ b/src/modules/abstraction-reform/lib/wr22-helpers.js
@@ -2,7 +2,7 @@ const { find, omit, get, mapValues, isObject } = require('lodash');
 
 const { setValues } = require('../../../lib/forms');
 const loader = require('./loader');
-const { wr22 } = require('./schema');
+const { getWR22 } = require('./schema');
 const formGenerator = require('./form-generator.js');
 const { createAddData, createEditData } = require('./action-creators');
 const { stateManager, getInitialState } = require('./state-manager');
@@ -13,7 +13,7 @@ const { stateManager, getInitialState } = require('./state-manager');
  * @return {Object}            the JSON schema
  */
 const getSchema = (schemaName) => {
-  const item = find(wr22, { id: schemaName });
+  const item = find(getWR22(), { id: schemaName });
   if (item) {
     return item;
   }
@@ -112,6 +112,7 @@ const getEditFormAndSchema = async (request) => {
 
   const item = findDataItem(result.finalState, id);
 
+  console.log('wr22-helpers - getEditFormAndSchema');
   const schema = await formGenerator.dereference(getSchema(item.schema), { documentId });
 
   const values = flattenData(item.content);

--- a/test/modules/abstraction-reform/forms/delete.js
+++ b/test/modules/abstraction-reform/forms/delete.js
@@ -3,7 +3,7 @@ const Lab = require('lab');
 const { expect } = require('code');
 const { find } = require('lodash');
 const { deleteForm } = require('../../../../src/modules/abstraction-reform/forms/delete');
-const { wr22 } = require('../../../../src/modules/abstraction-reform/lib/schema');
+const { getWR22 } = require('../../../../src/modules/abstraction-reform/lib/schema');
 
 const lab = exports.lab = Lab.script();
 
@@ -21,6 +21,7 @@ lab.experiment('delete WR22 condition form', () => {
   let form;
 
   lab.beforeEach(async () => {
+    const wr22 = getWR22();
     form = deleteForm(request, wr22);
   });
 

--- a/test/modules/abstraction-reform/forms/select-schema.js
+++ b/test/modules/abstraction-reform/forms/select-schema.js
@@ -3,7 +3,7 @@ const Lab = require('lab');
 const { expect } = require('code');
 const { find } = require('lodash');
 const { selectSchemaForm } = require('../../../../src/modules/abstraction-reform/forms/select-schema');
-const { wr22 } = require('../../../../src/modules/abstraction-reform/lib/schema');
+const { getWR22 } = require('../../../../src/modules/abstraction-reform/lib/schema');
 
 const lab = exports.lab = Lab.script();
 
@@ -20,6 +20,7 @@ lab.experiment('selectSchemaForm', () => {
   let form;
 
   lab.beforeEach(async () => {
+    const wr22 = getWR22();
     form = selectSchemaForm(request, wr22);
   });
 

--- a/test/modules/abstraction-reform/lib/schema.js
+++ b/test/modules/abstraction-reform/lib/schema.js
@@ -1,0 +1,24 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const schema = require('../../../../src/modules/abstraction-reform/lib/schema');
+
+/*
+ * When the json ref parser dereferences data the original schema object was mutated.
+ *
+ * This test ensures that next time the schema is requested, a new copy of the schema is
+ * returned to prevent the caching effect of the singleton.
+ */
+experiment('getWR22', () => {
+  test('returns clones of the data to protect against mutations', async () => {
+    // get the schema
+    const schemaA = schema.getWR22();
+
+    // update the ref to a fake resolved value
+    schemaA[0].properties.nald_condition.$ref = 'some data';
+
+    // ensure that the original schema is returned without the mutation
+    const schemaB = schema.getWR22();
+    expect(schemaB[0].properties.nald_condition.$ref).to.equal('water://licences/conditions.json');
+  });
+});


### PR DESCRIPTION
WATER-1814

The json ref parser module was mutating the references of the schema for
WR22 so this change uses a function to return deep clones of the schema
objects so the references are resolved per licence condition.