### PR TITLE
Feat: Improve configuration of accessible autocomplete

### DIFF
--- a/src/modules/abstraction-reform/schema/types/water-bodies.json
+++ b/src/modules/abstraction-reform/schema/types/water-bodies.json
@@ -1,5 +1,6 @@
 {
   "type": "object",
+  "defaultEmpty": true,
   "enum": [
     {
       "id": "138c4d3d-3307-3e03-a9c3-0a04d55cfa21",

--- a/src/public/javascripts/abstraction-reform.js
+++ b/src/public/javascripts/abstraction-reform.js
@@ -1,0 +1,23 @@
+'use strict';
+
+window.WRLS = window.WRLS || {};
+
+window.WRLS.initAutoComplete = function () {
+  var selects = document.querySelectorAll('select');
+  var currentSelect;
+
+  for (var index = 0; index < selects.length; index += 1) {
+    currentSelect = selects[index];
+
+    if (currentSelect.getElementsByTagName('option').length > 200) {
+      window.accessibleAutocomplete.enhanceSelectElement({
+        selectElement: currentSelect,
+        showAllValues: true,
+        showNoOptionsFound: true,
+        defaultValue: '',
+        autoselect: false,
+        confirmOnBlur: false
+      });
+    }
+  }
+};

--- a/src/views/nunjucks/abstraction-reform/add-data.njk
+++ b/src/views/nunjucks/abstraction-reform/add-data.njk
@@ -71,21 +71,9 @@
 
 {% block bodyEnd %}
 <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+<script src="/public/javascripts/abstraction-reform.min.js"></script>
 <link href="/public/stylesheets/accessible-autocomplete.min.css" rel="stylesheet" />
 <script nonce={{nonces.script}}>
-  var selects = document.querySelectorAll('select');
-  var selectsLength = selects.length;
-  var index = 0;
-  var currentSelect;
-
-  for (index; index < selectsLength; index += 1) {
-    currentSelect = selects[index];
-    
-    if (currentSelect.getElementsByTagName('option').length > 200) {
-      accessibleAutocomplete.enhanceSelectElement({
-        selectElement: currentSelect
-      });
-    }
-  } 
+  window.WRLS.initAutoComplete();
 </script>
 {% endblock %}

--- a/src/views/nunjucks/abstraction-reform/edit-data.njk
+++ b/src/views/nunjucks/abstraction-reform/edit-data.njk
@@ -35,20 +35,8 @@
 <script src="/public/javascripts/json-forms-toggle.js"></script>
 <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
 <link href="/public/stylesheets/accessible-autocomplete.min.css" rel="stylesheet" />
+<script src="/public/javascripts/abstraction-reform.js"></script>
 <script nonce={{nonces.script}}>
-  var selects = document.querySelectorAll('select');
-  var selectsLength = selects.length;
-  var index = 0;
-  var currentSelect;
-
-  for (index; index < selectsLength; index += 1) {
-    currentSelect = selects[index];
-    
-    if (currentSelect.getElementsByTagName('option').length > 200) {
-      accessibleAutocomplete.enhanceSelectElement({
-        selectElement: currentSelect
-      });
-    }
-  } 
+  WRLS.initAutoComplete();
 </script>
 {% endblock %}

--- a/test/modules/abstraction-reform/lib/form-generator.js
+++ b/test/modules/abstraction-reform/lib/form-generator.js
@@ -3,7 +3,11 @@ const sandbox = require('sinon').createSandbox();
 
 const apiHelpers = require('../../../../src/modules/abstraction-reform/lib/api-helpers');
 const {
-  dereference, picklistSchemaFactory, schemaToForm, guessLabel, addAttribute
+  dereference,
+  picklistSchemaFactory,
+  schemaToForm, guessLabel,
+  addAttribute,
+  createEnumField
 } = require('../../../../src/modules/abstraction-reform/lib/form-generator');
 const { expect } = require('code');
 const licencesConnector = require('../../../../src/lib/connectors/water-service/licences');
@@ -254,5 +258,57 @@ experiment('addAttribute should add one or more attribute properties to field ob
     f = addAttribute(f, 'bar', 'baz');
     expect(f.options.attr.foo).to.equal('1');
     expect(f.options.attr.bar).to.equal('baz');
+  });
+});
+
+experiment('createEnumField', () => {
+  test('for 5 enum values, a radio group is created', async () => {
+    const item = {
+      enum: [1, 2, 3, 4, 5]
+    };
+
+    const field = createEnumField('name-of-field', item);
+    expect(field.options.widget).to.equal('radio');
+  });
+
+  test('for > 5 enum values, a dropdown is created', async () => {
+    const item = {
+      enum: [1, 2, 3, 4, 5, 6]
+    };
+
+    const field = createEnumField('name-of-field', item);
+    expect(field.options.widget).to.equal('dropdown');
+  });
+
+  test('for 5 enum values, and defaultEmpty set to true, there are still only 5 entries', async () => {
+    const item = {
+      enum: [1, 2, 3, 4, 5],
+      defaultEmpty: true
+    };
+
+    const field = createEnumField('name-of-field', item);
+    expect(field.options.choices.length).to.equal(5);
+  });
+
+  test('for > 5 scalar enum values, and defaultEmpty set to true, an empty values is added to choices', async () => {
+    const item = {
+      enum: [1, 2, 3, 4, 5, 6],
+      defaultEmpty: true
+    };
+
+    const field = createEnumField('name-of-field', item);
+    expect(field.options.choices.length).to.equal(7);
+    expect(field.options.choices[0]).to.equal({ value: '', label: '' });
+  });
+
+  test('for > 5 object enum values, and defaultEmpty set to true, an empty values is added to choices', async () => {
+    const item = {
+      enum: [1, 2, 3, 4, 5, 6].map(i => ({ label: i, value: i })),
+      defaultEmpty: true
+    };
+
+    const field = createEnumField('name-of-field', item);
+    expect(field.options.choices.length).to.equal(7);
+    expect(field.options.choices[0]).to.equal({ value: '', label: '' });
   });
 });


### PR DESCRIPTION
WATER-1815

Updates the usage of the accessible-autocomplete component to make
finding data without knowing its value upfront.

 - Adds `defaultEmpty` to the JSON schema for water bodies
 - Changes the form generator to use the `defaultEmpty` value to include
an empty value when enums are rendered as drop downs.
 - Moves the client side JavaScript into an external file
(abstraction-reform.js) that can be used in the add and edit AR data
templates.