### PR TITLE
Feat: Include empty entry for gauging stations

### DIFF
--- a/src/modules/abstraction-reform/schema/types/gauging-stations.json
+++ b/src/modules/abstraction-reform/schema/types/gauging-stations.json
@@ -1,5 +1,6 @@
 {
   "type": "object",
+  "defaultEmpty": true,
   "enum": [
     {
       "id": "921cad5b-4af6-4f4d-b8dc-0198e1ab15f8",


### PR DESCRIPTION
WATER-1815

Configure the gauging stations JSON type to request that an empty value
is included in the rendered select element.