### PR TITLE
Feat: Dynamically load internal user scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const { getPermissions: permissionsFunc } = require('./src/lib/permissions.js');
 const routes = require('./src/modules/routes');
 const returnsPlugin = require('./src/modules/returns/plugin.js');
 const entityRolesPlugin = require('./src/lib/hapi-plugins/entity-roles');
+const authCredentialsPlugin = require('./src/lib/hapi-plugins/auth-credentials');
 const viewEngine = require('./src/lib/view-engine/');
 
 // Initialise logger
@@ -63,6 +64,8 @@ async function start () {
     });
 
     await server.register([Inert, Vision]);
+
+    await server.register({ plugin: authCredentialsPlugin });
 
     // The following plugins all are part of the auth phase in
     // the request lifecycle and hook into onPostAuth.

--- a/src/lib/hapi-plugins/auth-credentials.js
+++ b/src/lib/hapi-plugins/auth-credentials.js
@@ -1,0 +1,54 @@
+/**
+ * Plugin to allow modifcation of the credentials object
+ * before the preAuth phase begins.
+ *
+ * In the first instance this allow scopes to be updated
+ * from the user object, rather than having to save this in the cookie
+ * and have it injected into credentials via the hapi-auth-cookie plugin.
+ */
+const idmConnector = require('../connectors/idm');
+const { get } = require('lodash');
+const logger = require('../logger');
+
+const shouldLoadScopes = request => request.auth.isAuthenticated;
+
+const getUserId = request => get(request, 'auth.credentials.user_id');
+
+const getUser = async request => {
+  const userId = getUserId(request);
+  const { error, data: user } = await idmConnector.getUser(userId);
+
+  if (error) {
+    error.params = {
+      credentials: request.auth.credentials
+    };
+    throw error;
+  }
+  return user;
+};
+
+const plugin = {
+  register: (server, options) => {
+    server.ext({
+      type: 'onCredentials',
+      async method (request, h) {
+        if (shouldLoadScopes(request)) {
+          try {
+            const user = await getUser(request);
+            request.auth.credentials.scope = get(user, 'role.scopes');
+          } catch (error) {
+            logger.error('Failed to load user', error);
+          }
+        }
+        return h.continue;
+      }
+    });
+  },
+
+  pkg: {
+    name: 'authCredentialsPlugin',
+    version: '2.0.0'
+  }
+};
+
+module.exports = plugin;

--- a/src/lib/hapi-plugins/index.js
+++ b/src/lib/hapi-plugins/index.js
@@ -8,6 +8,11 @@ module.exports = {
   adminFirewall: require('./admin-firewall'),
   redirect: require('./redirect'),
   secureHeaders: require('./secure-headers'),
+
+  // licence details should be loaded before the view context is
+  // updated with the main navigation.
+  licenceLoader: require('./licence-loader'),
+
   viewContext: require('./view-context'),
   formValidator: require('./form-validator'),
   anonGoogleAnalytics: require('./anon-google-analytics')

--- a/src/lib/hapi-plugins/licence-loader.js
+++ b/src/lib/hapi-plugins/licence-loader.js
@@ -1,0 +1,71 @@
+const crmDocumentConnector = require('../connectors/crm/documents');
+const crmVerifcationConnector = require('../connectors/crm/verification');
+const { set, get } = require('lodash');
+
+const addToRequest = (request, key, value) => set(request, `licence.${key}`, value);
+
+const getEntityId = request => request.auth.credentials.entity_id;
+
+const loadUserLicenceCount = async request => {
+  const entityId = getEntityId(request);
+  const licenceCount = await crmDocumentConnector.getLicenceCount(entityId);
+  addToRequest(request, 'userLicenceCount', licenceCount);
+};
+
+const loadOutstandingVerifications = async request => {
+  const entityId = getEntityId(request);
+  const { data: verifications } = await crmVerifcationConnector.getOutstandingVerifications(entityId);
+  addToRequest(request, 'outstandingVerifications', verifications);
+};
+
+/*
+ * Maps the settings key to a functin that satisfies the requirement
+ */
+const requirementsMap = {
+  loadUserLicenceCount,
+  loadOutstandingVerifications
+};
+
+/*
+ * For each key on the settings object the relevant loading
+ * function is called in order to add the required data to
+ * the request object
+ */
+const loadRequirements = async (request, settings) => {
+  const requirements = Object.keys(settings).reduce((acc, key) => {
+    return settings[key] === true
+      ? [...acc, key]
+      : acc;
+  }, []);
+
+  const promises = requirements.map(requirement => {
+    return requirementsMap[requirement](request);
+  });
+
+  return Promise.all(promises);
+};
+
+const plugin = {
+  register: (server, options) => {
+    server.ext({
+      type: 'onPreHandler',
+      async method (request, h) {
+        if (get(request, 'auth.isAuthenticated') === true) {
+          const settings = get(request, 'route.settings.plugins.licenceLoader');
+
+          if (settings) {
+            await loadRequirements(request, settings);
+          }
+        }
+        return h.continue;
+      }
+    });
+  },
+
+  pkg: {
+    name: 'licenceLoaderPlugin',
+    version: '2.0.0'
+  }
+};
+
+module.exports = plugin;

--- a/src/lib/hapi-plugins/permissions.js
+++ b/src/lib/hapi-plugins/permissions.js
@@ -11,8 +11,9 @@ const permissionsPlugin = {
     server.ext({
       type: 'onPostAuth',
       method: (request, reply) => {
-        request.permissions = getPermissions(request.state.sid, request.entityRoles);
-        request.permissions.companies = getCompanyPermissions(request.state.sid, request.entityRoles);
+        const credentials = request.auth.credentials || {};
+        request.permissions = getPermissions(credentials, request.entityRoles);
+        request.permissions.companies = getCompanyPermissions(credentials, request.entityRoles);
 
         /**
          * Checks whether the user has the requested permission

--- a/src/lib/sign-in.js
+++ b/src/lib/sign-in.js
@@ -3,8 +3,8 @@
  */
 const CRM = require('./connectors/crm');
 const uuid = require('uuid/v4');
-const idm = require('./connectors/idm');
 const { get } = require('lodash');
+const idm = require('./connectors/idm');
 
 /**
  * Loads user data from IDM
@@ -52,7 +52,11 @@ async function auto (request, emailAddress) {
 
   // Set user info in signed cookie
   request.cookieAuth.set(session);
-  return session;
+
+  // update the credentials object with the scopes to allow permissions
+  // to be calculated elsewhere. On subsequent requests this will be
+  // done by the auth-credentials plugin in the onCredentials phase.
+  request.auth.credentials = { scope: get(user, 'role.scopes') };
 }
 
 /**
@@ -64,8 +68,7 @@ const createSessionData = (sessionId, user, entityId) => {
     username: user.user_name.toLowerCase().trim(),
     user_id: user.user_id,
     entity_id: entityId,
-    lastLogin: user.last_login,
-    scope: get(user, 'role.scopes', [])
+    lastLogin: user.last_login
   };
 
   return session;

--- a/src/lib/view-engine/filters/form.js
+++ b/src/lib/view-engine/filters/form.js
@@ -278,7 +278,6 @@ const mapFormDropdownField = (field) => {
     }
   };
 
-  // console.log(find(options, { selected: true }));
   return applyErrors(options, field.errors);
 };
 

--- a/src/lib/view-engine/handlebars.js
+++ b/src/lib/view-engine/handlebars.js
@@ -63,9 +63,9 @@ function paginationLink (url, params, page, options = {}) {
   return `<a class="pagination__link${options.isActive ? ' pagination__link--active' : ''}" href="${fullUrl}" ${ariaLabel}>`;
 }
 
-handlebars.registerHelper('pagination', function (pagination, options) {
+handlebars.registerHelper('pagination', function (pagination = {}, options) {
   const { url = '/', params = {} } = options.hash;
-  const { page, pageCount } = pagination;
+  const { page, pageCount = 0 } = pagination;
 
   if (pageCount <= 1) {
     return null;

--- a/src/lib/view/main-nav.js
+++ b/src/lib/view/main-nav.js
@@ -37,17 +37,32 @@ const getInternalNav = (request) => {
 };
 
 /**
+ * If a route is configured to load the user licence count,
+ * there will be a number available at request.licence.userLicenceCount.
+ *
+ * If the route does not configure this setting, then assume that the
+ * user does have licences.
+ */
+const userHasLicences = request => {
+  return get(request, 'licence.userLicenceCount') !== 0;
+};
+
+/**
  * Get links for public users
  * @param  {Object} request - HAPI request instance
  * @return {Array}         array of links
  */
 const getExternalNav = (request) => {
   const links = [externalLinks.licences];
-  if (isExternalReturns(request)) {
-    links.push(externalLinks.returns);
-  }
-  if (isPrimary(request)) {
-    links.push(externalLinks.manage);
+
+  if (userHasLicences(request)) {
+    if (isExternalReturns(request)) {
+      links.push(externalLinks.returns);
+    }
+
+    if (isPrimary(request)) {
+      links.push(externalLinks.manage);
+    }
   }
   return links;
 };

--- a/src/modules/add-licences/controller.js
+++ b/src/modules/add-licences/controller.js
@@ -379,16 +379,12 @@ function verifySelectedLicences (documentIds, requestDocumentIds) {
  * @param {Object} request - HAPI HTTP request
  * @param {Object} reply - HAPI HTTP reply
  */
-async function getSecurityCode (request, reply) {
+async function getSecurityCode (request, h) {
   const viewContext = request.view;
   viewContext.pageTitle = 'Enter your security code';
   viewContext.activeNavLink = 'manage';
 
-  try {
-    return reply.view('water/licences-add/security-code', viewContext);
-  } catch (error) {
-    throw error;
-  }
+  return h.view('water/licences-add/security-code', viewContext);
 }
 
 /**
@@ -421,8 +417,6 @@ async function postSecurityCode (request, reply) {
     // Licences have been verified if no error thrown
     return reply.redirect('/licences');
   } catch (error) {
-    logger.error('Post security code error', error);
-
     // Verification code invalid
     if (['VerificationNotFoundError', 'ValidationError'].includes(error.name)) {
       viewContext.licences = await CRM.getOutstandingLicenceRequests(entityId);

--- a/src/modules/add-licences/routes.js
+++ b/src/modules/add-licences/routes.js
@@ -97,7 +97,12 @@ module.exports = {
     path: '/security-code',
     handler: controller.getSecurityCode,
     config: {
-      description: 'Enter auth code received by post'
+      description: 'Enter auth code received by post',
+      plugins: {
+        licenceLoader: {
+          loadUserLicenceCount: true
+        }
+      }
     }
   },
   postSecurityCode: {
@@ -106,6 +111,11 @@ module.exports = {
     handler: controller.postSecurityCode,
     config: {
       description: 'Enter auth code received by post',
+      plugins: {
+        licenceLoader: {
+          loadUserLicenceCount: true
+        }
+      },
       validate: {
         payload: {
           verification_code: Joi.string().allow('').max(5),

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -84,10 +84,10 @@ async function postSignin (request, h) {
       return h.redirect(`reset_password_change_password?resetGuid=${resetGuid}&forced=1`);
     }
 
-    const session = await signIn.auto(request, request.payload.user_id);
+    await signIn.auto(request, request.payload.user_id);
 
     // Redirect user
-    const permissions = getPermissions(session);
+    const permissions = getPermissions(request.auth.credentials);
     const redirectPath = permissions.admin.defra ? '/admin/licences' : '/licences';
 
     // Resolves Chrome issue where it won't set cookie and redirect in same request

--- a/src/modules/manage-licences/controller.js
+++ b/src/modules/manage-licences/controller.js
@@ -218,7 +218,7 @@ const removeColleague = async (regimeId, companyId, entityId, colleagueId) => {
     ...regimeId && { regime_entity_id: regimeId }
   };
 
-  const { data: roles, error: roleError } = await CRM.entityRoles.setParams({entityId: colleagueId}).findMany(filter);
+  const { data: roles, error: roleError } = await CRM.entityRoles.setParams({ entityId: colleagueId }).findMany(filter);
 
   if (roleError) {
     throw Boom.badImplementation(`CRM error getting roles on company ${companyId} for entity ${colleagueId}`, roleError);
@@ -239,7 +239,7 @@ async function postRemoveAccess (request, h) {
 
   // Need to find all roles that the colleage has for the company
   // for whom the current user is the primary_user
-  const { regime_entity_id: regimeId, company_entity_id: companyId } = find(request.auth.credentials.roles, role => role.role === 'primary_user');
+  const { regime_entity_id: regimeId, company_entity_id: companyId } = find(request.entityRoles, role => role.role === 'primary_user');
 
   await removeColleague(regimeId, companyId, entityId, colleagueEntityID);
 

--- a/src/modules/update-password/routes.js
+++ b/src/modules/update-password/routes.js
@@ -13,6 +13,9 @@ module.exports = {
         viewContext: {
           pageTitle: 'Enter your current password',
           activeNavLink: 'change-password'
+        },
+        licenceLoader: {
+          loadUserLicenceCount: true
         }
       }
     }
@@ -39,6 +42,9 @@ module.exports = {
             password: VALID_PASSWORD,
             csrf_token: VALID_GUID
           }
+        },
+        licenceLoader: {
+          loadUserLicenceCount: true
         }
       }
     },
@@ -73,6 +79,9 @@ module.exports = {
           options: {
             abortEarly: false
           }
+        },
+        licenceLoader: {
+          loadUserLicenceCount: true
         }
       }
     },

--- a/src/modules/view-licences/controller.js
+++ b/src/modules/view-licences/controller.js
@@ -7,8 +7,6 @@
 const Boom = require('boom');
 const { get } = require('lodash');
 const CRM = require('../../lib/connectors/crm');
-const { getLicenceCount } = require('../../lib/connectors/crm/documents');
-const { getOutstandingVerifications } = require('../../lib/connectors/crm/verification');
 const { getLicences: baseGetLicences } = require('./base');
 const { getLicencePageTitle, loadLicenceData, loadRiverLevelData, validateStationReference, riverLevelFlags, errorMapper } = require('./helpers');
 
@@ -25,19 +23,14 @@ const { getLicencePageTitle, loadLicenceData, loadRiverLevelData, validateStatio
  */
 async function getLicences (request, reply) {
   const { view } = request;
-  const { entity_id: entityId } = request.auth.credentials;
 
-  // Check for verifications
-  const { data: verifications } = await getOutstandingVerifications(entityId);
+  const verifications = request.licence.outstandingVerifications;
+  const licenceCount = request.licence.userLicenceCount;
 
-  // Check if user has any licences
-  const licenceCount = await getLicenceCount(entityId);
-
-  if (licenceCount === 0 && verifications.length > 0) {
-    return reply.redirect('/security-code');
-  }
   if (licenceCount === 0) {
-    return reply.redirect('/add-licences');
+    return verifications.length === 0
+      ? reply.redirect('/add-licences')
+      : reply.redirect('/security-code');
   }
 
   // Set view flags

--- a/src/modules/view-licences/routes.js
+++ b/src/modules/view-licences/routes.js
@@ -209,6 +209,10 @@ module.exports = {
           showResults: true,
           activeNavLink: 'view'
         },
+        licenceLoader: {
+          loadOutstandingVerifications: true,
+          loadUserLicenceCount: true
+        },
         formValidator: {
           query: {
             emailAddress: Joi.string().allow('').email(),

--- a/test/lib/hapi-plugins/entity-roles.js
+++ b/test/lib/hapi-plugins/entity-roles.js
@@ -18,7 +18,7 @@ const getServer = async (requestStubFn = () => {}) => {
   await server.register([
     {
       plugin: requestStubPlugin,
-      options: { setupRequest: requestStubFn }
+      options: { onPostAuth: requestStubFn }
     },
     {
       plugin: entityRolesPlugin

--- a/test/lib/hapi-plugins/licence-loader.js
+++ b/test/lib/hapi-plugins/licence-loader.js
@@ -1,0 +1,117 @@
+const Hapi = require('hapi');
+const { expect } = require('code');
+const { beforeEach, afterEach, experiment, test } = exports.lab = require('lab').script();
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { set, get } = require('lodash');
+
+const licenceLoaderPlugin = require('../../../src/lib/hapi-plugins/licence-loader');
+
+const crmDocumentConnector = require('../../../src/lib/connectors/crm/documents');
+const crmVerifcationConnector = require('../../../src/lib/connectors/crm/verification');
+const requestStubPlugin = require('./request-stub-plugin');
+
+const addEntityIdToRequest = request => {
+  set(request, 'auth.isAuthenticated', true);
+  set(request, 'auth.credentials.entity_id', 'test-entity-id');
+};
+
+const getServer = async (licenceLoaderSettings) => {
+  const server = Hapi.server();
+  await server.register([
+    {
+      plugin: requestStubPlugin,
+      options: { onPostAuth: addEntityIdToRequest }
+    },
+    { plugin: licenceLoaderPlugin }
+  ]);
+
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: () => 'ok',
+    config: {
+      plugins: {
+        licenceLoader: licenceLoaderSettings
+      }
+    }
+  });
+
+  return server;
+};
+
+experiment('loadUserLicenceCount', () => {
+  beforeEach(async () => {
+    sandbox.stub(crmDocumentConnector, 'getLicenceCount');
+    sandbox.stub(crmVerifcationConnector, 'getOutstandingVerifications');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('when loadUserLicenceCount is true the data is added to the request', async () => {
+    crmDocumentConnector.getLicenceCount.resolves(2);
+    const loaderSettings = { loadUserLicenceCount: true };
+    const server = await getServer(loaderSettings);
+    const request = { url: '/' };
+
+    const response = await server.inject(request);
+
+    expect(response.request.licence.userLicenceCount).to.equal(2);
+  });
+
+  test('when loadUserLicenceCount is not true, the data is not added to the request', async () => {
+    const loaderSettings = {};
+    const server = await getServer(loaderSettings);
+    const request = { url: '/' };
+
+    const response = await server.inject(request);
+
+    const licence = get(response, 'request.licence', {});
+    expect(licence.userLicenceCount).to.be.undefined();
+  });
+
+  test('when loadOutstandingVerifications is true the data is added to the request', async () => {
+    crmVerifcationConnector.getOutstandingVerifications.resolves({
+      data: [{ id: 1 }]
+    });
+    const loaderSettings = { loadOutstandingVerifications: true };
+    const server = await getServer(loaderSettings);
+    const request = { url: '/' };
+
+    const response = await server.inject(request);
+
+    expect(response.request.licence.outstandingVerifications).to.equal([{ id: 1 }]);
+  });
+
+  test('when loadOutstandingVerifications is not true, the data is not added to the request', async () => {
+    const loaderSettings = {};
+    const server = await getServer(loaderSettings);
+    const request = { url: '/' };
+
+    const response = await server.inject(request);
+
+    const licence = get(response, 'request.licence', {});
+    expect(licence.outstandingVerifications).to.be.undefined();
+  });
+
+  test('all requested data is loaded for multilpe keys', async () => {
+    crmVerifcationConnector.getOutstandingVerifications.resolves({
+      data: [{ id: 1 }]
+    });
+    crmDocumentConnector.getLicenceCount.resolves(2);
+
+    const loaderSettings = {
+      loadUserLicenceCount: true,
+      loadOutstandingVerifications: true
+    };
+    const server = await getServer(loaderSettings);
+    const request = { url: '/' };
+
+    const response = await server.inject(request);
+
+    expect(response.request.licence.outstandingVerifications).to.equal([{ id: 1 }]);
+    expect(response.request.licence.userLicenceCount).to.equal(2);
+  });
+});

--- a/test/lib/hapi-plugins/request-stub-plugin.js
+++ b/test/lib/hapi-plugins/request-stub-plugin.js
@@ -13,7 +13,7 @@
  * server.register({
  *   plugin: requestStub,
  *   options: {
- *     setupRequest: request => {
+ *     onPostAuth: request => {
  *       request.auth = { isAuthenticated: true }
  *     }
  *   }
@@ -24,8 +24,8 @@ const plugin = {
     server.ext({
       type: 'onPostAuth',
       method: async (request, h) => {
-        if (options.setupRequest) {
-          options.setupRequest(request);
+        if (options.onPostAuth) {
+          options.onPostAuth(request);
         }
         return h.continue;
       }

--- a/test/lib/sign-in.js
+++ b/test/lib/sign-in.js
@@ -69,10 +69,6 @@ experiment('createSessionData', () => {
   test('adds the last login value from the user', async () => {
     expect(sessionData.lastLogin).to.equal(user.last_login);
   });
-
-  test('adds the scopes from the user', async () => {
-    expect(sessionData.scope).to.equal(user.role.scopes);
-  });
 });
 
 experiment('auto', () => {
@@ -82,7 +78,14 @@ experiment('auto', () => {
     sandbox.stub(idmConnector, 'getUserByEmail').resolves({
       error: null,
       data: [
-        { user_id: 1, user_name: 'test@example.com', external_id: 'external-id' }
+        {
+          user_id: 1,
+          user_name: 'test@example.com',
+          external_id: 'external-id',
+          role: {
+            scopes: ['one', 'two']
+          }
+        }
       ]
     });
 
@@ -96,7 +99,8 @@ experiment('auto', () => {
       },
       cookieAuth: {
         set: sinon.spy()
-      }
+      },
+      auth: {}
     };
   });
 
@@ -172,5 +176,11 @@ experiment('auto', () => {
 
     const cookieSetArg = request.cookieAuth.set.args[0][0];
     expect(cookieSetArg).to.be.an.object();
+  });
+
+  test('updates the auth.credentials object with the user scope', async () => {
+    await auto(request, 'test@example.com');
+
+    expect(request.auth.credentials.scope).to.equal(['one', 'two']);
   });
 });

--- a/test/lib/view/main-nav.js
+++ b/test/lib/view/main-nav.js
@@ -2,7 +2,7 @@
 
 const { find, set } = require('lodash');
 const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const { experiment, test } = exports.lab = Lab.script();
 
 const { expect } = require('code');
 
@@ -65,60 +65,74 @@ const getReturnsRequest = () => {
 
 const getIds = links => links.map(link => link.id);
 
-lab.experiment('getMainNav', () => {
-  lab.test('It should not display any links if the user is not authenticated', async () => {
+experiment('getMainNav', () => {
+  test('It should not display any links if the user is not authenticated', async () => {
     const request = {};
     const links = getMainNav(request);
     expect(links.length).to.equal(0);
   });
 
-  lab.test('It should set the active nav link flag', async () => {
+  test('It should set the active nav link flag', async () => {
     const request = getPrimaryUserRequest();
     const links = getMainNav(request);
     const link = find(links, { id: 'view' });
     expect(link.active).to.equal(true);
   });
 
-  lab.test('Non-active links should have the active flag set to false', async () => {
+  test('Non-active links should have the active flag set to false', async () => {
     const request = getPrimaryUserRequest();
     const links = getMainNav(request);
     const flags = links.filter(link => (link.id !== 'view')).map(link => link.active);
     expect(flags).to.equal([false, false]);
   });
 
-  lab.test('It should display correct links for external user', async () => {
+  test('It should display correct links for external user', async () => {
     const request = getAuthenticatedRequest();
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view']);
   });
 
-  lab.test('It should display correct links for external primary', async () => {
+  test('It should display correct links for external primary', async () => {
     const request = getPrimaryUserRequest();
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view', 'returns', 'manage']);
   });
 
-  lab.test('It should display correct links for internal user', async () => {
+  test('It should display correct links for internal user', async () => {
     const request = getAuthenticatedRequest(true);
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view', 'notifications']);
   });
 
-  lab.test('It should display correct links for AR user', async () => {
+  test('It should display correct links for AR user', async () => {
     const request = getARUserRequest();
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view', 'ar', 'notifications']);
   });
 
-  lab.test('It should display correct links for AR approver', async () => {
+  test('It should display correct links for AR approver', async () => {
     const request = getARApproverRequest();
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view', 'ar', 'notifications']);
   });
 
-  lab.test('It should display correct links for WIRS/returns user', async () => {
+  test('It should display correct links for WIRS/returns user', async () => {
     const request = getReturnsRequest();
     const ids = getIds(getMainNav(request));
     expect(ids).to.equal(['view', 'notifications', 'returns']);
+  });
+
+  test('for a request with licence.userLicenceCount of 0, only view is added', async () => {
+    const request = getPrimaryUserRequest();
+    request.licence = { userLicenceCount: 0 };
+    const ids = getIds(getMainNav(request));
+    expect(ids).to.equal(['view']);
+  });
+
+  test('for a request with licence.userLicenceCount of 1, all tabs are added', async () => {
+    const request = getPrimaryUserRequest();
+    request.licence = { userLicenceCount: 1 };
+    const ids = getIds(getMainNav(request));
+    expect(ids).to.equal(['view', 'returns', 'manage']);
   });
 });

--- a/test/modules/add-licences/controller.js
+++ b/test/modules/add-licences/controller.js
@@ -1,0 +1,81 @@
+const { expect } = require('code');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
+
+const Hapi = require('hapi');
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const crmDocumentConnector = require('../../../src/lib/connectors/crm/documents');
+const routes = require('../../../src/modules/add-licences/routes');
+const licenceLoaderPlugin = require('../../../src/lib/hapi-plugins/licence-loader');
+const viewContextPlugin = require('../../../src/lib/hapi-plugins/view-context');
+const requestStubPlugin = require('../../lib/hapi-plugins/request-stub-plugin');
+
+const { set } = require('lodash');
+
+const getRequestSetupForAuthenticatedUser = request => {
+  set(request, 'auth.isAuthenticated', true);
+  set(request, 'auth.credentials.entity_id', '123');
+  set(request, 'state.sid', 'something');
+
+  request.permissions = {
+    admin: { defra: false },
+    returns: { submit: true, edit: true },
+    licences: { edit: true }
+  };
+};
+
+/**
+ * Creates a test server with as few dependencies as possible
+ * to allow the testing of the output view context/
+ */
+const getServer = async () => {
+  const server = Hapi.server();
+  server.decorate('toolkit', 'view', sandbox.stub().resolves('testing'));
+  await server.register([
+    {
+      plugin: requestStubPlugin,
+      options: { onPostAuth: getRequestSetupForAuthenticatedUser }
+    },
+    { plugin: licenceLoaderPlugin },
+    { plugin: viewContextPlugin }
+  ]);
+
+  server.route(Object.values(routes));
+
+  return server;
+};
+
+experiment('getSecurityCode', () => {
+  let request;
+
+  beforeEach(async () => {
+    sandbox.stub(crmDocumentConnector, 'getLicenceCount');
+    request = {
+      method: 'GET',
+      url: '/security-code'
+    };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('when the user has already got licences all main nav links are shown', async () => {
+    crmDocumentConnector.getLicenceCount.resolves(1);
+    const server = await getServer();
+    const response = await server.inject(request);
+    const mainNavLinks = response.request.view.mainNavLinks;
+    expect(mainNavLinks.length).to.equal(3);
+  });
+
+  test('when the user has no licences only the first link is shown', async () => {
+    crmDocumentConnector.getLicenceCount.resolves(0);
+    const server = await getServer();
+    const response = await server.inject(request);
+    const mainNavLinks = response.request.view.mainNavLinks;
+    expect(mainNavLinks.length).to.equal(1);
+    expect(mainNavLinks[0].id).to.equal('view');
+  });
+});

--- a/test/modules/registration/controller.js
+++ b/test/modules/registration/controller.js
@@ -2,14 +2,14 @@ const { expect } = require('code');
 const { beforeEach, experiment, test } = exports.lab = require('lab').script();
 const sinon = require('sinon');
 
-const getMinimalRequest = require('../../test-helpers');
+const testHelpers = require('../../test-helpers');
 const controller = require('../../../src/modules/registration/controller');
 
 experiment('getRegisterSuccess', () => {
   let viewContext;
 
   beforeEach(async () => {
-    const request = getMinimalRequest();
+    const request = testHelpers.getMinimalRequest();
     request.query = {
       email: 'test@example.com'
     };

--- a/test/modules/update-password/routes.js
+++ b/test/modules/update-password/routes.js
@@ -1,0 +1,25 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const routes = require('../../../src/modules/update-password/routes');
+
+experiment('getCurrentPassword', () => {
+  test('is configured to load user licence count', async () => {
+    const loaderConfig = routes.getCurrentPassword.config.plugins.licenceLoader;
+    expect(loaderConfig.loadUserLicenceCount).to.be.true();
+  });
+});
+
+experiment('postCurrentPassword', () => {
+  test('is configured to load user licence count', async () => {
+    const loaderConfig = routes.postCurrentPassword.config.plugins.licenceLoader;
+    expect(loaderConfig.loadUserLicenceCount).to.be.true();
+  });
+});
+
+experiment('postNewPassword', () => {
+  test('is configured to load user licence count', async () => {
+    const loaderConfig = routes.postNewPassword.config.plugins.licenceLoader;
+    expect(loaderConfig.loadUserLicenceCount).to.be.true();
+  });
+});

--- a/test/modules/view-licences/controller.js
+++ b/test/modules/view-licences/controller.js
@@ -1,0 +1,39 @@
+const { expect } = require('code');
+const sinon = require('sinon');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const controller = require('../../../src/modules/view-licences/controller');
+
+experiment('getLicences', () => {
+  test('redirects to security code page if no licences but outstanding verifications', async () => {
+    const request = {
+      licence: {
+        userLicenceCount: 0,
+        outstandingVerifications: [{ id: 1 }]
+      }
+    };
+
+    const h = {
+      redirect: sinon.stub().resolves('ok')
+    };
+
+    await controller.getLicences(request, h);
+    expect(h.redirect.calledWith('/security-code')).to.be.true();
+  });
+
+  test('redirects to add licences page if no licences or outstanding verifications', async () => {
+    const request = {
+      licence: {
+        userLicenceCount: 0,
+        outstandingVerifications: []
+      }
+    };
+
+    const h = {
+      redirect: sinon.stub().resolves('ok')
+    };
+
+    await controller.getLicences(request, h);
+    expect(h.redirect.calledWith('/add-licences')).to.be.true();
+  });
+});

--- a/test/modules/view-licences/routes.js
+++ b/test/modules/view-licences/routes.js
@@ -1,0 +1,16 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const routes = require('../../../src/modules/view-licences/routes');
+
+experiment('getLicences', () => {
+  test('adds config to load the user licence count', async () => {
+    const plugins = routes.getLicences.config.plugins;
+    expect(plugins.licenceLoader.loadUserLicenceCount).to.be.true();
+  });
+
+  test('adds config to load the outstanding verifications', async () => {
+    const plugins = routes.getLicences.config.plugins;
+    expect(plugins.licenceLoader.loadOutstandingVerifications).to.be.true();
+  });
+});

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -12,4 +12,6 @@ const getMinimalRequest = () => ({
   view: {}
 });
 
-module.exports = getMinimalRequest;
+module.exports = {
+  getMinimalRequest
+};


### PR DESCRIPTION
WATER-1691

Extension of previous work for external users, this time dealing with
the internal users, whose permissions are based on scopes that used to
be included in the cookie.

This meant that the sign out - sign in cycle had to be completed to see
updated roles take effect.

Introduces a new plugin that operates in the onCredentials phase where
the user is loaded and the `request.auth.credentials` object is updated
with the user's scopes.

Also updates the handlebars pagination helper to make is handle an
undefined pagination object.

Adds licence loader plugin

Allows some licence data to be added to the request before the handler
is executed. This allows common licence data to be requested to save
duplicate code in the controller functions.

Makes use of the above plugin to update the mainNav functions that
determine which links to place in the top nav bar. Now the options are
reduced for a user who has no registered licences.