### PR TITLE
Fix: Root was not redirecting based on user type

### DIFF
--- a/src/modules/core/routes.js
+++ b/src/modules/core/routes.js
@@ -8,7 +8,6 @@ module.exports = {
     path: '/',
     handler: controller.index,
     config: {
-      auth: false,
       validate: {
         query: VALID_UTM
       }


### PR DESCRIPTION
WATER-1691

After changing the roles to dynamically load the root ('/') route was
not loading the roles because authentication was set to being not
required.

By leaving auth required on this route, the user will be redirected to
the sign in page if required, else their scope/entity roles will be
loaded, allowing the correct redirect to either `/admin/licences` or
`/licences`.