### PR TITLE
Feat: Handles returns with a void status

### DIFF
--- a/src/assets/sass/blocks/_badge.scss
+++ b/src/assets/sass/blocks/_badge.scss
@@ -12,28 +12,32 @@
   letter-spacing: 1px;
   color: $page-colour;
 
-  &--error {
-    background: $error-colour;
-  }
+}
 
-  &--success {
-    background: $button-colour;
-  }
+.badge--error {
+  background: $error-colour;
+}
 
-  &--completed {
-    background: $link-colour;
-  }
+.badge--success {
+  background: $button-colour;
+}
 
+.badge--completed {
+  background: $link-colour;
+}
 
-  &--info {
-    background: #6f777b;
-  }
+.badge--void {
+  background: #b10e1e;
+}
 
-  &--caps {
-    text-transform: uppercase;
-  }
+.badge--info {
+  background: #6f777b;
+}
 
-  &--no-wrap {
-    white-space: nowrap;
-  }
+.badge--caps {
+  text-transform: uppercase;
+}
+
+.badge--no-wrap {
+  white-space: nowrap;
 }

--- a/src/modules/returns/controllers/view.js
+++ b/src/modules/returns/controllers/view.js
@@ -78,7 +78,8 @@ const getReturn = async (request, h) => {
     pageTitle: `Abstraction return for ${licenceNumber}`,
     documentHeader,
     canEdit: canEdit(request.permissions, data),
-    showVersions
+    showVersions,
+    isVoid: data.status === 'void'
   };
   return h.view('water/returns/return', view);
 };

--- a/src/views/partials/return-due-badge.html
+++ b/src/views/partials/return-due-badge.html
@@ -7,9 +7,13 @@
 {{/equal}}
 
 {{#equal status 'received'}}
-    <strong class="badge badge--completed badge--caps badge--no-wrap">Received</strong>
+  <strong class="badge badge--completed badge--caps badge--no-wrap">Received</strong>
 {{/equal}}
 
 {{#equal status 'completed'}}
-    <strong class="badge badge--completed badge--caps badge--no-wrap">Completed</strong>
+  <strong class="badge badge--completed badge--caps badge--no-wrap">Completed</strong>
+{{/equal}}
+
+{{#equal status 'void'}}
+  <strong class="badge badge--void badge--caps badge--no-wrap">Void</strong>
 {{/equal}}

--- a/src/views/water/returns/index.html
+++ b/src/views/water/returns/index.html
@@ -42,7 +42,7 @@
               </h3>
 
 
-              {{#if isReceived }}
+              {{#if isReceivedOrInternalVoid }}
               <a href="{{#if ../../isAdmin}}/admin{{/if}}/returns/return?id={{ return_id }}">
                 <span class="sr-only">View return from </span>
               {{else}}

--- a/src/views/water/returns/licence.html
+++ b/src/views/water/returns/licence.html
@@ -45,7 +45,7 @@
                 Return period
               </h4>
 
-              {{#if isReceived }}
+              {{#if isReceivedOrInternalVoid }}
               <a href="{{#if ../../isAdmin}}/admin{{/if}}/returns/return?id={{ return_id }}">
                 <span class="sr-only">View return from </span>
               {{else}}

--- a/src/views/water/returns/return.html
+++ b/src/views/water/returns/return.html
@@ -27,61 +27,61 @@
 
   {{>return-header}}
 
-
-  {{# if return.isNil }}
-    <h2 class="heading-large">Nil return</h2>
+  {{# if isVoid }}
+    <h2 class="heading-large">This return has been made void</h2>
   {{else}}
-    <h2 class="heading-medium">Abstraction volumes</h2>
-  {{/if}}
 
-  {{#if canEdit }}
-  <a class="button" href="/admin/return/internal?returnId={{ return.returnId }}">Edit return</a>
-  <br />
-  <br />
-  {{/if}}
+    {{# if return.isNil }}
+      <h2 class="heading-large">Nil return</h2>
+    {{else}}
+      <h2 class="heading-medium">Abstraction volumes</h2>
+    {{/if}}
 
-  {{#ifNot isAdmin }}
+    {{#if canEdit }}
+    <a class="button" href="/admin/return/internal?returnId={{ return.returnId }}">Edit return</a>
+    <br />
+    <br />
+    {{/if}}
 
-  <details role="group">
-    <summary role="button" aria-controls="details-content-0" aria-expanded="false"><span class="summary">Do you need to make a change to a submitted return?</span></summary>
-    <div id="details-content-0" aria-hidden="true">
-        {{>contact-details}}
-    </div>
-  </details>
+    {{#ifNot isAdmin }}
 
-  {{/ifNot}}
+      <details role="group">
+        <summary role="button" aria-controls="details-content-0" aria-expanded="false"><span class="summary">Do you need to make a change to a submitted return?</span></summary>
+        <div id="details-content-0" aria-hidden="true">
+            {{>contact-details}}
+        </div>
+      </details>
 
-  {{#ifNot return.isNil }}
-    {{>return-quantities-table }}
-  {{/ifNot}}
+    {{/ifNot}}
 
+    {{#ifNot return.isNil }}
+      {{>return-quantities-table }}
+    {{/ifNot}}
 
+    {{#if showVersions }}
 
-  {{#if showVersions }}
+      <br /><br />
+      <h3 class="heading-medium">Submitted by</h3>
 
-    <br /><br />
-    <h3 class="heading-medium">Submitted by</h3>
-
-    {{#eachReverse return.versions }}
-
-      {{#equal versionNumber ../return.versionNumber }}
-          <div class="panel panel-border-wide this-version version clickable">
-            <p class="version spaceless selected clickable">
-              <span class="sr-only">This version</span>
-              {{ email }}<br>
-              {{ formatISODate createdAt }}<br>
-            </p>
-          </div>
-      {{else}}
-      <div class="version clickable">
-              <p class="spaceless">
+      {{#eachReverse return.versions }}
+        {{#equal versionNumber ../return.versionNumber }}
+            <div class="panel panel-border-wide this-version version clickable">
+              <p class="version spaceless selected clickable">
+                <span class="sr-only">This version</span>
                 {{ email }}<br>
-                <a href="{{#if ../isAdmin}}/admin{{/if}}/returns/return?id={{ ../return.returnId }}&amp;version={{ versionNumber }}">{{ formatISODate createdAt }}</a><br>
+                {{ formatISODate createdAt }}<br>
               </p>
             </div>
-      {{/equal}}
-
-    {{/eachReverse}}
+        {{else}}
+        <div class="version clickable">
+                <p class="spaceless">
+                  {{ email }}<br>
+                  <a href="{{#if ../isAdmin}}/admin{{/if}}/returns/return?id={{ ../return.returnId }}&amp;version={{ versionNumber }}">{{ formatISODate createdAt }}</a><br>
+                </p>
+              </div>
+        {{/equal}}
+      {{/eachReverse}}
+    {{/if}}
   {{/if}}
 
 </main>

--- a/test/modules/returns/lib/helpers.js
+++ b/test/modules/returns/lib/helpers.js
@@ -2,8 +2,12 @@
 const moment = require('moment');
 const { expect } = require('code');
 const Lab = require('lab');
-const { experiment, test } = exports.lab = Lab.script();
+const { beforeEach, afterEach, experiment, test } = exports.lab = Lab.script();
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { get } = require('lodash');
 
+const returnsConnector = require('../../../../src/lib/connectors/returns').returns;
 const helpers = require('../../../../src/modules/returns/lib/helpers');
 const config = require('../../../../config');
 
@@ -162,5 +166,83 @@ experiment('isReturnId', () => {
 
   test('returns false for other strings', async () => {
     expect(helpers.isReturnId('01/1234/56/78')).to.equal(false);
+  });
+});
+
+experiment('getLicenceReturns', () => {
+  beforeEach(async () => {
+    sandbox.stub(returnsConnector, 'findMany').resolves({
+      data: {},
+      error: null,
+      pagination: {}
+    });
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('does not filter void returns for internal users', async () => {
+    await helpers.getLicenceReturns([], 1, true);
+    const filter = returnsConnector.findMany.args[0][0];
+    expect(get(filter, 'status.$ne')).to.be.undefined();
+  });
+
+  test('omits void returns for external users', async () => {
+    await helpers.getLicenceReturns([], 1, false);
+    const filter = returnsConnector.findMany.args[0][0];
+    expect(get(filter, 'status.$ne')).to.equal('void');
+  });
+});
+
+experiment('addFlags', () => {
+  test('isReceivedOrInternalVoid = true if return is recieved and completed', async () => {
+    const returns = [{ received_date: '2018-01-01', status: 'completed' }];
+    const request = {
+      permissions: {
+        admin: { defra: true },
+        returns: { submit: true, edit: true }
+      }
+    };
+    const modified = helpers.addFlags(returns, request);
+    expect(modified[0].isReceivedOrInternalVoid).to.be.true();
+    expect(modified[0].isClickable).to.be.true();
+  });
+
+  test('isReceivedOrInternalVoid = false if return status is due', async () => {
+    const returns = [{ status: 'due' }];
+    const request = {
+      permissions: {
+        admin: { defra: true },
+        returns: { submit: true, edit: true }
+      }
+    };
+    const modified = helpers.addFlags(returns, request);
+    expect(modified[0].isReceivedOrInternalVoid).to.be.false();
+  });
+
+  test('isReceivedOrInternalVoid = true if return status is void and user is internal', async () => {
+    const returns = [{ status: 'void' }];
+    const request = {
+      permissions: {
+        admin: { defra: true },
+        returns: { submit: true, edit: true }
+      }
+    };
+    const modified = helpers.addFlags(returns, request);
+    expect(modified[0].isReceivedOrInternalVoid).to.be.true();
+    expect(modified[0].isClickable).to.be.true();
+  });
+
+  test('isReceivedOrInternalVoid = false if return status is void and user is external', async () => {
+    const returns = [{ status: 'void' }];
+    const request = {
+      permissions: {
+        admin: { defra: false },
+        returns: { submit: true, edit: true }
+      }
+    };
+    const modified = helpers.addFlags(returns, request);
+    expect(modified[0].isReceivedOrInternalVoid).to.be.false();
   });
 });


### PR DESCRIPTION
WATER-1805

Internal user changes:

 - Show void returns in returns list, with new void colour
 - Show that a return is void in the return detail page.

External user changes:

 - Void returns are hidden completely.
 - Attempting to access a void return redirects user away (no code
required for this)