### PR TITLE
Fix: Fixes badge styles

### DIFF
--- a/src/assets/sass/blocks/_badge.scss
+++ b/src/assets/sass/blocks/_badge.scss
@@ -1,5 +1,4 @@
 .badge {
-
   min-width: 4rem;
   line-height: 2.25rem;
   display: inline-block;
@@ -8,10 +7,10 @@
   font-weight: bold;
   font-size: 16px;
   padding: 3px 5px 0 5px;
-  background: $grey-4;
+  background: #005ea5;
   letter-spacing: 1px;
   color: $page-colour;
-
+  text-transform: uppercase;
 }
 
 .badge--error {
@@ -26,6 +25,10 @@
   background: $link-colour;
 }
 
+.badge--due {
+  background: #f47738;
+}
+
 .badge--void {
   background: #b10e1e;
 }
@@ -35,7 +38,6 @@
 }
 
 .badge--caps {
-  text-transform: uppercase;
 }
 
 .badge--no-wrap {

--- a/src/modules/notifications-reports/controller.js
+++ b/src/modules/notifications-reports/controller.js
@@ -37,7 +37,6 @@ async function getNotificationsList (request, reply) {
  */
 async function getNotification (request, reply) {
   const { id } = request.params;
-  const { sort, direction } = request.query;
 
   // Load event
   const { error, data: event } = await events.findOne(id);

--- a/src/modules/notifications-reports/routes.js
+++ b/src/modules/notifications-reports/routes.js
@@ -22,7 +22,6 @@ module.exports = {
       },
       plugins: {
         viewContext: {
-          activeNavLink: 'reports',
           pageTitle: 'Notification report',
           activeNavLink: 'notifications'
         }

--- a/src/views/partials/notify-status-badge.html
+++ b/src/views/partials/notify-status-badge.html
@@ -1,50 +1,33 @@
 {{#if this}}
 
   {{#equal this 'sending'}}
-  <span class="badge">
-  Pending
-  </span>
+  <span class="badge">Pending</span>
   {{/equal}}
 
   {{#equal this 'accepted'}}
-  <span class="badge">
-  Pending
-  </span>
+  <span class="badge">Pending</span>
   {{/equal}}
 
   {{#equal this 'received'}}
-  <span class="badge">
-  Sent
-  </span>
+  <span class="badge">Sent</span>
   {{/equal}}
 
   {{#equal this 'delivered'}}
-  <span class="badge">
-  Sent
-  </span>
+  <span class="badge">Sent</span>
   {{/equal}}
 
   {{#equal this 'permanent-failure'}}
-  <span class="badge badge--error">
-  Error
-  </span>
+  <span class="badge badge--error">Error</span>
   {{/equal}}
 
   {{#equal this 'temporary-failure'}}
-  <span class="badge badge--error">
-  Error
-  </span>
+  <span class="badge badge--error">Error</span>
   {{/equal}}
 
-
   {{#equal this 'technical-failure'}}
-  <span class="badge badge--error">
-  Error
-  </span>
+  <span class="badge badge--error">Error</span>
   {{/equal}}
 
 {{ else }}
-<span class="badge">
-Pending
-</span>
+  <span class="badge">Pending</span>
 {{/if}}

--- a/src/views/partials/return-due-badge.html
+++ b/src/views/partials/return-due-badge.html
@@ -1,19 +1,19 @@
 {{# equal status 'due' }}
   {{#if isPastDueDate}}
-    <strong class="badge badge--success badge--caps badge--no-wrap">Overdue</strong>
+    <strong class="badge badge--due badge--no-wrap">Overdue</strong>
   {{else}}
-    <strong class="badge badge--success badge--caps badge--no-wrap">Due</strong>
+    <strong class="badge badge--due badge--no-wrap">Due</strong>
   {{/if}}
 {{/equal}}
 
 {{#equal status 'received'}}
-  <strong class="badge badge--completed badge--caps badge--no-wrap">Received</strong>
+  <strong class="badge badge--completed badge--no-wrap">Received</strong>
 {{/equal}}
 
 {{#equal status 'completed'}}
-  <strong class="badge badge--completed badge--caps badge--no-wrap">Completed</strong>
+  <strong class="badge badge--completed badge--no-wrap">Completed</strong>
 {{/equal}}
 
 {{#equal status 'void'}}
-  <strong class="badge badge--void badge--caps badge--no-wrap">Void</strong>
+  <strong class="badge badge--void badge--no-wrap">Void</strong>
 {{/equal}}


### PR DESCRIPTION

WATER-1858

Changes the CSS so that the `badge` class uses the inherited color for
text, which is then made white when a background is requested via a
modifier class.


After:

![screenshot 2019-01-22 at 17 36 00](https://user-images.githubusercontent.com/885922/51600109-27818380-1ef9-11e9-98d0-5e9d847d4aec.png)

Before:

![screenshot 2019-01-23 at 10 23 59](https://user-images.githubusercontent.com/885922/51600080-1769a400-1ef9-11e9-94b3-0220a8394d59.png)
