### PR TITLE
Feat: Adds registered user to licence detail page

### DIFF
--- a/src/assets/sass/application.scss
+++ b/src/assets/sass/application.scss
@@ -61,7 +61,6 @@ family: "nta", Arial, sans-serif;
   }
 }
 
-
 .panel {
   border-top: none;
 }
@@ -73,15 +72,6 @@ family: "nta", Arial, sans-serif;
   @media screen and (min-width: 641px) {
     width : 66%;
   }
-}
-
-
-.teststyle {
-  color: green;
-}
-
-.arbitraryStyle {
-  padding: 2px;
 }
 
 // Related items
@@ -137,21 +127,14 @@ family: "nta", Arial, sans-serif;
   }
 }
 
-.govuk-related-items {
-  margin-top: $gutter;
-  border-top: 10px solid $govuk-blue;
-  padding-top: 5px;
-}
-
 .heading-medium {
   margin-top: 0.3em;
   margin-bottom: 0.5em;
 }
 
 .medium-space {
-    margin-bottom: 30px;
+  margin-bottom: 30px;
 }
-
 
 li {
   margin-bottom: 10px;
@@ -166,59 +149,6 @@ li {
   font-weight: bold;
 }
 
-.sourceofsupplyqs {
-  display: inline-block;
-  vertical-align: top;
-  padding-bottom: 0;
-  padding-top: 5px;
-  padding-right: 0.25em;
-  width: 20%;
-}
-
-.sourceofsupplyqstop {
-  display: inline-block;
-  vertical-align: top;
-  padding-bottom: 0;
-  padding-top: 10px;
-  padding-right: 0.25em;
-  width: 20%;
-}
-
-.licenceLabel {
-  display: inline-block;
-  vertical-align: top;
-  padding-bottom: 7px;
-  padding-right: 0.25em;
-  width: 20%;
-}
-
-.address {
-  width: 100%;
-  padding-bottom: 10px;
-  padding-top: 20px;
-  border-bottom: 1px solid #bfc1c3;
-}
-
-.siteaddress {
-  padding-bottom: 10px;
-  padding-top: 20px;
-  border-bottom: 1px solid #bfc1c3;
-  border-top: 1px solid #bfc1c3;
-}
-
-.sourceofsupplya {
-  display: inline-block;
-  width: 50%;
-  padding-left: 1em;
-}
-
-.sourceofsupplyatop {
-  display: inline-block;
-  width: 50%;
-  padding-bottom: 7px;
-  padding-left: 1em;
-}
-
 .licenceAnswer {
   display: inline-block;
   width: 50%;
@@ -226,60 +156,11 @@ li {
   padding-left: 3em;
 }
 
-.licenceAnswers {
-  display: inline-block;
-  width: 50%;
-  padding-bottom: 0;
-  padding-top: 5px;
-  padding-left: 1em;
-}
-
-.licenceAnswerstop {
-  display: inline-block;
-  width: 50%;
-  padding-bottom: 0;
-  padding-top: 10px;
-  padding-left: 1em;
-}
-
 .name {
   display: inline-block;
   width: 50%;
   padding-bottom: 7px;
   padding-left: 0.5em;
-}
-
-.data-table {
-  border-top: 1px solid #bfc1c3;
-  padding-top: 0.5em;
-}
-
-.list-link {
-  background-color: #FFF;
-  cursor: pointer;
-  padding-left: 0;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  width: 100%;
-  text-align: left;
-  border-top: 1px solid #bfc1c3;
-  transition: 0.4s;
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  font-size: 1.25em;
-  line-height: 1.25;
-  display: block;
-  margin-bottom:3px
-}
-
-.list-link:hover {
-  background-color: #F8F8F8;
-}
-
-.licence-title {
-  display: inline-block;
-  padding-bottom: 7px;
-  font-weight: bold;
 }
 
 .header-links {
@@ -294,79 +175,9 @@ li {
     }
 }
 
-.openall {
-  float: right;
-  padding-bottom: 0;
-}
-
-.check-all-contact-details {
-  font-size: 0.85em;
-}
-
 img {
   max-width: 100%;
   height: auto;
-}
-
-.maplist {
-  padding: 0 0 30px 21px;
-  line-height: 20px;
-}
-
-.licenceno {
-  padding: 0 0 20px;
-}
-
-.licenceholder {
-  padding: 0 0 7px;
-}
-
-.abstractionperiod {
-  padding: 5px 0 7px;
-}
-
-.abstractionpoint {
-  padding: 5px 0 7px;
-}
-
-.abstractionamount {
-  padding: 5px 0 0;
-}
-
-.handsoff {
-  padding: 5px 0 10px;
-}
-
-.hour {
-  padding: 0 0 0 237px;
-}
-
-.day {
-  padding: 0 0 5px 237px;
-}
-
-.smallprint {
-  font-size: 0.95em;
-  padding: 20px;
-}
-/* Style the buttons that are used to open and close the accordion panel */
-a.accordion,
-button.accordion {
-  background-color: #FFF;
-  color: #005ea5;
-  cursor: pointer;
-  padding-left: 0;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  width: 100%;
-  text-align: left;
-  border: none;
-  outline: none;
-  transition: 0.4s;
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  font-size: 1.25em;
-  line-height: 1.25;
 }
 
 a.accordion {
@@ -378,26 +189,6 @@ a.accordion:hover,
 button.accordion.active,
 button.accordion:hover {
   background-color: #F8F8F8;
-}
-
-div.grey_line {
-  border-top: 1px solid #bfc1c3;
-}
-
-div.grey_line_bottomh3 {
-  border-bottom: 1px solid #bfc1c3;
-  padding-bottom: 0;
-}
-
-div.grey_line_bottom {
-  border-top: 1px solid #bfc1c3;
-  border-bottom: 1px solid #bfc1c3;
-}
-/* Style the accordion panel. Note: hidden by default */
-div.white_panel {
-  padding: 30px 0 20px;
-  background-color: white;
-  display: none;
 }
 
 a.accordion:after,
@@ -418,23 +209,11 @@ button.accordion.active:after {
   /* Unicode character for "minus" sign (-) */
 }
 
-.sign-out2 {
-float: right;
-font-size: 0.875em;
-line-height: 1.14286;
-margin-left: 0.75em;
-}
-
-/* inline buttons - designed to be used next to input field */
-.button-inline {
-  line-height: 1.15;
-}
-
-
 /* hidden/shown utility classes */
 .hide {
   display: none;
 }
+
 .hide-js {
   display: block;
 
@@ -442,13 +221,13 @@ margin-left: 0.75em;
     display: none;
   }
 }
+
 .show-js {
   display: none;
   body.js-enabled & {
     display: block;
   }
 }
-
 
 // Tab nav
 nav.tabs {

--- a/src/lib/connectors/crm/document-verification.js
+++ b/src/lib/connectors/crm/document-verification.js
@@ -2,13 +2,9 @@
  * Creates a client connector for the CRM verification API endpoint
  * @module lib/connectors/crm-verification
  */
-const {
-  APIClient
-} = require('@envage/hapi-pg-rest-api');
-const rp = require('request-promise-native').defaults({
-  proxy: null,
-  strictSSL: false
-});
+const { APIClient } = require('@envage/hapi-pg-rest-api');
+const rp = require('request-promise-native').defaults({ proxy: null, strictSSL: false });
+const serviceRequest = require('../service-request');
 
 // Create API client
 const client = new APIClient(rp, {
@@ -19,14 +15,19 @@ const client = new APIClient(rp, {
 });
 
 /**
- * Get outstanding verifications for the supplied entityId
- * @param {String} document_id - the document id
- * @return {Promise} resolves with list of verifications
+ * Get outstanding verifications for the supplied document id
  */
-client.getDocumentVerifications = function (document_id) {
-  return client.findMany({
-    document_id: document_id
-  });
+client.getDocumentVerifications = documentId => {
+  const url = `${process.env.CRM_URI}/document_verifications`;
+
+  const qs = {
+    filter: JSON.stringify({
+      document_id: documentId,
+      'verification.date_verified': null
+    })
+  };
+
+  return serviceRequest.get(url, { qs });
 };
 
 module.exports = client;

--- a/src/lib/connectors/service-request.js
+++ b/src/lib/connectors/service-request.js
@@ -1,0 +1,24 @@
+/**
+ * Abstraction over request-promise-native for making requests to
+ * downstream services that are always JSON content type and
+ * always pass a JWT auth header.
+ */
+const rp = require('request-promise-native').defaults({
+  proxy: null,
+  strictSSL: false
+});
+
+module.exports = {
+  get: (url, additionalOptions = {}) => {
+    const options = Object.assign({
+      url,
+      method: 'GET',
+      json: true,
+      headers: {
+        Authorization: process.env.JWT_TOKEN
+      }
+    }, additionalOptions);
+
+    return rp(options);
+  }
+};

--- a/src/lib/connectors/water-service/licences.js
+++ b/src/lib/connectors/water-service/licences.js
@@ -1,26 +1,39 @@
-const rp = require('request-promise-native').defaults({ proxy: null, strictSSL: false });
+const serviceRequest = require('../service-request');
+const { partialRight } = require('lodash');
 
 const get = (documentId, tail) => {
-  const url = `${process.env.WATER_URI}/documents/${documentId}/licence`;
-  const options = {
-    method: 'GET',
-    uri: tail ? `${url}/${tail}` : url,
-    headers: {
-      Authorization: process.env.JWT_TOKEN
-    },
-    json: true
-  };
-  return rp(options);
+  const baseUrl = `${process.env.WATER_URI}/documents/${documentId}/licence`;
+  const url = tail ? `${baseUrl}/${tail}` : baseUrl;
+  return serviceRequest.get(url);
 };
 
 const getLicenceByDocumentId = documentId => get(documentId);
 
-const getLicenceConditionsByDocumentId = documentId => get(documentId, 'conditions');
+const getLicenceConditionsByDocumentId = partialRight(get, 'conditions');
 
-const getLicencePointsByDocumentId = documentId => get(documentId, 'points');
+const getLicencePointsByDocumentId = partialRight(get, 'points');
+
+const getLicenceUsersByDocumentId = partialRight(get, 'users');
+
+const getLicencePrimaryUserByDocumentId = async documentId => {
+  try {
+    const userResponse = await getLicenceUsersByDocumentId(documentId);
+
+    if (!userResponse.error) {
+      const users = userResponse.data || [];
+      return users.find(user => user.roles.includes('primary_user'));
+    }
+  } catch (error) {
+    if (error.statusCode !== 404) {
+      throw error;
+    }
+  }
+};
 
 module.exports = {
   getLicenceByDocumentId,
   getLicenceConditionsByDocumentId,
-  getLicencePointsByDocumentId
+  getLicencePointsByDocumentId,
+  getLicenceUsersByDocumentId,
+  getLicencePrimaryUserByDocumentId
 };

--- a/src/views/water/view-licences/licence.html
+++ b/src/views/water/view-licences/licence.html
@@ -5,21 +5,15 @@
 {{#if isAdmin }}
   {{#unless crmData.company_entity_id}}
     {{#if crmData.verifications}}
-    <div class="grid-row">
-        <div class="column-two-thirds">
-            <div class="panel panel-border-wide alert-default big-space">
-              {{#equal crmData.verifications.length 1}}
-              We have sent a security code by post.
+      <div class="grid-row">
+        <div class="column-full">
+          <div class="panel panel-border-wide alert-default">
+            We have sent {{crmData.verifications.length}} security code{{#notEqual crmData.verifications.length  1}}s{{/notEqual}} by post.
+            <ul>
               {{#each crmData.verifications }}
-                <br>The code is <strong class="bold-small">{{verification_code}}</strong>
+                <li class="spaceless">{{entity_nm}} - <strong class="bold-small">{{verification_code}}</strong></li>
               {{/each}}
-
-              {{else}}
-              We have sent {{crmData.verifications.length}} security codes by post
-              {{#each crmData.verifications }}
-                <br>{{entity_nm}} - <strong class="bold-small">{{verification_code}}</strong>
-              {{/each}}
-              {{/equal}}
+            </ul>
         </div>
       </div>
     </div>
@@ -27,13 +21,29 @@
   {{/unless}}
 {{/if}}
 
-  {{#if crmData.document_name }}
   <h1 class="heading-large">
-    <span class="heading-secondary">Licence number {{ licenceData.licenceNumber }}</span>
-    {{ crmData.document_name }}
+    {{#if crmData.document_name }}
+      <span class="heading-secondary">Licence number {{ licenceData.licenceNumber }}</span>
+      {{ crmData.document_name }}
+    {{else}}
+      {{#if isAdmin }}
+        {{#unless primaryUser }}
+          <span class="heading-secondary">Unregistered licence</span>
+        {{/unless}}
+      {{/if}}
+      Licence number {{ licenceData.licenceNumber }}
+    {{/if}}
   </h1>
-  {{else}}
-  <h1 class="heading-large">Licence number {{ licenceData.licenceNumber }}</h1>
+
+  {{#if isAdmin }}
+    {{#if primaryUser }}
+      <p class="govuk-body">
+        Registered to&nbsp;
+        <a href="/admin/user/{{primaryUser.userId}}/status" class="govuk-link">
+          {{primaryUser.userName}}
+        </a>
+      </p>
+    {{/if}}
   {{/if}}
 
   <p>Current licence version started on {{ formatDate licenceData.currentVersionEffectiveStartDate }}
@@ -48,7 +58,6 @@
   <div class="data-row">
     <div class="data-row__param">Licence name</div>
     <div class="data-row__value">
-
 
       <!-- Current licence name -->
       {{#if crmData.document_name }}
@@ -65,11 +74,8 @@
     </div>
   </div>
 
-
   {{>licence-details }}
-
 
 </main>
 {{> footerjs}}
-
 {{> debug}}

--- a/test/lib/connectors/crm/document-verification.js
+++ b/test/lib/connectors/crm/document-verification.js
@@ -1,0 +1,35 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { expect } = require('code');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
+
+const serviceRequest = require('../../../../src/lib/connectors/service-request');
+const crmConnector = require('../../../../src/lib/connectors/crm/document-verification');
+
+experiment('getDocumentVerifications', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await crmConnector.getDocumentVerifications('test-id');
+    const expectedUrl = `${process.env.CRM_URI}/document_verifications`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+
+  test('passes the expected filter query to the request', async () => {
+    await crmConnector.getDocumentVerifications('test-id');
+    const [, options] = serviceRequest.get.lastCall.args;
+    const filter = JSON.parse(options.qs.filter);
+    expect(filter).to.equal({
+      document_id: 'test-id',
+      'verification.date_verified': null
+    });
+  });
+});

--- a/test/lib/connectors/water-service/licences.js
+++ b/test/lib/connectors/water-service/licences.js
@@ -1,0 +1,114 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { expect } = require('code');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
+
+const serviceRequest = require('../../../../src/lib/connectors/service-request');
+const licencesConnector = require('../../../../src/lib/connectors/water-service/licences');
+
+const userResponses = require('../../../responses/water-service/documents/_documentId_/licence/users');
+
+experiment('getLicenceByDocumentId', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await licencesConnector.getLicenceByDocumentId('test-id');
+    const expectedUrl = `${process.env.WATER_URI}/documents/test-id/licence`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+});
+
+experiment('getLicenceUsersByDocumentId', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await licencesConnector.getLicenceUsersByDocumentId('test-id');
+    const expectedUrl = `${process.env.WATER_URI}/documents/test-id/licence/users`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+});
+
+experiment('getLicencePointsByDocumentId', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await licencesConnector.getLicencePointsByDocumentId('test-id');
+    const expectedUrl = `${process.env.WATER_URI}/documents/test-id/licence/points`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+});
+
+experiment('getLicenceConditionsByDocumentId', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await licencesConnector.getLicenceConditionsByDocumentId('test-id');
+    const expectedUrl = `${process.env.WATER_URI}/documents/test-id/licence/conditions`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+});
+
+experiment('getLicencePrimaryUserByDocumentId', async () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('returns undefined when the document is not found', async () => {
+    serviceRequest.get.resolves(userResponses.notFound());
+    const user = await licencesConnector.getLicencePrimaryUserByDocumentId('test-id');
+
+    expect(user).to.be.undefined();
+  });
+
+  test('returns undefined when there is not primary user', async () => {
+    serviceRequest.get.resolves(userResponses.multipleUsersExcludingPrimaryUser());
+    const user = await licencesConnector.getLicencePrimaryUserByDocumentId('test-id');
+
+    expect(user).to.be.undefined();
+  });
+
+  test('returns the expected user when there is a primary user', async () => {
+    serviceRequest.get.resolves(userResponses.multipleUsersIncludingPrimaryUser());
+    const user = await licencesConnector.getLicencePrimaryUserByDocumentId('test-id');
+
+    expect(user).to.be.equal({
+      userId: 4444,
+      entityId: '44444444-0000-0000-0000-000000000000',
+      userName: 'test4@example.com',
+      roles: ['primary_user']
+    });
+  });
+});

--- a/test/responses/water-service/documents/_documentId_/licence/users/index.js
+++ b/test/responses/water-service/documents/_documentId_/licence/users/index.js
@@ -1,0 +1,65 @@
+const multipleUsersIncludingPrimaryUser = () => ({
+  error: null,
+  data: [
+    {
+      userId: 1111,
+      entityId: '11111111-0000-0000-0000-000000000000',
+      userName: 'test1@example.com',
+      roles: ['user']
+    },
+    {
+      userId: 2222,
+      entityId: '22222222-0000-0000-0000-000000000000',
+      userName: 'test2@example.com',
+      roles: ['user', 'user_returns']
+    },
+    {
+      userId: 3333,
+      entityId: '33333333-0000-0000-0000-000000000000',
+      userName: 'test3@example.com',
+      roles: ['user', 'user_returns']
+    },
+    {
+      userId: 4444,
+      entityId: '44444444-0000-0000-0000-000000000000',
+      userName: 'test4@example.com',
+      roles: ['primary_user']
+    }
+  ]
+});
+
+const multipleUsersExcludingPrimaryUser = () => ({
+  error: null,
+  data: [
+    {
+      userId: 1111,
+      entityId: '11111111-0000-0000-0000-000000000000',
+      userName: 'test1@example.com',
+      roles: ['user']
+    },
+    {
+      userId: 2222,
+      entityId: '22222222-0000-0000-0000-000000000000',
+      userName: 'test2@example.com',
+      roles: ['user', 'user_returns']
+    },
+    {
+      userId: 3333,
+      entityId: '33333333-0000-0000-0000-000000000000',
+      userName: 'test3@example.com',
+      roles: ['user', 'user_returns']
+    }
+  ]
+});
+
+const notFound = () => ({
+  statusCode: 404,
+  error: 'Not Found',
+  message: 'Not found'
+});
+
+module.exports = {
+  multipleUsersIncludingPrimaryUser,
+  multipleUsersExcludingPrimaryUser,
+  notFound
+};

--- a/test/responses/water-service/user/_userId_/status/index.js
+++ b/test/responses/water-service/user/_userId_/status/index.js
@@ -1,4 +1,4 @@
-const externalUserWithLicences = {
+const externalUserWithLicences = () => ({
   data: {
     user: {
       isLocked: true,
@@ -54,9 +54,9 @@ const externalUserWithLicences = {
     ]
   },
   error: null
-};
+});
 
-const externalUserWithoutLicences = {
+const externalUserWithoutLicences = () => ({
   data: {
     user: {
       isLocked: true,
@@ -67,9 +67,9 @@ const externalUserWithoutLicences = {
     companies: []
   },
   error: null
-};
+});
 
 module.exports = {
-  externalUserWithLicences: () => externalUserWithLicences,
-  externalUserWithoutLicences: () => externalUserWithoutLicences
+  externalUserWithLicences,
+  externalUserWithoutLicences
 };


### PR DESCRIPTION
WATER-1833

If the user is an admin, changes the licence detail page to show that a
licence is either unregistered, or who the licence is registered to.

 - Adds the user name to the licence page if the licence has a primary
user.
 - Updates the security code display to show the recipient address if a
verification code has been sent.
 - Remove some unused CSS classes.