### PR TITLE
Fix: User status page visual bugs

### DIFF
--- a/src/assets/sass/v2/application.scss
+++ b/src/assets/sass/v2/application.scss
@@ -12,3 +12,4 @@ $govuk-global-styles: true;
 @import "blocks/link";
 @import "blocks/phone";
 @import "blocks/search";
+@import "blocks/text";

--- a/src/assets/sass/v2/blocks/_text.scss
+++ b/src/assets/sass/v2/blocks/_text.scss
@@ -1,0 +1,3 @@
+.break-word {
+  overflow-wrap: break-word;
+}

--- a/src/views/nunjucks/internal-search/macros/company-licences.njk
+++ b/src/views/nunjucks/internal-search/macros/company-licences.njk
@@ -1,9 +1,10 @@
 {% from "details-when.njk" import detailsWhen %}
+{% from "pluralise.njk" import pluralise %}
 
 {% macro companyLicences(licences) %}
   {% if licences.length > 0 %}
     <h3 class="govuk-heading-m govuk-!-margin-0">
-      {{ licences | length }} licences
+      {{ licences | length }} {{ pluralise(licences, 'licence', 'licences') }}
     </h3>
     {% call detailsWhen(licences.length, 5, 'View licences') -%}
       <table class="govuk-table">

--- a/src/views/nunjucks/internal-search/macros/user-details.njk
+++ b/src/views/nunjucks/internal-search/macros/user-details.njk
@@ -1,7 +1,7 @@
 {% macro userDetails(user) %}
 
   <div class="govuk-caption-l">{{ "Internal" if user.isInternal else "External" }}</div> 
-  <h1 class="govuk-heading-xl govuk-!-margin-0">{{user.userName}}</h1>
+  <h1 class="govuk-heading-xl govuk-!-margin-0 break-word">{{user.userName}}</h1>
 
   <p class="heading-small">
     {% if user.lastLogin %}

--- a/src/views/nunjucks/macros/pluralise.njk
+++ b/src/views/nunjucks/macros/pluralise.njk
@@ -1,0 +1,3 @@
+{% macro pluralise(collection, singular, plural) %}
+  {{ singular if collection.length === 1 else plural }}
+{% endmacro %}


### PR DESCRIPTION
WATER-1833

 - Use proper plurals for licence and licences in the user status page
 - Allow email addresses to overflow onto the next line because they can
be too long for a single line in mobile view.