### PR TITLE
Feat: Adds a communication viewer page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5485,17 +5485,27 @@
         "accept": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-          "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg=="
+          "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x"
+          }
         },
         "ammo": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-          "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ=="
+          "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         },
         "b64": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
-          "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ=="
+          "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         },
         "big-time": {
           "version": "2.0.1",
@@ -5505,12 +5515,19 @@
         "boom": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
-          "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A=="
+          "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         },
         "bounce": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.2.tgz",
-          "integrity": "sha512-1LPcXg3fkGVhjdA/P3DcR5cDktKEYtDpruJv9Nhmy36RoYaoxZfC82Zr2JmS3vysDJKqMtP0qJw3/P6iisTASg=="
+          "integrity": "sha512-1LPcXg3fkGVhjdA/P3DcR5cDktKEYtDpruJv9Nhmy36RoYaoxZfC82Zr2JmS3vysDJKqMtP0qJw3/P6iisTASg==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x"
+          }
         },
         "bourne": {
           "version": "1.0.0",
@@ -5520,32 +5537,57 @@
         "call": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/call/-/call-5.0.3.tgz",
-          "integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg=="
+          "integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x"
+          }
         },
         "catbox": {
           "version": "10.0.5",
           "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.5.tgz",
-          "integrity": "sha512-5SpI/tEP3SiLE1qkkV+/hdVW48sHVBEbzPX4jBiwl6hsZh/gkl4bqfGLkvh7mjpMK5evJ0Rm/6NRlhF/Jsy9ow=="
+          "integrity": "sha512-5SpI/tEP3SiLE1qkkV+/hdVW48sHVBEbzPX4jBiwl6hsZh/gkl4bqfGLkvh7mjpMK5evJ0Rm/6NRlhF/Jsy9ow==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x",
+            "joi": "14.x.x"
+          }
         },
         "catbox-memory": {
           "version": "3.1.4",
           "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.4.tgz",
-          "integrity": "sha512-1tDnll066au0HXBSDHS/YQ34MQ2omBsmnA9g/jseyq/M3m7UPrajVtPDZK/rXgikSC1dfjo9Pa+kQ1qcyG2d3g=="
+          "integrity": "sha512-1tDnll066au0HXBSDHS/YQ34MQ2omBsmnA9g/jseyq/M3m7UPrajVtPDZK/rXgikSC1dfjo9Pa+kQ1qcyG2d3g==",
+          "requires": {
+            "big-time": "2.x.x",
+            "boom": "7.x.x",
+            "hoek": "6.x.x"
+          }
         },
         "content": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
-          "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA=="
+          "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
+          "requires": {
+            "boom": "7.x.x"
+          }
         },
         "cryptiles": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw=="
+          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
+          "requires": {
+            "boom": "7.x.x"
+          }
         },
         "heavy": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
-          "integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg=="
+          "integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x",
+            "joi": "14.x.x"
+          }
         },
         "hoek": {
           "version": "6.0.1",
@@ -5555,12 +5597,31 @@
         "iron": {
           "version": "5.0.6",
           "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw=="
+          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
+          "requires": {
+            "b64": "4.x.x",
+            "boom": "7.x.x",
+            "cryptiles": "4.x.x",
+            "hoek": "6.x.x"
+          }
+        },
+        "isemail": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "requires": {
+            "punycode": "2.x.x"
+          }
         },
         "joi": {
           "version": "14.0.4",
           "resolved": "https://registry.npmjs.org/joi/-/joi-14.0.4.tgz",
-          "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ=="
+          "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
+          "requires": {
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
         },
         "mime-db": {
           "version": "1.37.0",
@@ -5570,32 +5631,64 @@
         "mimos": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.2.tgz",
-          "integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA=="
+          "integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA==",
+          "requires": {
+            "hoek": "6.x.x",
+            "mime-db": "1.x.x"
+          }
         },
         "nigel": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-          "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ=="
+          "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
+          "requires": {
+            "hoek": "6.x.x",
+            "vise": "3.x.x"
+          }
         },
         "pez": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
-          "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ=="
+          "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
+          "requires": {
+            "b64": "4.x.x",
+            "boom": "7.x.x",
+            "content": "4.x.x",
+            "hoek": "6.x.x",
+            "nigel": "3.x.x"
+          }
         },
         "podium": {
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.5.tgz",
-          "integrity": "sha512-+fAPmAj3d5fWKx5oSjQKeBIcl46/qZnGLhzyi/dJ/HzNiOpuxyX/Y4091LiVxZQ4ALdf/LCS7siV6ai5nNLlOg=="
+          "integrity": "sha512-+fAPmAj3d5fWKx5oSjQKeBIcl46/qZnGLhzyi/dJ/HzNiOpuxyX/Y4091LiVxZQ4ALdf/LCS7siV6ai5nNLlOg==",
+          "requires": {
+            "hoek": "6.x.x",
+            "joi": "14.x.x"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "shot": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
-          "integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew=="
+          "integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew==",
+          "requires": {
+            "hoek": "6.x.x",
+            "joi": "14.x.x"
+          }
         },
         "somever": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/somever/-/somever-2.0.0.tgz",
-          "integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw=="
+          "integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw==",
+          "requires": {
+            "bounce": "1.x.x",
+            "hoek": "6.x.x"
+          }
         },
         "statehood": {
           "version": "6.0.9",
@@ -5632,17 +5725,27 @@
         "topo": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ=="
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         },
         "vise": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.1.tgz",
-          "integrity": "sha512-7BJNjsv2o83+E6AHAFSnjQF324UTgypsR/Sw/iFmLvr7RgJrEXF1xNBvb5LJfi+1FvWQXjJK4X41WMuHMeunPQ=="
+          "integrity": "sha512-7BJNjsv2o83+E6AHAFSnjQF324UTgypsR/Sw/iFmLvr7RgJrEXF1xNBvb5LJfi+1FvWQXjJK4X41WMuHMeunPQ==",
+          "requires": {
+            "hoek": "6.x.x"
+          }
         },
         "wreck": {
           "version": "14.1.3",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
-          "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw=="
+          "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
+          "requires": {
+            "boom": "7.x.x",
+            "hoek": "6.x.x"
+          }
         }
       }
     },
@@ -7632,9 +7735,9 @@
       }
     },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.0.tgz",
+      "integrity": "sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g=="
     },
     "matchdep": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "joi": "^13.1.2",
     "json-schema-ref-parser": "^6.0.1",
     "lodash": "^4.17.5",
-    "marked": "^0.3.19",
+    "marked": "^0.6.0",
     "minimatch": "^3.0.4",
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.23",

--- a/src/assets/sass/v2/application.scss
+++ b/src/assets/sass/v2/application.scss
@@ -14,3 +14,4 @@ $govuk-global-styles: true;
 @import "blocks/phone";
 @import "blocks/search";
 @import "blocks/text";
+@import "blocks/message-preview";

--- a/src/assets/sass/v2/blocks/_message-preview.scss
+++ b/src/assets/sass/v2/blocks/_message-preview.scss
@@ -1,0 +1,10 @@
+.message-preview {
+  background-color: govuk-colour("grey-4");
+  border: 5px solid  $govuk-secondary-text-colour;
+  padding: 2rem;
+}
+
+.message-preview h1 {
+  font-size: 1.1875rem;
+  margin: 0;
+}

--- a/src/lib/connectors/water-service/communications.js
+++ b/src/lib/connectors/water-service/communications.js
@@ -1,0 +1,10 @@
+const serviceRequest = require('../service-request');
+
+const getCommunication = communicationId => {
+  const url = `${process.env.WATER_URI}/communications/${communicationId}`;
+  return serviceRequest.get(url);
+};
+
+module.exports = {
+  getCommunication
+};

--- a/src/lib/view-engine/filters/index.js
+++ b/src/lib/view-engine/filters/index.js
@@ -2,6 +2,7 @@ module.exports = {
   ...require('./abstraction-reform'),
   ...require('./date'),
   ...require('./form'),
+  ...require('./markdown'),
   ...require('./merge'),
   ...require('./most-significant-entity-role'),
   ...require('./query-string'),

--- a/src/lib/view-engine/filters/markdown.js
+++ b/src/lib/view-engine/filters/markdown.js
@@ -1,0 +1,16 @@
+const marked = require('marked');
+
+/**
+ * Notify's flavour of markdown uses caret for blcokquote so
+ * replace any carets with '>' for correct rendering.
+ */
+const markdown = (input = '') => {
+  const replacedCaret = input.replace(/\^/gm, '>');
+  return marked(replacedCaret, {
+    headerIds: false
+  });
+};
+
+module.exports = {
+  markdown
+};

--- a/src/modules/view-licences/controller.js
+++ b/src/modules/view-licences/controller.js
@@ -230,7 +230,7 @@ const getLicenceCommunication = async (request, h) => {
   const licence = response.data.licenceDocuments.find(doc => doc.documentId === documentId);
 
   const validationError = validateLicenceCommunicationResponses(request, licence);
-  if (validationError) return validationError;
+  if (validationError) throw validationError;
 
   const viewContext = {
     ...request.view,

--- a/src/modules/view-licences/routes-admin.js
+++ b/src/modules/view-licences/routes-admin.js
@@ -2,6 +2,8 @@ const externalRoutes = require('./routes');
 const constants = require('../../lib/constants');
 const allAdmin = constants.scope.allAdmin;
 const { preInternalView } = require('./pre-handlers');
+const controller = require('./controller');
+const { VALID_GUID } = require('../../lib/validators');
 
 const getLicenceAdmin = {
   ...externalRoutes.getLicence,
@@ -100,8 +102,26 @@ const getLicenceGaugingStationAdmin = {
 };
 
 const getLicenceCommunication = {
-  ...externalRoutes.getLicenceCommunication,
-  path: '/admin' + externalRoutes.getLicenceCommunication.path
+  method: 'GET',
+  path: '/admin/licences/{documentId}/communications/{communicationId}',
+  handler: controller.getLicenceCommunication,
+  config: {
+    description: 'Look at the content of a message sent to the user regarding the licence',
+    validate: {
+      params: {
+        communicationId: VALID_GUID,
+        documentId: VALID_GUID
+      }
+    },
+    plugins: {
+      viewContext: {
+        activeNavLink: 'view'
+      }
+    },
+    auth: {
+      scope: allAdmin
+    }
+  }
 };
 
 module.exports = {

--- a/src/modules/view-licences/routes-admin.js
+++ b/src/modules/view-licences/routes-admin.js
@@ -99,6 +99,11 @@ const getLicenceGaugingStationAdmin = {
   path: '/admin/licences/{licence_id}/station/{gauging_station}'
 };
 
+const getLicenceCommunication = {
+  ...externalRoutes.getLicenceCommunication,
+  path: '/admin' + externalRoutes.getLicenceCommunication.path
+};
+
 module.exports = {
   getLicenceAdmin,
   getLicenceRenameAdmin,
@@ -107,5 +112,6 @@ module.exports = {
   getLicencePurposesAdmin,
   getLicencePointsAdmin,
   getLicenceConditionsAdmin,
-  getLicenceGaugingStationAdmin
+  getLicenceGaugingStationAdmin,
+  getLicenceCommunication
 };

--- a/src/modules/view-licences/routes.js
+++ b/src/modules/view-licences/routes.js
@@ -1,7 +1,7 @@
 const Joi = require('joi');
 const controller = require('./controller');
 const { VALID_GUID, VALID_LICENCE_QUERY, VALID_LICENCE_NAME, VALID_GAUGING_STATION } = require('../../lib/validators');
-const { preAccessControl, preLoadDocument } = require('./pre-handlers');
+const { preAccessControl } = require('./pre-handlers');
 
 const getLicence = {
   method: 'GET',

--- a/src/modules/view-licences/routes.js
+++ b/src/modules/view-licences/routes.js
@@ -194,6 +194,26 @@ const getLicenceGaugingStation = {
   }
 };
 
+const getLicenceCommunication = {
+  method: 'GET',
+  path: '/licences/{documentId}/communications/{communicationId}',
+  handler: controller.getLicenceCommunication,
+  config: {
+    description: 'Look at the content of a message sent to the user regarding the licence',
+    validate: {
+      params: {
+        communicationId: VALID_GUID,
+        documentId: VALID_GUID
+      }
+    },
+    plugins: {
+      viewContext: {
+        activeNavLink: 'view'
+      }
+    }
+  }
+};
+
 module.exports = {
   getLicences: {
     method: 'GET',
@@ -234,5 +254,6 @@ module.exports = {
   getLicenceConditions,
   getLicencePoints,
   getLicencePurposes,
-  getLicenceGaugingStation
+  getLicenceGaugingStation,
+  getLicenceCommunication
 };

--- a/src/views/nunjucks/internal-search/macros/company-licences.njk
+++ b/src/views/nunjucks/internal-search/macros/company-licences.njk
@@ -1,10 +1,9 @@
 {% from "details-when.njk" import detailsWhen %}
-{% from "pluralise.njk" import pluralise %}
 
 {% macro companyLicences(licences) %}
   {% if licences.length > 0 %}
     <h3 class="govuk-heading-m govuk-!-margin-0">
-      {{ licences | length }} {{ pluralise(licences, 'licence', 'licences') }}
+      {{ licences | length }} {{ 'licence' | pluralize(licences) }}
     </h3>
     {% call detailsWhen(licences.length, 5, 'View licences') -%}
       <table class="govuk-table">

--- a/src/views/nunjucks/macros/pluralise.njk
+++ b/src/views/nunjucks/macros/pluralise.njk
@@ -1,3 +1,0 @@
-{% macro pluralise(collection, singular, plural) %}
-  {{ singular if collection.length === 1 else plural }}
-{% endmacro %}

--- a/src/views/nunjucks/view-licences/communication.njk
+++ b/src/views/nunjucks/view-licences/communication.njk
@@ -1,0 +1,19 @@
+{% extends "./nunjucks/layout.njk" %}
+
+{% block content %}
+  {{ title(licence.licenceRef, licence.documentName) }}
+
+  <h2 class="govuk-heading-m govuk-!-margin-0">{{messageType}}</h2>
+  <p>Sent {{sentDate | date}}</p>
+  <div class="message-preview govuk-body">
+    <p>
+    {% for part in recipientAddressParts %}
+      {{ part }}
+      </br>
+    {% endfor %}
+    </p>
+
+    {{ messageContent | markdown | safe }}
+  </div>
+
+{% endblock %}

--- a/src/views/nunjucks/view-licences/tabs/communications.njk
+++ b/src/views/nunjucks/view-licences/tabs/communications.njk
@@ -1,12 +1,16 @@
 {% macro messageRow(message, isInternal) %}
 <tr class="govuk-table__row">
   <td class="govuk-table__cell" scope="row">
-    <a href="{{ '/admin' if isInternal }}/licences/{{ documentId }}/communications/{{ message.notificationId }}">
+    {% if message.isPdf %}
       {{ message.notificationType }}
-    </a>
+    {% else %}
+      <a href="{{ '/admin' if isInternal }}/licences/{{ documentId }}/communications/{{ message.notificationId }}">
+        {{ message.notificationType }}
+      </a>
+    {% endif %}
   </td>
   <td class="govuk-table__cell">
-    {{ message.sent | date }}
+    {{ message.date | date }}
   </td>
   {% if isInternal %}
   <td class="govuk-table__cell">

--- a/test/lib/connectors/water-service/communications.js
+++ b/test/lib/connectors/water-service/communications.js
@@ -1,0 +1,25 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { expect } = require('code');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
+
+const serviceRequest = require('../../../../src/lib/connectors/service-request');
+const communicationsConnector = require('../../../../src/lib/connectors/water-service/communications');
+
+experiment('getCommunication', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await communicationsConnector.getCommunication('test-id');
+    const expectedUrl = `${process.env.WATER_URI}/communications/test-id`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+});

--- a/test/lib/view-engine/filters/markdown.js
+++ b/test/lib/view-engine/filters/markdown.js
@@ -1,0 +1,18 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const { markdown } = require('../../../../src/lib/view-engine/filters/markdown');
+
+experiment('markdown', () => {
+  test('converts the markdown to the expected html markup', async () => {
+    const markdownText = '# testing';
+    const htmlOutput = markdown(markdownText);
+    expect(htmlOutput).to.equal('<h1>testing</h1>\n');
+  });
+
+  test('replaces ^ with > due to notify markdown syntax', async () => {
+    const markdownText = '^ testing';
+    const htmlOutput = markdown(markdownText);
+    expect(htmlOutput).to.equal('<blockquote>\n<p>testing</p>\n</blockquote>\n');
+  });
+});

--- a/test/modules/view-licences/controller.js
+++ b/test/modules/view-licences/controller.js
@@ -1,4 +1,4 @@
-const { expect } = require('code');
+const { expect, fail } = require('code');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
@@ -140,9 +140,14 @@ experiment('getLicenceCommunication', () => {
 
   test('returns a 404 if the document id is not related to the notification', async () => {
     request.params.documentId = 'nope';
-    const response = await controller.getLicenceCommunication(request, h);
-    expect(response.isBoom).to.be.true();
-    expect(response.output.statusCode).to.equal(404);
+
+    try {
+      await controller.getLicenceCommunication(request, h);
+      fail('exception should have been thrown');
+    } catch (error) {
+      expect(error.isBoom).to.be.true();
+      expect(error.output.statusCode).to.equal(404);
+    }
   });
 
   test('returns 403 if user not associated with any of the notification companies', async () => {
@@ -153,9 +158,13 @@ experiment('getLicenceCommunication', () => {
       company_entity_id: 'nope'
     }];
 
-    const response = await controller.getLicenceCommunication(request, h);
-    expect(response.isBoom).to.be.true();
-    expect(response.output.statusCode).to.equal(403);
+    try {
+      await controller.getLicenceCommunication(request, h);
+      fail('exception should have been thrown');
+    } catch (error) {
+      expect(error.isBoom).to.be.true();
+      expect(error.output.statusCode).to.equal(403);
+    }
   });
 
   test('an admin user has access without company association', async () => {

--- a/test/modules/view-licences/controller.js
+++ b/test/modules/view-licences/controller.js
@@ -1,6 +1,11 @@
 const { expect } = require('code');
 const sinon = require('sinon');
-const { experiment, test } = exports.lab = require('lab').script();
+const sandbox = sinon.createSandbox();
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
+
+const communicationsConnector = require('../../../src/lib/connectors/water-service/communications');
+
+const communicationResponses = require('../../responses/water-service/communications/_documentId_');
 
 const controller = require('../../../src/modules/view-licences/controller');
 
@@ -35,5 +40,138 @@ experiment('getLicences', () => {
 
     await controller.getLicences(request, h);
     expect(h.redirect.calledWith('/add-licences')).to.be.true();
+  });
+});
+
+experiment('getLicenceCommunication', () => {
+  let request;
+  let h;
+
+  beforeEach(async () => {
+    sandbox.stub(communicationsConnector, 'getCommunication').resolves(communicationResponses.getCommunication());
+
+    h = {
+      view: (...args) => args
+    };
+
+    request = {
+      view: {},
+      params: {
+        documentId: 'doc-id-1',
+        communicationId: 'notification-id'
+      },
+      permissions: {
+        hasPermission: sandbox.stub().returns(true)
+      },
+      entityRoles: [{ company_entity_id: 'comany-id-1' }]
+    };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('assigns the licence details to the view model', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.licence.documentId).to.equal('doc-id-1');
+    expect(view.licence.companyEntityId).to.equal('company-id-1');
+    expect(view.licence.documentName).to.equal('doc-1-name');
+    expect(view.licence.licenceRef).to.equal('lic-1');
+  });
+
+  test('when the document has a name, it is added to the page title', async () => {
+    const response = communicationResponses.getCommunication();
+    response.data.licenceDocuments[0].documentName = 'named document';
+    communicationsConnector.getCommunication.resolves(response);
+
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.pageTitle).to.equal('named document, message review');
+  });
+
+  test('when the document has no name, the licence ref is added to the page title', async () => {
+    const response = communicationResponses.getCommunication();
+    response.data.licenceDocuments[0].documentName = null;
+    communicationsConnector.getCommunication.resolves(response);
+
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.pageTitle).to.equal('lic-1, message review');
+  });
+
+  test('the message content is added to the view', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.messageContent).to.equal('Test message content');
+  });
+
+  test('the message type is added to the view', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.messageType).to.equal('Message Type');
+  });
+
+  test('the message sent date is added to the view', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.sentDate).to.equal('2018-01-01T00:00:00.000Z');
+  });
+
+  test('the recipientAddressParts is added to the view', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.recipientAddressParts).to.equal(['Add 1', 'Add 2', 'Add 3', 'Add 4', 'Add 5', 'AB1 2CD']);
+  });
+
+  test('recipientAddressParts excludes falsey data', async () => {
+    const response = communicationResponses.getCommunication();
+    response.data.notification.address.addressLine2 = '    ';
+    response.data.notification.address.addressLine4 = '';
+    communicationsConnector.getCommunication.resolves(response);
+
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.recipientAddressParts).to.equal(['Add 1', 'Add 3', 'Add 5', 'AB1 2CD']);
+  });
+
+  test('recipientAddressParts trims address data', async () => {
+    const response = communicationResponses.getCommunication();
+    response.data.notification.address.addressLine1 = ' Add 1 ';
+    response.data.notification.address.addressLine2 = ' Add 2';
+    response.data.notification.address.addressLine3 = 'Add 3 ';
+    communicationsConnector.getCommunication.resolves(response);
+
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.recipientAddressParts).to.equal(['Add 1', 'Add 2', 'Add 3', 'Add 4', 'Add 5', 'AB1 2CD']);
+  });
+
+  test('returns a 404 if the document id is not related to the notification', async () => {
+    request.params.documentId = 'nope';
+    const response = await controller.getLicenceCommunication(request, h);
+    expect(response.isBoom).to.be.true();
+    expect(response.output.statusCode).to.equal(404);
+  });
+
+  test('returns 403 if user not associated with any of the notification companies', async () => {
+    request.permissions.hasPermission.returns(false);
+    request.entityRoles = [{
+      entity_id: '2',
+      role: 'user',
+      company_entity_id: 'nope'
+    }];
+
+    const response = await controller.getLicenceCommunication(request, h);
+    expect(response.isBoom).to.be.true();
+    expect(response.output.statusCode).to.equal(403);
+  });
+
+  test('an admin user has access without company association', async () => {
+    request.permissions.hasPermission.returns(true);
+    request.entityRoles = [{
+      entity_id: '2',
+      role: 'user',
+      company_entity_id: 'nope'
+    }];
+
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.licence.documentId).to.equal('doc-id-1');
+  });
+
+  test('requests the layout renders the back link', async () => {
+    const [, view] = await controller.getLicenceCommunication(request, h);
+    expect(view.back).to.equal('/licences/doc-id-1#communications');
   });
 });

--- a/test/responses/water-service/communications/_documentId_/index.js
+++ b/test/responses/water-service/communications/_documentId_/index.js
@@ -1,0 +1,48 @@
+const getCommunication = () => ({
+  error: null,
+  data: {
+    notification: {
+      id: 'notification-id',
+      recipient: 'n/a',
+      messageRef: 'notification_letter',
+      messageType: 'letter',
+      licences: ['lic-1', 'lic-2'],
+      plainText: 'Test message content',
+      address: {
+        addressLine1: 'Add 1',
+        addressLine2: 'Add 2',
+        addressLine3: 'Add 3',
+        addressLine4: 'Add 4',
+        addressLine5: 'Add 5',
+        postcode: 'AB1 2CD'
+      }
+    },
+    evt: {
+      referenceCode: 'ref-code',
+      type: 'notification',
+      issuer: 'issuer@example.com',
+      id: 'event-id',
+      subType: 'event-sub-type',
+      name: 'Message Type',
+      createdDate: '2018-01-01T00:00:00.000Z'
+    },
+    licenceDocuments: [
+      {
+        documentId: 'doc-id-1',
+        companyEntityId: 'company-id-1',
+        documentName: 'doc-1-name',
+        licenceRef: 'lic-1'
+      },
+      {
+        documentId: 'doc-id-2',
+        companyEntityId: 'company-id-2',
+        documentName: 'doc-2-name',
+        licenceRef: 'lic-2'
+      }
+    ]
+  }
+});
+
+module.exports = {
+  getCommunication
+};


### PR DESCRIPTION
WATER-1891

Adds a page that shows the message content that has been previously
sent.

 - Updates marked module to latest version to use option to remove header
ids that are added to the output html.

 - Replace pluralise macro with pluralize filter

 - Adds the back link to the communication detail page

 - Fixes an issue with the dates in the communications list.