### PR TITLE
Fix: Changes an emailto link to a href

### DIFF
--- a/src/views/nunjucks/view-licences/licence.njk
+++ b/src/views/nunjucks/view-licences/licence.njk
@@ -14,8 +14,8 @@
         {{ title('Licence number ' + licence.licenceNumber, licence.documentName ) }}
       {% endif %}
 
-      {% if primaryUser %}
-      <p>Registered to {{ primaryUser.userName | urlize | safe }}</p>
+      {% if isInternal and primaryUser %}
+        <p>Registered to <a href="/admin/user/{{primaryUser.userId}}/status">{{primaryUser.userName}}</a></p>
       {% endif %}
 
       {% set summaryHtml %}


### PR DESCRIPTION
WATER-1902

On the licence page, if the user is internal, and the primary user is
available, create a link to the user status page.