### PR TITLE
Fix: Adds screen reader aware text in comms table

### DIFF
--- a/src/views/nunjucks/view-licences/tabs/communications.njk
+++ b/src/views/nunjucks/view-licences/tabs/communications.njk
@@ -1,9 +1,11 @@
 {% macro messageLink(message) %}
   {% if message.isPdf %}
     {{ message.notificationType }}
+    <span class="govuk-visually-hidden"> sent {{ message.data | date }} via {{ message.messageType }}</span>
   {% else %}
     <a href="{{ '/admin' if isInternal }}/licences/{{ documentId }}/communications/{{ message.notificationId }}">
       {{ message.notificationType }}
+      <span class="govuk-visually-hidden"> sent {{ message.data | date }} via {{ message.messageType }}</span>
     </a>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
WATER-1892

Updates the 'type' column text in the communications table to include
additional context for screen reader user agents.