### PR TITLE
Fix: Prevent redirect of users to welcome page

### DIFF
--- a/src/lib/hapi-plugins/auth-credentials.js
+++ b/src/lib/hapi-plugins/auth-credentials.js
@@ -74,11 +74,9 @@ const augmentAuthenticatedRequest = async request => {
 
     data.user = await loadIDMUser(username);
     data.userScopes = getUserScopes(data.user);
-    data.isExternalUser = isExternalUser(data.user);
-    data.isInternalUser = !data.isExternalUser;
     data.companyId = companyId;
 
-    if (data.isExternalUser) {
+    if (isExternalUser(data.user)) {
       await assignExternalProperties(data, request);
     }
     set(request, 'auth.credentials.scope', data.userScopes);

--- a/src/lib/hapi-plugins/auth-credentials.js
+++ b/src/lib/hapi-plugins/auth-credentials.js
@@ -3,14 +3,10 @@
  * company and roles
  */
 const { get, set } = require('lodash');
+const logger = require('../logger');
 const { throwIfError } = require('@envage/hapi-pg-rest-api');
 const idmConnector = require('../connectors/idm');
 const crmConnector = require('../connectors/crm');
-const logger = require('../logger');
-
-const loadCRMEntityRoles = entityId => {
-  return crmConnector.entityRoles.setParams({ entityId }).findAll();
-};
 
 /**
  * Loads user data from IDM
@@ -29,6 +25,10 @@ const loadIDMUser = async (email) => {
   return user;
 };
 
+const loadCRMEntityRoles = entityId => {
+  return crmConnector.entityRoles.setParams({ entityId }).findAll();
+};
+
 /**
  * Gets scopes array from IDM user object
  * @param  {Object} user - from IDM users
@@ -43,61 +43,59 @@ const getUserScopes = user => get(user, 'role.scopes', []);
  */
 const isExternalUser = user => getUserScopes(user).includes('external');
 
-/**
- * Checks whether to load scopes.  Scopes should not be loaded on unauthenticated
- * routes
- * @param  {Object} request - HAPI request
- * @return {Boolean}         - true if authenticated route
- */
-const isAuthenticatedRoute = request => get(request, 'auth.isAuthenticated', false);
+const getUniqueCompanyIds = (entityRoles = []) => {
+  const allIds = entityRoles.map(er => er.company_entity_id);
+  return Array.from(new Set(allIds));
+};
 
 const mapRolesToScopes = roles => roles.map(role => role.role);
 
 const getCompanyPredicate = companyId => (role) => role.company_entity_id === companyId;
 
-/**
- * Loads all scopes for the current user based on their IDM and company roles
- * @param  {Object}  request - HAPI request
- * @return {Promise} resolves with scopes array
- */
-const loadScopes = async (request) => {
-  // Load scopes for current user and set in auth.credentials
-  const { username, companyId, entity_id: entityId } = request.auth.credentials;
+const assignExternalProperties = async (data, request) => {
+  const { entity_id: entityId, companyId } = request.auth.credentials;
 
-  const user = await loadIDMUser(username);
+  data.entityRoles = await loadCRMEntityRoles(entityId);
+  data.companyIds = getUniqueCompanyIds(data.entityRoles);
+  data.companyCount = data.companyIds.length;
 
-  // Get IDM scopes
-  const scopes = getUserScopes(user);
-
-  if (isExternalUser(user)) {
-    // Load all user's roles into current request
-    request.entityRoles = await loadCRMEntityRoles(entityId);
-
-    if (companyId) {
-      // Filter roles for selected company
-      const roles = request.entityRoles.filter(getCompanyPredicate(companyId));
-
-      // Use selected company roles to augment scopes
-      scopes.push(...mapRolesToScopes(roles));
-    }
+  if (companyId) {
+    // Filter roles for selected company
+    const roles = data.entityRoles.filter(getCompanyPredicate(companyId));
+    // Use selected company roles to augment scopes
+    data.userScopes = [...data.userScopes, ...mapRolesToScopes(roles)];
   }
+};
 
-  return scopes;
+const augmentAuthenticatedRequest = async request => {
+  try {
+    const { username, companyId } = request.auth.credentials;
+    const data = request.defra || {};
+
+    data.user = await loadIDMUser(username);
+    data.userScopes = getUserScopes(data.user);
+    data.isExternalUser = isExternalUser(data.user);
+    data.isInternalUser = !data.isExternalUser;
+    data.companyId = companyId;
+
+    if (data.isExternalUser) {
+      await assignExternalProperties(data, request);
+    }
+    set(request, 'auth.credentials.scope', data.userScopes);
+
+    request.defra = data;
+  } catch (error) {
+    logger.error('Failed to load entity scopes', error, get(request, 'auth.credentials'));
+    throw error;
+  }
 };
 
 /**
  * onCredentials plugin handler
  */
 const handler = async (request, h) => {
-  // We should only load scopes on authenticated routes
-  if (isAuthenticatedRoute(request)) {
-    try {
-      const scopes = await loadScopes(request);
-      set(request, 'auth.credentials.scope', scopes);
-    } catch (error) {
-      logger.error('Failed to load entity scopes', error, get(request, 'auth.credentials'));
-      throw error;
-    }
+  if (request.auth.isAuthenticated) {
+    await augmentAuthenticatedRequest(request);
   }
   return h.continue;
 };
@@ -116,4 +114,4 @@ const plugin = {
 };
 
 module.exports = plugin;
-module.exports.handler = handler;
+module.exports._handler = handler;

--- a/src/lib/hapi-plugins/company-selection.js
+++ b/src/lib/hapi-plugins/company-selection.js
@@ -1,0 +1,51 @@
+/**
+ * This plugin will redirect a user to the select-company route
+ * of the user has not selected a company, but does have entity roles
+ * and therefore a company.
+ *
+ * If the user has no company then they will be redirected to the
+ * add-licences route.
+ *
+ * Both of the above redirections will only take place if the user is
+ * attempting to access a route that is configured with an access scope.
+ */
+const { get } = require('lodash');
+const SELECT_COMPANY_PATH = '/select-company';
+const ADD_LICENCES_PATH = '/add-licences';
+
+const shouldRedirect = request => {
+  const { companyId, isExternalUser } = request.defra;
+  const { path } = request;
+  const access = get(request, 'route.settings.auth.access', false);
+
+  return (access && isExternalUser && !companyId && path !== SELECT_COMPANY_PATH);
+};
+
+const getRedirectPath = companyCount => {
+  return companyCount === 0 ? ADD_LICENCES_PATH : SELECT_COMPANY_PATH;
+};
+
+const handler = (request, h) => {
+  if (request.auth.isAuthenticated && shouldRedirect(request)) {
+    const path = getRedirectPath(request.defra.companyCount);
+    return h.redirect(path).takeover();
+  }
+  return h.continue;
+};
+
+const plugin = {
+  register: (server) => {
+    server.ext({
+      type: 'onPreResponse',
+      method: handler
+    });
+  },
+  pkg: {
+    name: 'companySelection',
+    version: '2.0.0'
+  },
+  dependencies: ['authCredentials']
+};
+
+module.exports = plugin;
+module.exports._handler = handler;

--- a/src/lib/hapi-plugins/company-selection.js
+++ b/src/lib/hapi-plugins/company-selection.js
@@ -12,13 +12,15 @@
 const { get } = require('lodash');
 const SELECT_COMPANY_PATH = '/select-company';
 const ADD_LICENCES_PATH = '/add-licences';
+const permissions = require('../permissions');
 
 const shouldRedirect = request => {
-  const { companyId, isExternalUser } = request.defra;
+  const isExternal = permissions.isExternal(request);
+  const { companyId } = request.defra;
   const { path } = request;
   const access = get(request, 'route.settings.auth.access', false);
 
-  return (access && isExternalUser && !companyId && path !== SELECT_COMPANY_PATH);
+  return (access && isExternal && !companyId && path !== SELECT_COMPANY_PATH);
 };
 
 const getRedirectPath = companyCount => {

--- a/src/lib/hapi-plugins/index.js
+++ b/src/lib/hapi-plugins/index.js
@@ -2,7 +2,6 @@ module.exports = {
   config: require('./config'),
   sessions: require('./sessions'),
   csrf: require('./csrf'),
-  error: require('./error'),
   adminFirewall: require('./admin-firewall'),
   redirect: require('./redirect'),
   secureHeaders: require('./secure-headers'),
@@ -14,5 +13,7 @@ module.exports = {
   viewContext: require('./view-context'),
   formValidator: require('./form-validator'),
   anonGoogleAnalytics: require('./anon-google-analytics'),
-  authCredentials: require('./auth-credentials')
+  authCredentials: require('./auth-credentials'),
+  companySelection: require('./company-selection'),
+  error: require('./error')
 };

--- a/src/lib/view.js
+++ b/src/lib/view.js
@@ -1,4 +1,4 @@
-const { get, uniq } = require('lodash');
+const { get } = require('lodash');
 const config = require('../../config');
 
 const { getPropositionLinks } = require('./view/proposition-links');
@@ -45,11 +45,7 @@ const getTracking = (credentials) => {
  * @param  {Object}  request - current request
  * @return {Boolean}         true if user can access > 1 company
  */
-const hasMultipleCompanies = (request) => {
-  const roles = get(request, 'entityRoles', []);
-  const companyIds = roles.map(role => role.company_entity_id);
-  return uniq(companyIds).length > 1;
-};
+const hasMultipleCompanies = request => get(request, 'defra.companyCount', 0) > 1;
 
 function viewContextDefaults (request) {
   const viewContext = request.view || {};

--- a/src/modules/manage-licences/controller.js
+++ b/src/modules/manage-licences/controller.js
@@ -239,7 +239,7 @@ async function postRemoveAccess (request, h) {
 
   // Need to find all roles that the colleage has for the company
   // for whom the current user is the primary_user
-  const { regime_entity_id: regimeId, company_entity_id: companyId } = find(request.entityRoles, role => role.role === 'primary_user');
+  const { regime_entity_id: regimeId, company_entity_id: companyId } = find(request.defra.entityRoles, role => role.role === 'primary_user');
 
   await removeColleague(regimeId, companyId, entityId, colleagueEntityID);
 

--- a/src/routes/public.js
+++ b/src/routes/public.js
@@ -1,5 +1,4 @@
 module.exports = [
-
   {
     method: 'GET',
     path: '/public/{param*}',
@@ -17,7 +16,6 @@ module.exports = [
       }
     }
   },
-
   {
     method: 'GET',
     path: '/images/{param*}',
@@ -33,7 +31,6 @@ module.exports = [
       }
     }
   },
-
   {
     method: 'GET',
     path: '/stylesheets/{param*}',
@@ -49,7 +46,6 @@ module.exports = [
       }
     }
   },
-
   {
     method: 'GET',
     path: '/javascripts/{param*}',
@@ -65,5 +61,4 @@ module.exports = [
       }
     }
   }
-
 ];

--- a/src/views/nunjucks/auth/select-company.njk
+++ b/src/views/nunjucks/auth/select-company.njk
@@ -1,12 +1,8 @@
 {% extends "./nunjucks/layout.njk" %}
 
-
 {% block mainNav %}
 {% endblock %}
 
-
 {% block content %}
-
   {{ formRender(form)}}
-
 {% endblock %}

--- a/src/views/nunjucks/layout.njk
+++ b/src/views/nunjucks/layout.njk
@@ -66,7 +66,7 @@
 
   {% block mainNav %}
 
-  {% if hasMultipleCompanies %}
+  {% if hasMultipleCompanies and companyName %}
   <div class="company-switcher">
     You are managing <b>{{ companyName }}</b>
     <a href="/select-company" class="company-switcher__link">
@@ -74,8 +74,6 @@
     </a>
   </div>
   {% endif %}
-
-
 
   {{ mainNav(mainNavLinks) }}
   {% endblock %}

--- a/src/views/partials/element-main-nav.html
+++ b/src/views/partials/element-main-nav.html
@@ -1,11 +1,13 @@
 
 {{#if hasMultipleCompanies }}
-<div class="company-switcher">
-  You are managing <b>{{ companyName }}</b>
-  <a href="/select-company" class="company-switcher__link">
-    Change <span class="sr-only">the company you manage</span>
-  </a>
-</div>
+  {{#if companyName }}
+    <div class="company-switcher">
+      You are managing <b>{{ companyName }}</b>
+      <a href="/select-company" class="company-switcher__link">
+        Change <span class="sr-only">the company you manage</span>
+      </a>
+    </div>
+  {{/if}}
 {{/if}}
 
 {{#if isAuthenticated}}

--- a/test/lib/hapi-plugins/auth-credentials.js
+++ b/test/lib/hapi-plugins/auth-credentials.js
@@ -144,14 +144,6 @@ experiment('auth credentials plugin handler', async () => {
     test('adds the companyId to the defra object', async () => {
       expect(request.defra.companyId).to.equal(companyId);
     });
-
-    test('sets isInternalUser to true', async () => {
-      expect(request.defra.isInternalUser).to.be.true();
-    });
-
-    test('sets isExternalUser to false', async () => {
-      expect(request.defra.isExternalUser).to.be.false();
-    });
   });
 
   experiment('for external users', async () => {
@@ -191,18 +183,6 @@ experiment('auth credentials plugin handler', async () => {
       const request = createRequestWithCompany();
       await plugin._handler(request, h);
       expect(request.defra.companyId).to.equal(companyId);
-    });
-
-    test('sets isInternalUser to false', async () => {
-      const request = createRequest();
-      await plugin._handler(request, h);
-      expect(request.defra.isInternalUser).to.be.false();
-    });
-
-    test('sets isExternalUser to true', async () => {
-      const request = createRequest();
-      await plugin._handler(request, h);
-      expect(request.defra.isExternalUser).to.be.true();
     });
 
     test('adds the entityRoles to the defra object', async () => {

--- a/test/lib/hapi-plugins/auth-credentials.js
+++ b/test/lib/hapi-plugins/auth-credentials.js
@@ -65,7 +65,7 @@ const createRequestWithCompany = () => {
   return request;
 };
 
-experiment('auth credentials plugin', () => {
+experiment('auth credentials plugin', async () => {
   test('is configured correctly', async () => {
     expect(plugin.register).to.be.a.function();
     expect(plugin.pkg.name).to.equal('authCredentials');
@@ -80,11 +80,11 @@ experiment('auth credentials plugin', () => {
     expect(server.ext.callCount).to.equal(1);
     const { method, type } = server.ext.lastCall.args[0];
     expect(type).to.equal('onCredentials');
-    expect(method).to.equal(plugin.handler);
+    expect(method).to.equal(plugin._handler);
   });
 });
 
-experiment('auth credentials plugin handler', () => {
+experiment('auth credentials plugin handler', async () => {
   let h;
 
   const sandbox = sinon.createSandbox();
@@ -102,57 +102,135 @@ experiment('auth credentials plugin handler', () => {
   });
 
   test('returns h.continue on unauthenticated routes', async () => {
-    const result = await plugin.handler({}, h);
+    const result = await plugin._handler({
+      auth: { isAuthenticated: false }
+    }, h);
     expect(result).to.equal(h.continue);
   });
 
   test('throws and logs an error if there is an IDM error', async () => {
     const request = createRequest();
     idmConnector.getUserByEmail.resolves(responses.error);
-    const func = () => plugin.handler(request, h);
+    const func = () => plugin._handler(request, h);
     expect(func()).to.reject().then(() => {
       expect(logger.error.callCount).to.equal(1);
     });
   });
 
-  experiment('for internal users', () => {
+  experiment('for internal users', async () => {
+    let request;
+    let result;
+
     beforeEach(async () => {
       idmConnector.getUserByEmail.resolves(responses.idmInternal);
+      request = createRequest();
+      request.auth.credentials.companyId = companyId;
+      result = await plugin._handler(request, h);
     });
 
     test('returns the scopes loaded from the IDM', async () => {
-      const request = createRequest();
-      const result = await plugin.handler(request, h);
       expect(result).to.equal(h.continue);
       expect(request.auth.credentials.scope).to.equal([scope.internal]);
     });
+
+    test('adds the user to the defra object', async () => {
+      expect(request.defra.user).to.equal(responses.idmInternal.data[0]);
+    });
+
+    test('adds the userScopes to the defra object', async () => {
+      expect(request.defra.userScopes).to.equal(['internal']);
+    });
+
+    test('adds the companyId to the defra object', async () => {
+      expect(request.defra.companyId).to.equal(companyId);
+    });
+
+    test('sets isInternalUser to true', async () => {
+      expect(request.defra.isInternalUser).to.be.true();
+    });
+
+    test('sets isExternalUser to false', async () => {
+      expect(request.defra.isExternalUser).to.be.false();
+    });
   });
 
-  experiment('for external users', () => {
+  experiment('for external users', async () => {
     beforeEach(async () => {
       idmConnector.getUserByEmail.resolves(responses.idmExternal);
       sandbox.stub(crmConnector.entityRoles, 'setParams').returns({
-        findAll: sandbox.stub().resolves(responses.crmRoles)
+        findAll: () => Promise.resolve(responses.crmRoles)
       });
     });
 
     test('places all user roles on the request', async () => {
       const request = createRequest();
-      await plugin.handler(request, h);
-      expect(request.entityRoles).to.equal(responses.crmRoles);
+      await plugin._handler(request, h);
+      expect(request.defra.entityRoles).to.equal(responses.crmRoles);
     });
 
     test('does not place company roles in scope if no company selected', async () => {
       const request = createRequest();
-      await plugin.handler(request, h);
+      await plugin._handler(request, h);
       expect(request.auth.credentials.scope).to.equal([scope.external]);
     });
 
     test('places company roles in scope if company is selected', async () => {
       const request = createRequestWithCompany();
-      const result = await plugin.handler(request, h);
+      const result = await plugin._handler(request, h);
       expect(result).to.equal(h.continue);
       expect(request.auth.credentials.scope).to.equal([scope.external, 'foo', 'bar']);
+    });
+
+    test('adds the user to the defra object', async () => {
+      const request = createRequest();
+      await plugin._handler(request, h);
+      expect(request.defra.user).to.equal(responses.idmExternal.data[0]);
+    });
+
+    test('adds the companyId to the defra object', async () => {
+      const request = createRequestWithCompany();
+      await plugin._handler(request, h);
+      expect(request.defra.companyId).to.equal(companyId);
+    });
+
+    test('sets isInternalUser to false', async () => {
+      const request = createRequest();
+      await plugin._handler(request, h);
+      expect(request.defra.isInternalUser).to.be.false();
+    });
+
+    test('sets isExternalUser to true', async () => {
+      const request = createRequest();
+      await plugin._handler(request, h);
+      expect(request.defra.isExternalUser).to.be.true();
+    });
+
+    test('adds the entityRoles to the defra object', async () => {
+      const request = createRequestWithCompany();
+      await plugin._handler(request, h);
+      expect(request.defra.entityRoles).to.equal([
+        { company_entity_id: 'company_1', role: 'foo' },
+        { company_entity_id: 'company_1', role: 'bar' },
+        { company_entity_id: 'company_2', role: 'baz' }
+      ]);
+    });
+
+    test('adds the unique company ids to the defra object', async () => {
+      const request = createRequestWithCompany();
+      await plugin._handler(request, h);
+      expect(request.defra.companyIds).to.equal(['company_1', 'company_2']);
+    });
+
+    test('adds the count of unique company ids to the defra object', async () => {
+      const request = createRequestWithCompany();
+      await plugin._handler(request, h);
+      expect(request.defra.companyCount).to.equal(2);
+    });
+
+    test('adds the userScopes to the defra object', async () => {
+      const request = createRequestWithCompany();
+      await plugin._handler(request, h);
+      expect(request.defra.userScopes).to.equal(['external', 'foo', 'bar']);
     });
   });
 });

--- a/test/lib/hapi-plugins/company-selection.js
+++ b/test/lib/hapi-plugins/company-selection.js
@@ -1,0 +1,154 @@
+const { set } = require('lodash');
+const { expect } = require('code');
+const {
+  beforeEach,
+  afterEach,
+  experiment,
+  test
+} = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const plugin = require('../../../src/lib/hapi-plugins/company-selection');
+const handler = plugin._handler;
+
+const getTestRequest = (overrides = {}) => {
+  const defaults = Object.assign({
+    isAuthenticated: true,
+    isExternal: true,
+    companyId: undefined,
+    companyCount: 1,
+    path: '/test',
+    access: undefined
+  }, overrides);
+
+  const request = { path: defaults.path };
+  set(request, 'auth.isAuthenticated', defaults.isAuthenticated);
+  set(request, 'defra.isExternalUser', defaults.isExternal);
+  set(request, 'defra.isInternalUser', !defaults.isExternal);
+  set(request, 'defra.companyId', defaults.companyId);
+  set(request, 'defra.companyCount', defaults.companyCount);
+  set(request, 'route.settings.auth.access', defaults.access);
+  return request;
+};
+
+experiment('plugin', async () => {
+  test('is configured correctly', async () => {
+    expect(plugin.pkg.name).to.equal('companySelection');
+    expect(plugin.pkg.version).to.equal('2.0.0');
+  });
+
+  test('defines a dependency on authCredentials', async () => {
+    expect(plugin.dependencies).to.contain('authCredentials');
+  });
+
+  test('registers an onPreResponse handler', async () => {
+    const server = {
+      ext: sinon.stub()
+    };
+    plugin.register(server);
+    expect(server.ext.callCount).to.equal(1);
+    const { method, type } = server.ext.lastCall.args[0];
+    expect(type).to.equal('onPreResponse');
+    expect(method).to.equal(plugin._handler);
+  });
+});
+
+experiment('handler', () => {
+  let h;
+
+  beforeEach(async () => {
+    h = {
+      redirect: sinon.stub().returns({
+        takeover: () => 'takeover'
+      }),
+      continue: 'CONTINUE' };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('continues if the request is not authenticated', async () => {
+    const request = {
+      auth: {
+        isAuthenticated: false
+      }
+    };
+
+    const result = handler(request, h);
+    expect(result).to.equal(h.continue);
+  });
+
+  experiment('for an internal user', () => {
+    test('does not redirect for a route with access config', async () => {
+      const request = {
+        auth: {
+          isAuthenticated: true
+        },
+        defra: {
+          isExternalUser: false,
+          isInternalUser: true
+        },
+        path: '/',
+        access: {}
+      };
+
+      const result = handler(request, h);
+      expect(result).to.equal(h.continue);
+    });
+  });
+
+  experiment('external user', () => {
+    test('does not redirect for a route with access config', async () => {
+      const request = getTestRequest(true, {
+        access: {}
+      });
+      const result = handler(request, h);
+      expect(result).to.equal(h.continue);
+    });
+
+    test('does not redirect when there is a company id', async () => {
+      const request = getTestRequest(true, {
+        companyId: 'test-id'
+      });
+      const result = handler(request, h);
+      expect(result).to.equal(h.continue);
+    });
+
+    test('does not redirect when the select-company page is requested', async () => {
+      const request = getTestRequest(true, {
+        path: '/select-company'
+      });
+      const result = handler(request, h);
+      expect(result).to.equal(h.continue);
+    });
+  });
+
+  experiment('external user with no selected company', () => {
+    test('is redirected to "add licences" if they have no companies', async () => {
+      const request = getTestRequest({
+        companyCount: 0,
+        access: {}
+      });
+
+      const result = handler(request, h);
+      const [redirectPath] = h.redirect.lastCall.args;
+      expect(result).to.equal('takeover');
+      expect(redirectPath).to.equal('/add-licences');
+    });
+
+    test('is redirected to "select company" if they have companies', async () => {
+      const request = getTestRequest({
+        companyCount: 1,
+        access: {}
+      });
+
+      const result = handler(request, h);
+      const [redirectPath] = h.redirect.lastCall.args;
+      expect(result).to.equal('takeover');
+      expect(redirectPath).to.equal('/select-company');
+    });
+  });
+});

--- a/test/lib/hapi-plugins/company-selection.js
+++ b/test/lib/hapi-plugins/company-selection.js
@@ -25,11 +25,14 @@ const getTestRequest = (overrides = {}) => {
 
   const request = { path: defaults.path };
   set(request, 'auth.isAuthenticated', defaults.isAuthenticated);
-  set(request, 'defra.isExternalUser', defaults.isExternal);
-  set(request, 'defra.isInternalUser', !defaults.isExternal);
   set(request, 'defra.companyId', defaults.companyId);
   set(request, 'defra.companyCount', defaults.companyCount);
   set(request, 'route.settings.auth.access', defaults.access);
+
+  if (defaults.isExternal) {
+    set(request, 'auth.credentials.scope', ['external']);
+  }
+
   return request;
 };
 


### PR DESCRIPTION
WATER-1955

Fixes a bug where the user could end up on a page that is not the
company selector without having selected a company. This mean licence
lookups where not authorised so the user was redirected to the welcome
page.

This change updates the `auth-credentials` plugin to add more content to
the request under the `defra` property (to avoid collisions). This data
is then used in a `preResponse` handler to redirect the user either to
the `select-company` route if the user has companies, or the
`add-licences` route if they don't.

Also hides the company switcher if there is no company name selected
preventing it showing if the user has not selected a company but wishes
to update a password.