### PR TITLE
Fix: Don't show company switcher to single company users

### DIFF
--- a/src/lib/login-helpers.js
+++ b/src/lib/login-helpers.js
@@ -1,9 +1,9 @@
 const { get } = require('lodash');
 const { throwIfError } = require('@envage/hapi-pg-rest-api');
 
-const waterUser = require('../../../lib/connectors/water-service/user');
+const waterUser = require('./connectors/water-service/user');
 const getUserID = request => get(request, 'auth.credentials.user_id');
-const { isInternal } = require('../../../lib/permissions');
+const { isInternal } = require('./permissions');
 
 /**
  * Asynchronously loads user data from the water service, including their list

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -15,7 +15,7 @@ const { destroySession, authValidationErrorResponse } = require('./helpers');
 const { selectCompanyForm } = require('./forms/select-company');
 const { handleRequest, getValues } = require('../../lib/forms');
 
-const loginHelpers = require('./lib/login-helpers');
+const loginHelpers = require('../../lib/login-helpers');
 
 /**
  * Welcome page before routing to signin/register

--- a/src/modules/reset-password/controller.js
+++ b/src/modules/reset-password/controller.js
@@ -1,8 +1,10 @@
 const IDM = require('../../lib/connectors/idm');
 const { UserNotFoundError } = require('./errors');
 const signIn = require('../../lib/sign-in');
+const loginHelpers = require('../../lib/login-helpers');
 const mapJoiPasswordError = require('./map-joi-password-error');
 const logger = require('../../lib/logger');
+
 
 /**
  * Renders form for start of reset password flow
@@ -92,8 +94,8 @@ async function postChangePassword (request, reply) {
 
     // Log user in
     await signIn.auto(request, user.user_name);
-
-    return reply.redirect('/licences');
+    const redirectPath = await loginHelpers.getLoginRedirectPath(request);
+    return reply.redirect(redirectPath);
   } catch (error) {
     return reply.redirect('/reset_password?flash=resetLinkExpired');
   }

--- a/test/lib/login-helpers.js
+++ b/test/lib/login-helpers.js
@@ -2,9 +2,9 @@ const sinon = require('sinon');
 const { expect } = require('code');
 const { set } = require('lodash');
 const { experiment, test, afterEach, beforeEach } = exports.lab = require('lab').script();
-const loginHelpers = require('../../../../src/modules/auth/lib/login-helpers');
-const waterUser = require('../../../../src/lib/connectors/water-service/user');
-const { scope } = require('../../../../src/lib/constants');
+const loginHelpers = require('../../src/lib/login-helpers');
+const waterUser = require('../../src/lib/connectors/water-service/user');
+const { scope } = require('../../src/lib/constants');
 
 const userId = 'user_1';
 

--- a/test/modules/reset-password/controller.js
+++ b/test/modules/reset-password/controller.js
@@ -1,10 +1,19 @@
 'use strict';
 
 const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = Lab.script();
+const { expect } = require('code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
 
-const Code = require('code');
-
+const loginHelpers = require('../../../src/lib/login-helpers');
+const idmConnector = require('../../../src/lib/connectors/idm');
+const signIn = require('../../../src/lib/sign-in');
 const controller = require('../../../src/modules/reset-password/controller');
 
 /**
@@ -15,24 +24,101 @@ function isAsync (fn) {
   return fn.constructor.name === 'AsyncFunction';
 }
 
-lab.experiment('Check methods on reset password controller', () => {
-  lab.test('getResetPassword function exists', async () => {
-    Code.expect(isAsync(controller.getResetPassword)).to.equal(true);
+experiment('Check methods on reset password controller', () => {
+  test('getResetPassword function exists', async () => {
+    expect(isAsync(controller.getResetPassword)).to.equal(true);
   });
 
-  lab.test('postResetPassword function exists', async () => {
-    Code.expect(isAsync(controller.postResetPassword)).to.equal(true);
+  test('postResetPassword function exists', async () => {
+    expect(isAsync(controller.postResetPassword)).to.equal(true);
   });
 
-  lab.test('getResetSuccess function exists', async () => {
-    Code.expect(isAsync(controller.getResetSuccess)).to.equal(true);
+  test('getResetSuccess function exists', async () => {
+    expect(isAsync(controller.getResetSuccess)).to.equal(true);
   });
 
-  lab.test('getChangePassword function exists', async () => {
-    Code.expect(isAsync(controller.getChangePassword)).to.equal(true);
+  test('getChangePassword function exists', async () => {
+    expect(isAsync(controller.getChangePassword)).to.equal(true);
   });
 
-  lab.test('postChangePassword function exists', async () => {
-    Code.expect(isAsync(controller.postChangePassword)).to.equal(true);
+  test('postChangePassword function exists', async () => {
+    expect(isAsync(controller.postChangePassword)).to.equal(true);
+  });
+});
+
+experiment('postChangePassword', () => {
+  let h;
+  let request;
+
+  beforeEach(async () => {
+    h = {
+      redirect: sandbox.spy(),
+      view: sandbox.spy()
+    };
+
+    request = {
+      payload: {
+        resetGuid: 'test-id',
+        password: 'test-password'
+      }
+    };
+
+    sandbox.stub(idmConnector, 'getUserByResetGuid').resolves({
+      user_name: 'test-user-name',
+      error: null
+    });
+
+    sandbox.stub(idmConnector, 'updatePasswordWithGuid').resolves({
+      error: null
+    });
+
+    sandbox.stub(loginHelpers, 'getLoginRedirectPath').resolves('test-path');
+
+    sandbox.stub(signIn, 'auto').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('redirects to reset expired if user not found', async () => {
+    idmConnector.getUserByResetGuid.resolves(null);
+    await controller.postChangePassword(request, h);
+
+    const [redirectPath] = h.redirect.lastCall.args;
+    expect(redirectPath).to.equal('/reset_password?flash=resetLinkExpired');
+  });
+
+  test('renders the form again for form errors', async () => {
+    request.formError = {};
+    await controller.postChangePassword(request, h);
+
+    const [view] = h.view.lastCall.args;
+    expect(view).to.equal('water/reset-password/reset_password_change_password');
+  });
+
+  test('redirects to reset expired if password not updated', async () => {
+    idmConnector.updatePasswordWithGuid.resolves({
+      error: 'bad'
+    });
+    await controller.postChangePassword(request, h);
+
+    const [redirectPath] = h.redirect.lastCall.args;
+    expect(redirectPath).to.equal('/reset_password?flash=resetLinkExpired');
+  });
+
+  experiment('on success', () => {
+    test('the user is signed in', async () => {
+      await controller.postChangePassword(request, h);
+      const [, userName] = signIn.auto.lastCall.args;
+      expect(userName).to.equal('test-user-name');
+    });
+
+    test('redirects to the return values from the login helper', async () => {
+      await controller.postChangePassword(request, h);
+      const [redirectPath] = h.redirect.lastCall.args;
+      expect(loginHelpers.getLoginRedirectPath.calledWith(request)).to.be.true();
+      expect(redirectPath).to.equal('test-path');
+    });
   });
 });


### PR DESCRIPTION
WATER-1967

FIxes a bug where the company switcher was shown to a user
after they had reset their password via the email route.

Moves the `login-helpers` module up to `/src/lib/` so it is accessible
to the `auth` and `reset-password` modules.