### PR TITLE
Fix path for return links, add method to get path for Edit Return button

### DIFF
--- a/src/modules/returns/controllers/view.js
+++ b/src/modules/returns/controllers/view.js
@@ -14,7 +14,7 @@ const {
   getLinesWithReadings
 } = require('../lib/return-helpers');
 
-const { getReturnPath } = require('../lib/return-path');
+const { getEditButtonPath } = require('../lib/return-path');
 
 const { returns } = require('../../../lib/connectors/water');
 
@@ -81,7 +81,7 @@ const getReturn = async (request, h) => {
     lines,
     pageTitle: `Abstraction return for ${licenceNumber}`,
     documentHeader,
-    path: getReturnPath(data, request),
+    editButtonPath: getEditButtonPath(data, request),
     showVersions,
     isVoid: data.status === 'void'
   };

--- a/src/modules/returns/lib/return-path.js
+++ b/src/modules/returns/lib/return-path.js
@@ -19,6 +19,19 @@ const isAfterSummer2018 = ret => moment(getEndDate(ret)).isSameOrAfter('2018-10-
 const isEndDatePast = ret => moment().isSameOrAfter(getEndDate(ret), 'day');
 
 /**
+ * Gets a link to the edit return page
+ * @param  {Object} ret     - return row
+ * @param  {Object} request - HAPI request
+ * @return {String}         link to edit return page
+ */
+const getEditButtonPath = (ret, request) => {
+  // Link to editable return
+  if (isAfterSummer2018(ret) && isEndDatePast(ret) && isInternalReturns(request) && !isVoid(ret)) {
+    return `/admin/return/internal?returnId=${ret.return_id}`;
+  }
+};
+
+/**
  * Gets a link to view/edit return for internal users
  * @param  {Object} ret     - return row
  * @param  {Object} request - HAPI request
@@ -26,13 +39,13 @@ const isEndDatePast = ret => moment().isSameOrAfter(getEndDate(ret), 'day');
  */
 const getInternalPath = (ret, request) => {
   const returnId = getReturnId(ret);
-  // Link to editable return
-  if (isAfterSummer2018(ret) && isEndDatePast(ret) && isInternalReturns(request) && !isVoid(ret)) {
-    return { path: `/admin/return/internal?returnId=${returnId}`, isEdit: true };
-  }
   // Link to completed/void return
   if (isCompleted(ret) || isVoid(ret)) {
     return { path: `/admin/returns/return?id=${returnId}`, isEdit: false };
+  }
+  // Link to editable return
+  if (isAfterSummer2018(ret) && isEndDatePast(ret) && isInternalReturns(request)) {
+    return { path: `/admin/return/internal?returnId=${ret.return_id}`, isEdit: true };
   }
 };
 
@@ -66,5 +79,6 @@ const getReturnPath = (ret, request) => {
 };
 
 module.exports = {
-  getReturnPath
+  getReturnPath,
+  getEditButtonPath
 };

--- a/src/views/water/returns/return.html
+++ b/src/views/water/returns/return.html
@@ -37,8 +37,8 @@
       <h2 class="heading-medium">Abstraction volumes</h2>
     {{/if}}
 
-    {{#if path.isEdit }}
-    <a class="button" href="{{ path.path }}">Edit return</a>
+    {{#if editButtonPath }}
+    <a class="button" href="{{ editButtonPath }}">Edit return</a>
     <br />
     <br />
     {{/if}}

--- a/test/modules/returns/lib/return-path.js
+++ b/test/modules/returns/lib/return-path.js
@@ -5,7 +5,8 @@ const { experiment, test } = exports.lab = Lab.script();
 const { expect } = require('code');
 
 const {
-  getReturnPath
+  getReturnPath,
+  getEditButtonPath
 } = require('../../../../src/modules/returns/lib/return-path');
 
 const { scope } = require('../../../../src/lib/constants');
@@ -132,8 +133,8 @@ experiment('returnPath -  internal users', () => {
   test('An internal returns user can edit a return if has completed status', async () => {
     const request = getInternalRequest(true);
     expect(getReturnPath({ ...ret, status: 'completed' }, request)).to.equal({
-      path: internalEdit,
-      isEdit: true
+      path: internalView,
+      isEdit: false
     });
   });
 
@@ -145,5 +146,32 @@ experiment('returnPath -  internal users', () => {
   test('An internal returns user cannot edit a return if the cycle ends before 2018-10-31', async () => {
     const request = getInternalRequest(true);
     expect(getReturnPath({ ...ret, status: 'received', end_date: '2018-10-30' }, request)).to.equal(undefined);
+  });
+});
+
+experiment('Edit Return button - internal users', () => {
+  test('An internal user cannot see the edit return button', async () => {
+    const request = getInternalRequest();
+    expect(getEditButtonPath(ret, request)).to.equal(undefined);
+  });
+
+  test('An internal returns user cannot see the edit return button if it has void status', async () => {
+    const request = getInternalRequest(true);
+    expect(getEditButtonPath({ ...ret, status: 'void' }, request)).to.equal(undefined);
+  });
+
+  test('An internal returns user cannot see the edit return button if it is before Summer 2018', async () => {
+    const request = getInternalRequest(true);
+    expect(getEditButtonPath({ ...ret, end_date: '2018-10-30' }, request)).to.equal(undefined);
+  });
+
+  test('An internal returns user cannot see the edit return button if it the end date has not passed', async () => {
+    const request = getInternalRequest(true);
+    expect(getEditButtonPath({ ...ret, end_date: '3000-01-01' }, request)).to.equal(undefined);
+  });
+
+  test('An internal returns user can see the edit return button if it has completed status', async () => {
+    const request = getInternalRequest(true);
+    expect(getEditButtonPath({ ...ret, status: 'completed' }, request)).to.equal(internalEdit);
   });
 });


### PR DESCRIPTION
WATER-1954

Revert getInternalPath method to previous version, add getEditReturnButtonPath method to get the path for the button and to use it as a flag to display button when required