### PR TITLE
Add check for returns editing for internal returns users

### DIFF
--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -26,7 +26,7 @@ const {
   getLinesWithReadings, applyStatus, applyUnderQuery
 } = require('../lib/return-helpers');
 
-const { getReturnPath } = require('../lib/return-path');
+const { isInternalEdit } = require('../lib/return-path');
 
 const { isInternal } = require('../../../lib/permissions');
 
@@ -70,8 +70,7 @@ const getAmounts = async (request, h) => {
   }
 
   // Check date/roles
-  const { isEdit } = getReturnPath(data, request);
-  if (!isEdit) {
+  if (!isInternalEdit(data, request)) {
     throw Boom.unauthorized(`Access denied to submit return ${returnId}`, request.auth.credentials);
   }
 

--- a/src/modules/returns/lib/return-path.js
+++ b/src/modules/returns/lib/return-path.js
@@ -19,17 +19,26 @@ const isAfterSummer2018 = ret => moment(getEndDate(ret)).isSameOrAfter('2018-10-
 const isEndDatePast = ret => moment().isSameOrAfter(getEndDate(ret), 'day');
 
 /**
+ * Checks if return can be edited by internal returns user
+ * @param  {Object} ret     - return row
+ * @param  {Object} request - HAPI request
+ * @return {Boolean}        whether return can be edited
+ */
+const isInternalEdit = (ret, request) => {
+  return (isAfterSummer2018(ret) && isEndDatePast(ret) && isInternalReturns(request) && !isVoid(ret));
+};
+
+/**
  * Gets a link to the edit return page
  * @param  {Object} ret     - return row
  * @param  {Object} request - HAPI request
  * @return {String}         link to edit return page
  */
 const getEditButtonPath = (ret, request) => {
-  // Link to editable return
-  if (isAfterSummer2018(ret) && isEndDatePast(ret) && isInternalReturns(request) && !isVoid(ret)) {
+  if (isInternalEdit(ret, request)) {
     const returnId = getReturnId(ret);
     return `/admin/return/internal?returnId=${returnId}`;
-  }
+  };
 };
 
 /**
@@ -81,5 +90,6 @@ const getReturnPath = (ret, request) => {
 
 module.exports = {
   getReturnPath,
+  isInternalEdit,
   getEditButtonPath
 };

--- a/test/modules/returns/lib/return-path.js
+++ b/test/modules/returns/lib/return-path.js
@@ -6,6 +6,7 @@ const { expect } = require('code');
 
 const {
   getReturnPath,
+  isInternalEdit,
   getEditButtonPath
 } = require('../../../../src/modules/returns/lib/return-path');
 
@@ -155,23 +156,40 @@ experiment('Edit Return button - internal users', () => {
     expect(getEditButtonPath(ret, request)).to.equal(undefined);
   });
 
-  test('An internal returns user cannot see the edit return button if it has void status', async () => {
+  test('An internal returns user cannot see the edit return button if isInternalEdit is false', async () => {
     const request = getInternalRequest(true);
     expect(getEditButtonPath({ ...ret, status: 'void' }, request)).to.equal(undefined);
   });
 
-  test('An internal returns user cannot see the edit return button if it is before Summer 2018', async () => {
+  test('An internal returns user can see the edit return button if isInternalEdit is true', async () => {
     const request = getInternalRequest(true);
-    expect(getEditButtonPath({ ...ret, end_date: '2018-10-30' }, request)).to.equal(undefined);
+    expect(getEditButtonPath(ret, request)).to.equal(internalEdit);
+  });
+});
+
+experiment('isInternalEdit - internal users', () => {
+  test('An internal user cannot see the edit return button', async () => {
+    const request = getInternalRequest();
+    expect(isInternalEdit(ret, request)).to.equal(false);
   });
 
-  test('An internal returns user cannot see the edit return button if it the end date has not passed', async () => {
+  test('An internal returns user cannot edit a return if it has void status', async () => {
     const request = getInternalRequest(true);
-    expect(getEditButtonPath({ ...ret, end_date: '3000-01-01' }, request)).to.equal(undefined);
+    expect(isInternalEdit({ ...ret, status: 'void' }, request)).to.equal(false);
   });
 
-  test('An internal returns user can see the edit return button if it has completed status', async () => {
+  test('An internal returns user cannot edit a return if the end date is before Summer 2018', async () => {
     const request = getInternalRequest(true);
-    expect(getEditButtonPath({ ...ret, status: 'completed' }, request)).to.equal(internalEdit);
+    expect(isInternalEdit({ ...ret, end_date: '2018-10-30' }, request)).to.equal(false);
+  });
+
+  test('An internal returns user cannot edit a return if it the end date has not passed', async () => {
+    const request = getInternalRequest(true);
+    expect(isInternalEdit({ ...ret, end_date: '3000-01-01' }, request)).to.equal(false);
+  });
+
+  test('An internal returns user can edit a return if it has completed status', async () => {
+    const request = getInternalRequest(true);
+    expect(isInternalEdit({ ...ret, status: 'completed' }, request)).to.equal(true);
   });
 });


### PR DESCRIPTION
WATER-1971

Use returns editing logic for internal returns users to display 'Edit Return' button and when checking if return can be edited