### PR TITLE
Feat: Changes to paper form issuing

### DIFF
--- a/src/lib/connectors/water-service/returns-notifications.js
+++ b/src/lib/connectors/water-service/returns-notifications.js
@@ -41,14 +41,15 @@ const buildRequest = (filter, issuer, name, messageRef, isSending = false) => {
 const getPaperFormFilter = (licenceNumbers, refDate) => {
   const minEndDate = moment(refDate).subtract(1, 'years').format('YYYY-MM-DD');
   return {
-    status: 'due',
+    status: {
+      $in: ['due', 'completed']
+    },
     end_date: {
       $gt: minEndDate
     },
     licence_ref: {
       $in: licenceNumbers
-    },
-    'metadata->>isCurrent': 'true'
+    }
   };
 };
 

--- a/src/modules/returns-notifications/controller.js
+++ b/src/modules/returns-notifications/controller.js
@@ -1,5 +1,5 @@
 const Boom = require('boom');
-const { difference } = require('lodash');
+const { reduce, pick, uniqBy, difference } = require('lodash');
 const { handleRequest, getValues, setValues } = require('../../lib/forms');
 const { csvDownload } = require('../../lib/csv-download');
 const licenceNumbersForm = require('./forms/licence-numbers');
@@ -7,8 +7,9 @@ const confirmLicenceNumbersForm = require('./forms/licence-numbers-confirm');
 const { schema } = require('./forms/licence-numbers');
 const { sendRemindersForm } = require('./forms/send-reminders');
 
-const { previewPaperForms, sendPaperForms, finalReturnReminders } = require('../../lib/connectors/water-service/returns-notifications');
-const { getUniqueLicenceNumbers, getFinalReminderConfig } = require('./lib/helpers');
+const notificationsConnector = require('../../lib/connectors/water-service/returns-notifications');
+
+const { getFinalReminderConfig } = require('./lib/helpers');
 
 /**
  * Renders a page for the user to input a list of licences to whom
@@ -19,6 +20,37 @@ const getSendForms = async (request, h) => {
     ...request.view,
     form: licenceNumbersForm(request)
   });
+};
+
+/**
+ * Takes the return data object that has the licence end date properties
+ * and adds comma separated string for any of the end dates that are set.
+ *
+ * e.g.
+ * { licence_ref: '12', dateRevoked: null, dateExpired: 'a date', dateLapsed: 'a date' }
+ *
+ * will be augmented with an value 'Expired, Lapsed'
+ *
+ * {
+ *  licence_ref: '12',
+ *  dateRevoked: null, dateExpired: 'a date', dateLapsed: 'a date',
+ *  endedReasons: 'Expired, Lapsed'
+ * }
+ */
+const addEndedReasonList = returnData => {
+  const ret = pick(returnData, 'dateRevoked', 'dateExpired', 'dateLapsed');
+
+  const reasons = reduce(ret, (acc, val, key) => {
+    return val ? [...acc, key.replace('date', '')] : acc;
+  }, []);
+
+  returnData.endedReasons = reasons.join(', ');
+  return returnData;
+};
+
+const getUniqueLicences = returns => {
+  const uniqueLicences = uniqBy(returns, 'licence_ref');
+  return uniqueLicences.map(addEndedReasonList);
 };
 
 /**
@@ -36,21 +68,24 @@ const postPreviewRecipients = async (request, h) => {
 
     // Preview sending of paper forms.  This checks whether due returns exist
     // for the requested licence numbers
-    const result = await previewPaperForms(licenceNumbers, emailAddress);
+    const result = await notificationsConnector.previewPaperForms(licenceNumbers, emailAddress);
 
     if (result.error) {
       throw Boom.badImplementation(`Error previewing returns paper forms`, result.error);
     }
 
-    const foundLicenceNumbers = getUniqueLicenceNumbers(result.data);
+    const uniqueLicences = getUniqueLicences(result.data);
+    const uniqueLicenceNumbers = uniqueLicences.map(l => l.licence_ref);
 
-    const confirmForm = setValues(confirmLicenceNumbersForm(request), { licenceNumbers: foundLicenceNumbers });
+    const confirmForm = setValues(confirmLicenceNumbersForm(request), {
+      licenceNumbers: uniqueLicenceNumbers
+    });
 
     return h.view('water/returns-notifications/forms-confirm', {
       ...request.view,
       form: confirmForm,
-      licenceNumbers: foundLicenceNumbers,
-      notMatched: difference(licenceNumbers, foundLicenceNumbers)
+      uniqueLicences,
+      notMatched: difference(licenceNumbers, uniqueLicenceNumbers)
     });
   } else {
     return h.view('water/returns-notifications/forms', {
@@ -74,7 +109,7 @@ const postSendForms = async (request, h) => {
 
     // Preview sending of paper forms.  This checks whether due returns exist
     // for the requested licence numbers
-    const result = await sendPaperForms(licenceNumbers, emailAddress);
+    const result = await notificationsConnector.sendPaperForms(licenceNumbers, emailAddress);
 
     if (result.error) {
       throw Boom.badImplementation(`Error previewing returns paper forms`, result.error);
@@ -114,7 +149,7 @@ const getFinalReminder = async (request, h) => {
  */
 const getFinalReminderCSV = async (request, h) => {
   const { email, endDate } = getFinalReminderConfig(request);
-  const { messages } = await finalReturnReminders(endDate, email, true);
+  const { messages } = await notificationsConnector.finalReturnReminders(endDate, email, true);
   const data = messages.map(row => row.personalisation);
   return csvDownload(h, data, `final-reminders-${endDate}.csv`);
 };
@@ -124,7 +159,7 @@ const getFinalReminderCSV = async (request, h) => {
  */
 const postSendFinalReminder = async (request, h) => {
   const { email, endDate } = getFinalReminderConfig(request);
-  const { event } = await finalReturnReminders(endDate, email, false);
+  const { event } = await notificationsConnector.finalReturnReminders(endDate, email, false);
   const view = {
     ...request.view,
     event

--- a/src/modules/returns-notifications/forms/licence-numbers.js
+++ b/src/modules/returns-notifications/forms/licence-numbers.js
@@ -1,5 +1,4 @@
 const Joi = require('joi');
-const { cloneDeep, set } = require('lodash');
 const { formFactory, fields } = require('../../../lib/forms');
 
 const licenceNumbersForm = (request) => {

--- a/src/views/water/returns-notifications/forms-confirm.html
+++ b/src/views/water/returns-notifications/forms-confirm.html
@@ -2,37 +2,38 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-
-
   <div class="grid-row">
     <div class="column-two-thirds">
 
-
       {{#if notMatched }}
-      <h1 class="heading-large">Due returns could not be found for some licences:</h1>
-
+        <h1 class="heading-large">Due returns could not be found for some licences:</h1>
         <ul class="list list-bullet text">
           {{#each notMatched }}<li>{{ this }}</li>{{/each}}
         </ul>
-
       {{else}}
         <h1 class="heading-large">{{ pageTitle }}</h1>
       {{/if}}
 
+      {{# if uniqueLicences.length }}
+        <div class="notice medium-space">
+          <i class="icon icon-important">
+            <span class="visually-hidden">Warning</span>
+          </i>
+          <strong class="bold-small">
+            You are about to send paper return forms to the licence holders for the following licences by post.
+          </strong>
+        </div>
 
-      {{# if licenceNumbers.length }}
-      <div class="notice medium-space">
-                <i class="icon icon-important">
-                  <span class="visually-hidden">Warning</span>
-                </i>
-                <strong class="bold-small">
-                  You are about to send paper return forms to the licence holders for the following licences by post.
-                </strong>
-              </div>
-
-              <ul class="list list-bullet text">
-                {{#each licenceNumbers }}<li>{{ this }}</li>{{/each}}
-              </ul>
+        <ul class="list list-bullet text">
+          {{#each uniqueLicences }}
+            <li>
+              {{ this.licence_ref }}
+              {{# if this.endedReasons }}
+                - {{ this.endedReasons }}
+              {{/if}}
+            </li>
+          {{/each}}
+        </ul>
 
         {{>form form }}
 
@@ -42,9 +43,5 @@
   </div>
 </main>
 
-
-
 {{> footerjs}}
-
-
 {{> debug}}

--- a/test/modules/returns-notifications/controller.js
+++ b/test/modules/returns-notifications/controller.js
@@ -1,0 +1,119 @@
+const { expect } = require('code');
+const {
+  beforeEach,
+  afterEach,
+  experiment,
+  test
+} = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const controller = require('../../../src/modules/returns-notifications/controller');
+const notificationsConnector = require('../../../src/lib/connectors/water-service/returns-notifications');
+
+const createLicence = (id, overrides = {}) => {
+  return {
+    licence_ref: `l${id}`,
+    return_id: `r${id}`,
+    dateRevoked: overrides.dateRevoked || null,
+    dateExpired: overrides.dateExpired || null,
+    dateLapsed: overrides.dateLapsed || null
+  };
+};
+
+experiment('postPreviewRecipients', () => {
+  let h;
+  let request;
+
+  beforeEach(async () => {
+    h = { view: sandbox.spy() };
+
+    request = {
+      payload: {
+        licenceNumbers: 'l1 l2 l3 l4 l5 l6',
+        csrf_token: 'bfc56166-e983-4f01-90fe-f70c191017ca'
+      },
+      view: {},
+      log: sandbox.spy(),
+      auth: {
+        credentials: {
+          username: 'test-user@example.com'
+        }
+      }
+    };
+
+    sandbox.stub(notificationsConnector, 'previewPaperForms').resolves({
+      error: null,
+      data: [
+        createLicence(1),
+        createLicence(2, { dateRevoked: '20020202' }),
+        createLicence(3, { dateExpired: '20030303' }),
+        createLicence(4, { dateLapsed: '20040404' }),
+        createLicence(5, { dateRevoked: '20050505', dateExpired: '20050505' })
+      ]
+    });
+  });
+
+  afterEach(async () => { sandbox.restore(); });
+
+  experiment('when the form is not valid', () => {
+    test('the form view is shown again', async () => {
+      request.payload = { licenceNumbers: '' };
+      await controller.postPreviewRecipients(request, h);
+      const [viewName] = h.view.lastCall.args;
+      expect(viewName).to.equal('water/returns-notifications/forms');
+    });
+  });
+
+  experiment('when there is an error previewing the forms', () => {
+    test('a boom error is thrown', async () => {
+      notificationsConnector.previewPaperForms.resolves({
+        error: {
+          name: 'test-error',
+          message: 'test-error-message'
+        },
+        data: null
+      });
+
+      const err = await expect(controller.postPreviewRecipients(request, h)).to.reject();
+      expect(err.isBoom).to.be.true();
+      expect(err.data).to.equal({ name: 'test-error', message: 'test-error-message' });
+    });
+  });
+
+  experiment('when the data is valid', () => {
+    test('the confirm view is rendered', async () => {
+      await controller.postPreviewRecipients(request, h);
+      const [viewName] = h.view.lastCall.args;
+      expect(viewName).to.equal('water/returns-notifications/forms-confirm');
+    });
+
+    test('the found licences are added to the view', async () => {
+      await controller.postPreviewRecipients(request, h);
+      const [, context] = h.view.lastCall.args;
+      expect(context.uniqueLicences[0].licence_ref).to.equal('l1');
+      expect(context.uniqueLicences[1].licence_ref).to.equal('l2');
+      expect(context.uniqueLicences[2].licence_ref).to.equal('l3');
+      expect(context.uniqueLicences[3].licence_ref).to.equal('l4');
+      expect(context.uniqueLicences[4].licence_ref).to.equal('l5');
+    });
+
+    test('licences that are not matched are added to the view', async () => {
+      await controller.postPreviewRecipients(request, h);
+      const [, context] = h.view.lastCall.args;
+      expect(context.notMatched).to.equal(['l6']);
+    });
+
+    test('licence objects with end dates contain endedReasons', async () => {
+      await controller.postPreviewRecipients(request, h);
+      const [, context] = h.view.lastCall.args;
+      const [l1, l2, l3, l4, l5] = context.uniqueLicences;
+      expect(l1.endedReasons).to.equal('');
+      expect(l2.endedReasons).to.equal('Revoked');
+      expect(l3.endedReasons).to.equal('Expired');
+      expect(l4.endedReasons).to.equal('Lapsed');
+      expect(l5.endedReasons).to.equal('Revoked, Expired');
+    });
+  });
+});


### PR DESCRIPTION
WATER-1950

Allow paper forms to be produced even if they have already been received
by updating the query filter to also included 'complete' returns.

Add licence ended reasons for notification preview to warn the user that
the licence is revoked/expired/lapsed.