### PR TITLE
Fix: Selects company when creating security code

### DIFF
--- a/src/lib/connectors/api-client-factory.js
+++ b/src/lib/connectors/api-client-factory.js
@@ -1,0 +1,13 @@
+const { APIClient } = require('@envage/hapi-pg-rest-api');
+const http = require('./http');
+
+const create = endpoint => {
+  return new APIClient(http.request, {
+    endpoint,
+    headers: {
+      Authorization: process.env.JWT_TOKEN
+    }
+  });
+};
+
+exports.create = create;

--- a/src/modules/add-licences/controller.js
+++ b/src/modules/add-licences/controller.js
@@ -10,7 +10,8 @@ const CRM = require('../../lib/connectors/crm');
 const Notify = require('../../lib/connectors/notify');
 const { forceArray } = require('../../lib/helpers');
 const logger = require('../../lib/logger');
-
+const loginHelpers = require('../../lib/login-helpers');
+const { throwIfError } = require('@envage/hapi-pg-rest-api');
 const { checkLicenceSimilarity, checkNewLicenceSimilarity, extractLicenceNumbers, uniqueAddresses } = require('../../lib/licence-helpers');
 
 const {
@@ -274,76 +275,100 @@ async function getAddressSelect (request, reply) {
   }
 }
 
+const validateDocumentIdInSelectedIds = (addressDocumentId, selectedIds) => {
+  if (!selectedIds.includes(addressDocumentId)) {
+    throw new InvalidAddressError();
+  }
+};
+
+const getEntityIdFromRequest = request => request.auth.credentials.entity_id;
+
+const getAddressSelectViewContext = async (request, verification, licence) => {
+  const entityId = getEntityIdFromRequest(request);
+  const userLicences = await getAllUserEntityLicences(entityId);
+
+  const context = request.view;
+  context.pageTitle = 'We are sending you a letter';
+  context.activeNavLink = 'manage';
+  context.verification = verification;
+  context.licence = licence;
+  context.licenceCount = userLicences.length;
+  return context;
+};
+
+const getLicences = async selectedIds => {
+  const { error, data } = await CRM.documents.findMany({
+    document_id: { $or: selectedIds }
+  });
+
+  throwIfError(error);
+  return data;
+};
+
+const getAllUserEntityLicences = async entityId => {
+  const { error, data } = await CRM.documents.findMany({
+    company_entity_id: { $ne: null },
+    entity_id: entityId
+  });
+
+  throwIfError(error);
+  return data;
+};
+
+const getLicence = async documentId => {
+  const { error, data } = await CRM.documents.findOne(documentId);
+  throwIfError(error);
+  return data;
+};
+
 /**
  * Post handler for select address form
  * @param {Object} request - HAPI HTTP request
  * @param {Object} request.payload - HTTP POST request params
  * @param {String} request.payload.token - signed Iron token containing all and selected licence IDs
  * @param {String} request.payload.address - documentId for licence with address for post verify
- * @param {Object} reply - HAPI HTTP reply
+ * @param {Object} h - HAPI Response Toolkit
  */
-async function postAddressSelect (request, reply) {
+async function postAddressSelect (request, h) {
   const { address } = request.payload;
-  const { entity_id: entityId } = request.auth.credentials;
+  const entityId = getEntityIdFromRequest(request);
 
   try {
     // Load session data
     const { selectedIds } = request.sessionStore.get('addLicenceFlow');
 
-    // Ensure address present in list of document IDs in data
-    if (!selectedIds.includes(address)) {
-      throw new InvalidAddressError();
-    }
+    validateDocumentIdInSelectedIds(address, selectedIds);
 
     // Find licences in CRM for selected documents
-    const { data: licenceData, error: licenceError } = await CRM.documents.findMany({ document_id: { $or: selectedIds } });
-    if (licenceError) {
-      throw licenceError;
-    }
+    const licenceData = await getLicences(selectedIds);
 
     // Get company entity ID for current user
-    const companyEntityId = await CRM.getOrCreateCompanyEntity(entityId, licenceData[0].metadata.Name);
+    const companyName = licenceData[0].metadata.Name;
+    const companyEntityId = await CRM.getOrCreateCompanyEntity(entityId, companyName);
 
     // Create verification
     const verification = await CRM.createVerification(entityId, companyEntityId, selectedIds);
 
     // Get the licence containing the selected verification address
-    const { error, data } = await CRM.documents.findOne(address);
-    if (error) {
-      throw error;
-    }
+    const addressLicence = await getLicence(address);
 
     // Post letter
-    await Notify.sendSecurityCode(data, verification.verification_code);
-
-    // Get all licences - this is needed to determine whether to display link back to dashboard
-    const { error: err2, data: licences } = await CRM.documents.findMany({
-      company_entity_id: { $ne: null },
-      entity_id: entityId
-    });
-
-    if (err2) {
-      throw err2;
-    }
+    await Notify.sendSecurityCode(addressLicence, verification.verification_code);
 
     // Delete data in session
     request.sessionStore.delete('addLicenceFlow');
+    //
+    // add the company id to the cookie to configure company switcher correctly
+    loginHelpers.selectCompany(request, { entityId: companyEntityId, name: companyName });
 
-    const viewContext = request.view;
-    viewContext.pageTitle = `We are sending you a letter`;
-    viewContext.activeNavLink = 'manage';
-    viewContext.verification = verification;
-    viewContext.licence = data;
-    viewContext.licenceCount = licences.length;
+    const viewContext = await getAddressSelectViewContext(request, verification, addressLicence);
 
-    return reply.view('water/licences-add/verification-sent', viewContext);
+    return h.view('water/licences-add/verification-sent', viewContext);
   } catch (err) {
     if (err.name === 'InvalidAddressError') {
-      return reply.redirect('/select-address?error=invalidAddress');
+      return h.redirect('/select-address?error=invalidAddress');
     }
-
     throw err;
-    // errorHandler(request, reply)(err);
   }
 }
 

--- a/src/views/water/licences-add/verification-sent.html
+++ b/src/views/water/licences-add/verification-sent.html
@@ -1,16 +1,6 @@
 {{> styles}}
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
-  <!-- <nav>
-    <div class="breadcrumbs">
-
-      <ol>
-        <li><a href="/licences">{{ labels.licences }}</a></li>
-        <li><a href="/manage_licences_add">Manage your licences</a></li>
-        <li><a href="/add-licences">Request access</a></li>
-      </ol>
-    </div>
-  </nav> -->
 
   <div class="grid-row">
     <div class="column-two-thirds">
@@ -29,9 +19,7 @@
           {{ licence.metadata.Postcode }}
         </p>
 
-        <p>
-          You should receive it within 2 to 3 days
-        </p>
+        <p>You should receive it within 2 to 3 days</p>
 
         <!-- Links -->
         <p>
@@ -48,13 +36,8 @@
         {{/if}}
 
       </div>
-
-
     </div>
   </div>
-
-
-
 </main>
 {{> footerjs}}
 {{> debug}}

--- a/test/lib/connectors/water.js
+++ b/test/lib/connectors/water.js
@@ -1,0 +1,120 @@
+const { expect } = require('code');
+const {
+  beforeEach,
+  afterEach,
+  experiment,
+  test
+} = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const waterConnector = require('../../../src/lib/connectors/water');
+const serviceRequest = require('../../../src/lib/connectors/service-request');
+const config = require('../../../config');
+
+beforeEach(async () => {
+  sandbox.stub(serviceRequest, 'get').resolves();
+  sandbox.stub(serviceRequest, 'post').resolves();
+});
+
+afterEach(async () => {
+  sandbox.restore();
+});
+
+experiment('sendNotifyMessage', () => {
+  let recipient;
+  let personalisation;
+
+  beforeEach(async () => {
+    recipient = { to: 'test@example.com' };
+    personalisation = { address: 'test-address' };
+  });
+
+  test('uses the expected url', async () => {
+    await waterConnector.sendNotifyMessage('test-ref', recipient, personalisation);
+    const [url] = serviceRequest.post.lastCall.args;
+    expect(url).to.equal(`${config.services.water}/notify/test-ref`);
+  });
+
+  test('passes the expected body', async () => {
+    await waterConnector.sendNotifyMessage('test-ref', recipient, personalisation);
+    const [, body] = serviceRequest.post.lastCall.args;
+    expect(body).to.equal({
+      body: {
+        recipient: {
+          to: 'test@example.com'
+        },
+        personalisation: {
+          address: 'test-address'
+        }
+      }
+    });
+  });
+
+  test('returns the response body on success', async () => {
+    serviceRequest.post.resolves({
+      body: 'body-content'
+    });
+
+    const data = await waterConnector.sendNotifyMessage('test-ref', recipient, personalisation);
+
+    expect(data).to.equal('body-content');
+  });
+
+  test('returns the response body on failure', async () => {
+    serviceRequest.post.rejects({
+      error: 'bad news'
+    });
+
+    const response = await waterConnector.sendNotifyMessage('test-ref', recipient, personalisation);
+
+    expect(response).to.equal({ error: 'bad news' });
+  });
+});
+
+experiment('sendNotification', () => {
+  const taskConfigId = 'test-config-id';
+  const licenceNumbers = ['123', '456'];
+  const params = { one: 1 };
+  const sender = 'test-sender';
+
+  test('uses the preview url when no sender', async () => {
+    await waterConnector.sendNotification(taskConfigId, licenceNumbers, params);
+    const [url] = serviceRequest.post.lastCall.args;
+
+    expect(url).to.equal(`${config.services.water}/notification/preview`);
+  });
+
+  test('uses the send url when a sender is passed', async () => {
+    await waterConnector.sendNotification(taskConfigId, licenceNumbers, params, sender);
+    const [url] = serviceRequest.post.lastCall.args;
+
+    expect(url).to.equal(`${config.services.water}/notification/send`);
+  });
+
+  test('passes the expected body', async () => {
+    await waterConnector.sendNotification(taskConfigId, licenceNumbers, params, sender);
+    const [, options] = serviceRequest.post.lastCall.args;
+
+    expect(options).to.equal({
+      body: {
+        filter: {
+          system_external_id: {
+            $in: licenceNumbers
+          }
+        },
+        taskConfigId,
+        params,
+        sender
+      }
+    });
+  });
+});
+
+experiment('getRiverLevel', () => {
+  test('uses the expected url', async () => {
+    await waterConnector.getRiverLevel('test-station');
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(`${config.services.water}/river-levels/station/test-station`);
+  });
+});

--- a/test/modules/add-licences/controller.js
+++ b/test/modules/add-licences/controller.js
@@ -6,12 +6,15 @@ const Hapi = require('hapi');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 
+const crmConnector = require('../../../src/lib/connectors/crm');
 const crmDocumentConnector = require('../../../src/lib/connectors/crm/documents');
 const routes = require('../../../src/modules/add-licences/routes');
 const licenceLoaderPlugin = require('../../../src/lib/hapi-plugins/licence-loader');
 const viewContextPlugin = require('../../../src/lib/hapi-plugins/view-context');
 const requestStubPlugin = require('../../lib/hapi-plugins/request-stub-plugin');
 const { scope } = require('../../../src/lib/constants');
+const controller = require('../../../src/modules/add-licences/controller');
+const notifyConnector = require('../../../src/lib/connectors/notify');
 
 const { set } = require('lodash');
 
@@ -76,5 +79,139 @@ experiment('getSecurityCode', () => {
     const mainNavLinks = response.request.view.mainNavLinks;
     expect(mainNavLinks.length).to.equal(1);
     expect(mainNavLinks[0].id).to.equal('view');
+  });
+});
+
+experiment('postAddressSelect', () => {
+  let request;
+  let h;
+
+  beforeEach(async () => {
+    request = {
+      sessionStore: {
+        get: () => ({
+          selectedIds: [1, 2]
+        }),
+        delete: sinon.spy()
+      },
+      auth: {
+        credentials: {
+          entity_id: 'test-entity-id'
+        }
+      },
+      payload: {
+        address: 1
+      },
+      view: {},
+      cookieAuth: {
+        set: sinon.spy()
+      }
+    };
+
+    h = {
+      redirect: sinon.spy(),
+      view: sinon.spy()
+    };
+
+    sandbox.stub(crmConnector.documents, 'findMany').resolves({
+      error: null,
+      data: [{ metadata: { Name: 'test-company-name' } }]
+    });
+
+    sandbox.stub(crmConnector.documents, 'findOne').resolves({
+      error: null,
+      data: { licence_ref: 'test-licence-id' }
+    });
+
+    sandbox.stub(crmConnector, 'getOrCreateCompanyEntity').resolves('test-company-entity-id');
+    sandbox.stub(crmConnector, 'createVerification').resolves({
+      verification_code: 'test-verification-code'
+    });
+
+    sandbox.stub(notifyConnector, 'sendSecurityCode').resolves();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('when payload address id is not in the selected documents', () => {
+    test('an error is not thrown', async () => {
+      request.payload.address = 999;
+      await expect(controller.postAddressSelect(request, h)).to.not.reject();
+    });
+
+    test('a redirect is returned', async () => {
+      request.payload.address = 999;
+      await controller.postAddressSelect(request, h);
+
+      const [path] = h.redirect.lastCall.args;
+      expect(path).to.equal('/select-address?error=invalidAddress');
+    });
+  });
+
+  test('throws if the crm licences cannot be read', async () => {
+    crmConnector.documents.findMany.resolves({
+      error: 'bad news',
+      data: null
+    });
+
+    await expect(controller.postAddressSelect(request, h)).to.reject();
+  });
+
+  test('gets the company id user entity id', async () => {
+    await controller.postAddressSelect(request, h);
+    const [companyEntityId, companyName] = crmConnector.getOrCreateCompanyEntity.lastCall.args;
+    expect(companyEntityId).to.equal('test-entity-id');
+    expect(companyName).to.equal('test-company-name');
+  });
+
+  test('uses the company id to create the verification', async () => {
+    await controller.postAddressSelect(request, h);
+    const [entityId, companyEntityId, selectedIds] = crmConnector.createVerification.lastCall.args;
+
+    expect(entityId).to.equal('test-entity-id');
+    expect(companyEntityId).to.equal('test-company-entity-id');
+    expect(selectedIds).to.equal([1, 2]);
+  });
+
+  test('throws if the licences cannot be read', async () => {
+    crmConnector.documents.findMany.onSecondCall().resolves({
+      error: 'bang',
+      data: null
+    });
+
+    await expect(controller.postAddressSelect(request, h)).to.reject();
+  });
+
+  test('delete the licence flow data from session', async () => {
+    await controller.postAddressSelect(request, h);
+    expect(request.sessionStore.delete.calledWith('addLicenceFlow')).to.be.true();
+  });
+
+  test('renders the expected view', async () => {
+    await controller.postAddressSelect(request, h);
+    const [viewName] = h.view.lastCall.args;
+    expect(viewName).to.equal('water/licences-add/verification-sent');
+  });
+
+  test('passes the expected data to the view', async () => {
+    await controller.postAddressSelect(request, h);
+    const [, viewData] = h.view.lastCall.args;
+    expect(viewData.pageTitle).to.equal('We are sending you a letter');
+    expect(viewData.activeNavLink).to.equal('manage');
+    expect(viewData.verification.verification_code).to.equal('test-verification-code');
+    expect(viewData.licence.licence_ref).to.equal('test-licence-id');
+    expect(viewData.licenceCount).to.equal(1);
+  });
+
+  test('adds the company id to the cookie', async () => {
+    await controller.postAddressSelect(request, h);
+
+    expect(request.cookieAuth.set.calledWith('companyId', 'test-company-entity-id'))
+      .to.be.true();
+
+    expect(request.cookieAuth.set.calledWith('companyName', 'test-company-name'))
+      .to.be.true();
   });
 });


### PR DESCRIPTION
WATER-1967

Fixes an issue where after a new user creates a security code, the
company was not set in the cookie meaning that the company switcher was
shown if the user navigated to the licences page.