### PR TITLE
Fix: Sending paper returns to expired licences

### DIFF
--- a/src/modules/returns-notifications/forms/licence-numbers.js
+++ b/src/modules/returns-notifications/forms/licence-numbers.js
@@ -18,8 +18,7 @@ const licenceNumbersForm = (request) => {
     multiline: true,
     rows: 5,
     controlClass: 'form-control form-control-3-4',
-    label: 'Enter your licence numbers',
-    hint: 'Add licence numbers here for the licences you wish to send paper forms to. Return forms will be sent for any due returns.'
+    label: 'Add licence numbers that you wish to send paper return forms to.'
   }));
   f.fields.push(fields.button(null, { label: 'Continue' }));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));

--- a/src/modules/returns-notifications/routes.js
+++ b/src/modules/returns-notifications/routes.js
@@ -13,7 +13,7 @@ module.exports = {
       plugins: {
         viewContext: {
           activeNavLink: 'notifications',
-          pageTitle: 'Send paper return forms to licence holders'
+          pageTitle: 'Send paper return forms'
         }
       }
     },
@@ -29,7 +29,7 @@ module.exports = {
       plugins: {
         viewContext: {
           activeNavLink: 'notifications',
-          pageTitle: 'Send paper return forms to licence holders'
+          pageTitle: 'Send paper return forms'
         }
       }
     },
@@ -45,7 +45,7 @@ module.exports = {
       plugins: {
         viewContext: {
           activeNavLink: 'notifications',
-          pageTitle: 'Send paper return forms to licence holders'
+          pageTitle: 'Send paper return forms'
         }
       }
     },

--- a/src/views/water/returns-notifications/forms-confirm.html
+++ b/src/views/water/returns-notifications/forms-confirm.html
@@ -20,7 +20,7 @@
             <span class="visually-hidden">Warning</span>
           </i>
           <strong class="bold-small">
-            You are about to send paper return forms to the licence holders for the following licences by post.
+            You are about to send paper return forms for the following licences.
           </strong>
         </div>
 

--- a/src/views/water/returns-notifications/forms-success.html
+++ b/src/views/water/returns-notifications/forms-success.html
@@ -2,33 +2,17 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-
-
-
   <div class="grid-row">
     <div class="column-two-thirds">
-
-
       <div class="govuk-box-highlight">
         <h1 class="heading-large">{{ pageTitle }}</h1>
-
-                <p class="font-medium">
-  They should arrive within the next five days
-                </p>
-              </div>
-
+        <p class="font-medium">They should arrive within the next five days</p>
+      </div>
 
       <a href="/admin/notifications/report">See report for notices</a>
-
-
-
     </div>
   </div>
 </main>
 
-
-
 {{> footerjs}}
-
-
 {{> debug}}

--- a/src/views/water/returns-notifications/forms.html
+++ b/src/views/water/returns-notifications/forms.html
@@ -1,29 +1,20 @@
 {{> styles}}
+
 <main id="content" tabindex="-1">
-  {{>element-phase-tag}}{{>element-main-nav}}
-
-
-
+  {{>element-phase-tag}}
+  {{>element-main-nav}}
 
   <div class="grid-row">
 
-  {{>form-errors form }}
+    {{>form-errors form }}
 
     <div class="column-two-thirds">
-
       <h1 class="heading-large">{{ pageTitle }}</h1>
-
-
-
-  {{>form form }}
-
+      
+      {{>form form }}
     </div>
   </div>
 </main>
 
-
-
 {{> footerjs}}
-
-
 {{> debug}}

--- a/test/modules/returns-notifications/controller.js
+++ b/test/modules/returns-notifications/controller.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 const { expect } = require('code');
 const {
   beforeEach,
@@ -114,6 +115,26 @@ experiment('postPreviewRecipients', () => {
       expect(l3.endedReasons).to.equal('Expired');
       expect(l4.endedReasons).to.equal('Lapsed');
       expect(l5.endedReasons).to.equal('Revoked, Expired');
+    });
+
+    test('licence objects with future end dates do not have endedReasons', async () => {
+      const futureDate = moment().add(1, 'year').format('YYYYMMDD');
+
+      notificationsConnector.previewPaperForms.resolves({
+        error: null,
+        data: [
+          createLicence(1, { dateRevoked: futureDate }),
+          createLicence(2, { dateExpired: futureDate }),
+          createLicence(3, { dateLapsed: futureDate })
+        ]
+      });
+
+      await controller.postPreviewRecipients(request, h);
+      const [, context] = h.view.lastCall.args;
+      const [l1, l2, l3] = context.uniqueLicences;
+      expect(l1.endedReasons).to.equal('');
+      expect(l2.endedReasons).to.equal('');
+      expect(l3.endedReasons).to.equal('');
     });
   });
 });


### PR DESCRIPTION
WATER-1950

Handles a bug where the presence of a date caused the licence to be
marked as expired/lapsed/revoked even if the date was in the future.