### PR TITLE
Fix: Prevent error when making no change to user returns

### DIFF
--- a/src/modules/manage-licences/controller.js
+++ b/src/modules/manage-licences/controller.js
@@ -299,17 +299,12 @@ async function postChangeAccess (request, h) {
   const { entity_id: entityID } = request.auth.credentials;
   const { returns, colleagueEntityID, returnsEntityRoleID } = request.payload;
 
-  try {
-    returns
-      ? await CRM.entityRoles.addColleagueRole(entityID, colleagueEntityID, 'user_returns')
-      : await CRM.entityRoles.deleteColleagueRole(entityID, returnsEntityRoleID);
-  } catch (error) {
-    // If a 404, the user may be deleting the role, when it is not actually set up.
-    // In that case continue to the redirect below.
-    // If anything else, this was not expected so re-throw
-    if (error.statusCode !== 404) {
-      throw error;
-    }
+  if (returns && !returnsEntityRoleID) {
+    await CRM.entityRoles.addColleagueRole(entityID, colleagueEntityID, 'user_returns');
+  }
+
+  if (!returns && returnsEntityRoleID) {
+    await CRM.entityRoles.deleteColleagueRole(entityID, returnsEntityRoleID);
   }
 
   return h.redirect('/manage_licences/access');


### PR DESCRIPTION
WATER-1973

Fixes an issue where not toggling the user returns status for an agent
caused an error.