### PR TITLE
Fix: Prevent empty inset text container

### DIFF
--- a/src/modules/returns/lib/return-helpers.js
+++ b/src/modules/returns/lib/return-helpers.js
@@ -227,14 +227,14 @@ const applyMeterDetailsProvided = (data, formValues) => {
   const { meterDetailsProvided } = formValues;
   const meter = meterDetailsProvided === true ? getMeter(data) : {};
   meter.meterDetailsProvided = meterDetailsProvided;
-  meter.multiplier = 1;
+  meter.multiplier = meter.multiplier || 1;
   return set(clone, 'meters', [meter]);
 };
 
 const applyMeterUnits = (data, formValues) => {
   const { units } = formValues;
   if (['m³', 'l', 'Ml', 'gal'].includes(units)) {
-    const clone = cloneDeep(data);
+    const clone = applyReadingType(data, 'measured');
     set(clone, 'meters[0].units', units);
     return set(clone, 'reading.units', units);
   }

--- a/src/views/nunjucks/returns/macros/confirm-page-inset-text.njk
+++ b/src/views/nunjucks/returns/macros/confirm-page-inset-text.njk
@@ -1,61 +1,49 @@
 {% from "inset-text/macro.njk" import govukInsetText %}
 
 {%macro confirmPageInsetText(return, endReading)%}
-{% set html %}
-  {%if return.reading.type == 'measured'%}
-  <div class="meta__row">
-    <dd class="meta__value">
-      {{ return.meters[0].manufacturer }}
-    </dd>
-  </div>
-  <div class="meta__row">
-    <dd class="meta__value">
-      {{ return.meters[0].serialNumber }}
-    </dd>
-  </div>
-  {%endif%}
-  {% if return.meters[0].multiplier == 10 %}
-  <div class="meta__row">
-    <dd class="meta__value">
-      Has a x10 display
-    </dd>
-  </div>
-  {%endif%}
-  {%if return.reading.method == 'oneMeter' %}
-  <div class="meta__row">
-    <dd class="meta__value">
-    Start Reading
-    {{ return.meters[0].startReading }}
-    </dd>
-  </div>
-  <div class="meta__row">
-    <dd class="meta__value">
-    End Reading
-    {{ endReading }}
-    </dd>
-  </div>
-  {%endif%}
-  {%if return.reading.type == 'estimated' %}
-  <div class="meta__row">
-    <dd class="meta__value">
-      Estimated
-    </dd>
-  </div>
-  <div class="meta__row">
-    <dd class="meta__value">
-    <!-- {{ estimateMethod? }} -->
-    </dd>
-  </div>
-  {%endif%}
-{% endset %}
 
-{%if return.reading.type == 'measured'%}
-  <br/>
-  <h4 class="govuk-heading-s">Your meter</h4>
-{%endif%}
+  {% set html %}
+    {%if return.meters[0].meterDetailsProvided%}
+      <div class="meta__row">
+        <dd class="meta__value">{{ return.meters[0].manufacturer }}</dd>
+      </div>
+      <div class="meta__row">
+        <dd class="meta__value">{{ return.meters[0].serialNumber }}</dd>
+      </div>
+      {% if return.meters[0].multiplier == 10 %}
+        <div class="meta__row">
+          <dd class="meta__value">Has a x10 display</dd>
+        </div>
+      {% endif %}
+    {% endif %}
 
-{{ govukInsetText({
-html: html
-}) }}
+    {%if return.reading.method == 'oneMeter' %}
+      <div class="meta__row">
+        <dd class="meta__value">Start reading {{ return.meters[0].startReading }}</dd>
+      </div>
+      <div class="meta__row">
+        <dd class="meta__value">End reading {{ endReading }}</dd>
+      </div>
+    {%endif%}
+
+    {%if return.reading.type == 'estimated' %}
+      <div class="meta__row">
+        <dd class="meta__value">Estimated</dd>
+      </div>
+      <div class="meta__row">
+        <dd class="meta__value">
+        <!-- {{ estimateMethod? }} -->
+        </dd>
+      </div>
+    {%endif%}
+  {% endset %}
+
+  {%if return.meters[0].meterDetailsProvided%}
+    <h4 class="govuk-heading-s">Your meter</h4>
+  {%endif%}
+
+  {% if html | trim | length %}
+    {{ govukInsetText({ html: html }) }}
+  {% endif %}
 
 {%endmacro%}

--- a/test/modules/returns/lib/return-helpers.js
+++ b/test/modules/returns/lib/return-helpers.js
@@ -548,13 +548,13 @@ experiment('applyMeterDetailsProvided', () => {
   test('leaves existing meter details if details are to be provided', async () => {
     const formValues = { meterDetailsProvided: true };
     const data = {
-      meters: [{ startReading: 100, multiplier: 1, units: 'm³' }]
+      meters: [{ startReading: 100, multiplier: 10, units: 'm³' }]
     };
     const applied = applyMeterDetailsProvided(data, formValues);
 
     expect(applied.meters[0]).to.equal({
       startReading: 100,
-      multiplier: 1,
+      multiplier: 10,
       units: 'm³',
       meterDetailsProvided: true
     });


### PR DESCRIPTION
WATER-2014

If there are no meter details, or there is no estimate for the
abstraction, then don't show the inset text container.

Also fixes an issue with the meter details being override to a 1x
multiplier.