### PR TITLE
Fix alignment issues with returns header

### DIFF
--- a/src/views/nunjucks/returns/confirm.njk
+++ b/src/views/nunjucks/returns/confirm.njk
@@ -8,12 +8,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {{ returnHeader(data, documentHeader, showMeta) }}
+    <h3 class="govuk-heading-m">Confirm your return</h3>
   </div>
 </div>
 
-  <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m">Confirm your return</h3>
-  </div>
   <div class="govuk-grid-row">
     <div class="{% if return.reading.units == 'm³' %}govuk-grid-column-two-thirds{% else %}govuk-grid-column-full{%endif%}">
       {{ returnQuantitiesTable(return, lines, endReading) }}

--- a/src/views/nunjucks/returns/macros/return-header.njk
+++ b/src/views/nunjucks/returns/macros/return-header.njk
@@ -8,7 +8,6 @@
   {% endif %}
 
   {%if showMeta %}
-  <div class="govuk-grid-column-two-thirds">
     <dl class="meta">
 
       {% if isAdmin %}
@@ -76,7 +75,6 @@
   <p class="medium-space">
     <a href="{%if isAdmin %}/admin{%endif%}/licences/{{ documentHeader.document_id }}">View this licence</a>
   </p>
-</div>
 
   {%endif%}
 


### PR DESCRIPTION
WATER-2019

Align return header with other elements on the page on 'Have you abstracted any water?' and Confirm pages