### PR TITLE
Fix: Prevent meter changes to external nil return

### DIFF
--- a/src/modules/returns/lib/return-helpers.js
+++ b/src/modules/returns/lib/return-helpers.js
@@ -437,12 +437,15 @@ const applyCleanup = (data, request) => {
     // External users can't submit single total value
     set(updated, 'reading.totalFlag', false);
     // External users must provide meter details for all meters
-    updated.meters = updated.meters.map(row => {
-      return {
-        ...row,
-        meterDetailsProvided: true
-      };
-    });
+
+    if (updated.meters) {
+      updated.meters = updated.meters.map(row => {
+        return {
+          ...row,
+          meterDetailsProvided: true
+        };
+      });
+    }
   }
 
   // Required lines and versions shouldn't be posted back to water service

--- a/test/modules/returns/lib/return-helpers.js
+++ b/test/modules/returns/lib/return-helpers.js
@@ -845,6 +845,11 @@ experiment('applyCleanup', () => {
       const result = applyCleanup(createReturn(), createRequest());
       expect(result.meters[0].meterDetailsProvided).to.equal(true);
     });
+
+    test('ignores the meters if they are undefined (nil return)', async () => {
+      const result = applyCleanup({}, createRequest());
+      expect(result.meters).to.be.undefined();
+    });
   });
 
   experiment('for internal users', () => {


### PR DESCRIPTION
WATER-2014

Updates the applyCleanUp function to ignore the updates to meters when
there is no meter information. This is for nil returns.