### PR TITLE
Fix: Spacing issue on return submitted page

### DIFF
--- a/src/views/nunjucks/returns/submitted.njk
+++ b/src/views/nunjucks/returns/submitted.njk
@@ -12,11 +12,9 @@
       html: html
     }) }}
 
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body govuk-!-margin-bottom-9">
-        <a href="{{ returnUrl }}">View this return</a>
-      </p>
-    </div>
+    <p class="govuk-body govuk-!-margin-bottom-9">
+      <a href="{{ returnUrl }}">View this return</a>
+    </p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Aligns the link for 'View this return'