### PR TITLE
Fix: Back link on log receipt for causing error

### DIFF
--- a/src/modules/returns/controllers/internal.js
+++ b/src/modules/returns/controllers/internal.js
@@ -112,7 +112,7 @@ const getLogReceipt = async (request, h) => {
     ...view,
     form: logReceiptForm(request, data),
     return: data,
-    back: getPreviousPath(STEP_INTERNAL_ROUTING, request, data)
+    back: getPreviousPath(STEP_LOG_RECEIPT, request, data)
   });
 };
 

--- a/src/modules/returns/lib/flow-helpers/index.js
+++ b/src/modules/returns/lib/flow-helpers/index.js
@@ -4,6 +4,10 @@ const externalFlows = require('./external.js');
 const permissions = require('../../../../lib/permissions');
 const steps = require('./steps');
 
+const getScopedPath = (request, path) => {
+  return permissions.isInternal(request) ? `/admin${path}` : path;
+};
+
 /**
  * Gets path with return ID query param and admin/ if required depending on scopes
  * @param {String} base path
@@ -13,9 +17,11 @@ const steps = require('./steps');
  */
 const getPath = (path, request, data) => {
   const returnId = get(data, 'returnId', request.query.returnId);
-  const scopedPath = (permissions.isInternal(request) ? `/admin${path}` : path);
-  if (path === '/returns') return scopedPath;
-  return `${scopedPath}?returnId=${returnId}`;
+  const scopedPath = getScopedPath(request, path);
+
+  return (['/returns', '/licences'].includes(path))
+    ? scopedPath
+    : `${scopedPath}?returnId=${returnId}`;
 };
 
 /**

--- a/src/modules/returns/lib/flow-helpers/internal.js
+++ b/src/modules/returns/lib/flow-helpers/internal.js
@@ -96,7 +96,8 @@ const previous = {
     return isMeterDetailsProvided(data)
       ? STEP_METER_DETAILS
       : STEP_METER_DETAILS_PROVIDED;
-  }
+  },
+  [STEP_LOG_RECEIPT]: () => STEP_INTERNAL_ROUTING
 };
 
 module.exports = {

--- a/test/modules/returns/lib/flow-helpers/index.js
+++ b/test/modules/returns/lib/flow-helpers/index.js
@@ -45,6 +45,18 @@ experiment('Returns flow helpers', () => {
       const result = getPath(path, request, data.nilReturn);
       expect(result).to.equal(`/admin/some/path?returnId=nilReturn`);
     });
+
+    test('does not add the return param for the licences route', async () => {
+      const request = createRequest(true);
+      const result = getPath('/licences', request, data.nilReturn);
+      expect(result).to.equal(`/admin/licences`);
+    });
+
+    test('does not add the return param for the returns route', async () => {
+      const request = createRequest(true);
+      const result = getPath('/returns', request, data.nilReturn);
+      expect(result).to.equal(`/admin/returns`);
+    });
   });
 
   experiment('getNextPath', () => {

--- a/test/modules/returns/lib/flow-helpers/internal.js
+++ b/test/modules/returns/lib/flow-helpers/internal.js
@@ -229,4 +229,16 @@ experiment('internal returns flow: ', () => {
       expect(result).to.equal(steps.STEP_CONFIRM);
     });
   });
+
+  experiment('for STEP_LOG_RECEIPT', () => {
+    test('next step is STEP_RECEIPT_LOGGED', async () => {
+      const result = internal.next[steps.STEP_LOG_RECEIPT]();
+      expect(result).to.equal(steps.STEP_RECEIPT_LOGGED);
+    });
+
+    test('previous step is STEP_INTERNAL_ROUTING', async () => {
+      const result = internal.previous[steps.STEP_LOG_RECEIPT]();
+      expect(result).to.equal(steps.STEP_INTERNAL_ROUTING);
+    });
+  });
 });


### PR DESCRIPTION
WATER-2038

Fixes a bug where the back link for the log return receipt was pointing
to the wrong location.

Also then fixes another issue where the back link on the internal
routing page contained the return id param, which caused a request
validation error. No goes directly to /licences as required.