### PR TITLE
Fix: Meter Details now being displayed on external confirm page

### DIFF
--- a/src/modules/returns/lib/return-helpers.js
+++ b/src/modules/returns/lib/return-helpers.js
@@ -223,7 +223,8 @@ const applyMeterDetails = (data, formValues) => {
   const details = {
     manufacturer: formValues.manufacturer,
     serialNumber: formValues.serialNumber,
-    multiplier
+    multiplier,
+    meterDetailsProvided: true
   };
 
   const meter = Object.assign(getMeter(data), details);


### PR DESCRIPTION
WATER-2044

Add meters[0].meterDetailsProvided to applyMeterDetails page to ensure flags is used in both internal and external flows