### PR TITLE
Fix: Show tariff details on confirm page

### DIFF
--- a/src/modules/returns/forms/meter-details.js
+++ b/src/modules/returns/forms/meter-details.js
@@ -19,11 +19,13 @@ const getTextField = (fieldName, label, errorMessage) => {
   });
 };
 
-const pageHeading = fields.paragraph(null, {
-  text: 'Tell us about your meter',
-  element: 'h3',
-  controlClass: 'govuk-heading-m'
-});
+const getPageHeading = isInternal => {
+  return fields.paragraph(null, {
+    text: isInternal ? 'Meter details' : 'Your current meter details',
+    element: 'h3',
+    controlClass: 'govuk-heading-m'
+  });
+};
 
 const introText = fields.paragraph(null, {
   text: 'You only need to tell us about one meter.'
@@ -32,14 +34,14 @@ const introText = fields.paragraph(null, {
 const form = (request, data) => {
   const isVolumes = get(data, 'reading.method') === 'abstractionVolumes';
 
-  const { csrfToken } = request.view;
+  const { csrfToken, isAdmin } = request.view;
 
   const action = getPath(STEP_METER_DETAILS, request);
 
   const f = formFactory(action);
   const meter = getMeter(data);
 
-  f.fields.push(pageHeading);
+  f.fields.push(getPageHeading(isAdmin));
 
   if (isVolumes) {
     f.fields.push(introText);

--- a/src/views/nunjucks/returns/confirm.njk
+++ b/src/views/nunjucks/returns/confirm.njk
@@ -8,14 +8,24 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {{ returnHeader(data, documentHeader, showMeta) }}
-    <h3 class="govuk-heading-m">Confirm your return</h3>
+    <h3 class="govuk-heading-m">
+      <span>Confirm </span>
+      {{ "this" if isAdmin else "your" }}
+      <span> return</span>
+    </h3>
   </div>
 </div>
 
   <div class="govuk-grid-row">
     <div class="{% if return.reading.units == 'm³' %}govuk-grid-column-two-thirds{% else %}govuk-grid-column-full{%endif%}">
-      {{ returnQuantitiesTable(return, lines, total, endReading) }}
-      <p><a href="{{ makeChangePath }}">Edit your {%if return.reading.method == 'oneMeter'%}meter readings{%else%}volumes{%endif%} </a></p>
+      {{ returnQuantitiesTable(return, lines, total, endReading, isAdmin) }}
+      <p>
+        <a href="{{ makeChangePath }}">
+          <span>Edit </span>
+          <span>{{ "these" if isAdmin else "your"}} </span>
+          <span>{{ "meter readings" if return.reading.method else "volumes" }}</span>
+        </a>
+      </p>
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/src/views/nunjucks/returns/macros/confirm-page-inset-text.njk
+++ b/src/views/nunjucks/returns/macros/confirm-page-inset-text.njk
@@ -1,6 +1,6 @@
 {% from "inset-text/macro.njk" import govukInsetText %}
 
-{%macro confirmPageInsetText(return, endReading)%}
+{%macro confirmPageInsetText(return, endReading, isAdmin)%}
 
   {% set html %}
     {%if return.meters[0].meterDetailsProvided%}
@@ -39,7 +39,9 @@
   {% endset %}
 
   {%if return.meters[0].meterDetailsProvided%}
-    <h4 class="govuk-heading-s">Your meter</h4>
+    <h4 class="govuk-heading-s">
+      {{ "Meter details" if isAdmin else "Your meter" }}
+    </h4>
   {%endif%}
 
   {% if html | trim | length %}

--- a/src/views/nunjucks/returns/macros/return-header.njk
+++ b/src/views/nunjucks/returns/macros/return-header.njk
@@ -70,11 +70,16 @@
           {{ return.metadata.nald.periodEndMonth | date('MMMM') }}
         </dd>
       </div>
-      </dl>
+      <div class="meta__row">
+        <dt class="meta__key">
+        {{ "Two part" if return.metadata.isTwoPartTariff else "Standard" }} tariff
+        </dt>
+      </div>
+    </dl>
 
-  <p class="medium-space">
-    <a href="{%if isAdmin %}/admin{%endif%}/licences/{{ documentHeader.document_id }}">View this licence</a>
-  </p>
+    <p class="medium-space">
+      <a href="{%if isAdmin %}/admin{%endif%}/licences/{{ documentHeader.document_id }}">View this licence</a>
+    </p>
 
   {%endif%}
 

--- a/src/views/nunjucks/returns/macros/return-quantities-table.njk
+++ b/src/views/nunjucks/returns/macros/return-quantities-table.njk
@@ -1,7 +1,7 @@
 {% from "nunjucks/returns/macros/confirm-page-inset-text.njk" import confirmPageInsetText %}
 
-{% macro returnQuantitiesTable(return, lines, total, endReading) %}
-  {{ confirmPageInsetText(return, endReading) }}
+{% macro returnQuantitiesTable(return, lines, total, endReading, isAdmin) %}
+  {{ confirmPageInsetText(return, endReading, isAdmin) }}
 
   <table class="govuk-table">
   <thead class="govuk-table__head">


### PR DESCRIPTION
WATER-2042

 - Shows the tariff type in the nunjucks confirm page
 - Updates some of the text to be from the point of view or either an
external or internal user.