### PR TITLE
Fix: Missing back buttons in forms with errors

### DIFF
--- a/src/modules/returns/controllers/edit.js
+++ b/src/modules/returns/controllers/edit.js
@@ -73,7 +73,8 @@ const postAmounts = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_START, request, data)
   }, { layout: false });
 };
 
@@ -169,7 +170,8 @@ const postMethod = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METHOD, request, data)
   }, { layout: false });
 };
 
@@ -206,7 +208,8 @@ const postUnits = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_UNITS, request, data)
   }, { layout: false });
 };
 
@@ -231,7 +234,6 @@ const postSingleTotal = async (request, h) => {
   const { data, view } = request.returns;
 
   const form = forms.handleRequest(singleTotalForm(request, data), request, singleTotalSchema);
-
   if (form.isValid) {
     const updatedData = applySingleTotal(data, forms.getValues(form));
     sessionHelpers.saveSessionData(request, updatedData);
@@ -241,7 +243,8 @@ const postSingleTotal = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_SINGLE_TOTAL, request, data)
   }, { layout: false });
 };
 
@@ -275,7 +278,8 @@ const postQuantities = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_QUANTITIES, request, data)
   }, { layout: false });
 };
 
@@ -327,7 +331,8 @@ const postMeterDetails = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METER_DETAILS, request, data)
   }, { layout: false });
 };
 
@@ -356,7 +361,8 @@ const postMeterUnits = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METER_UNITS, request, data)
   }, { layout: false });
 };
 
@@ -385,7 +391,8 @@ const postMeterReset = async (request, h) => {
   return h.view('nunjucks/returns/meter-reset.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METER_RESET, request, data)
   }, { layout: false });
 };
 
@@ -424,7 +431,8 @@ const postMeterReadings = async (request, h) => {
   return h.view('nunjucks/returns/form.njk', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METER_READINGS, request, data)
   }, { layout: false });
 };
 
@@ -461,7 +469,8 @@ const postMeterUsed = (request, h) => {
   return h.view('water/returns/internal/form', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: flowHelpers.getPreviousPath(flowHelpers.STEP_METER_USED, request, data)
   });
 };
 

--- a/src/modules/returns/controllers/internal.js
+++ b/src/modules/returns/controllers/internal.js
@@ -143,7 +143,7 @@ const postLogReceipt = async (request, h) => {
       ...view,
       form,
       return: data,
-      back: getPreviousPath(STEP_INTERNAL_ROUTING, request, data)
+      back: getPreviousPath(STEP_LOG_RECEIPT, request, data)
     });
   }
 };
@@ -212,7 +212,8 @@ const postDateReceived = async (request, h) => {
   return h.view('water/returns/internal/form', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: getPreviousPath(STEP_DATE_RECEIVED, request, data)
   });
 };
 
@@ -241,7 +242,8 @@ const postInternalMethod = async (request, h) => {
   return h.view('water/returns/internal/form', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: getPreviousPath(STEP_INTERNAL_METHOD, request, data)
   });
 };
 
@@ -270,7 +272,8 @@ const postMeterDetailsProvided = async (request, h) => {
   return h.view('water/returns/internal/form', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: getPreviousPath(STEP_METER_DETAILS_PROVIDED, request, data)
   });
 };
 
@@ -303,7 +306,8 @@ const postSingleTotalAbstractionPeriod = async (request, h) => {
   return h.view('water/returns/internal/form', {
     ...view,
     form,
-    return: data
+    return: data,
+    back: getPreviousPath(STEP_SINGLE_TOTAL_DATES, request, data)
   });
 };
 

--- a/src/views/nunjucks/layout.njk
+++ b/src/views/nunjucks/layout.njk
@@ -88,9 +88,6 @@
   {% endif %}
 {% endblock %}
 
-
-
-
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="/assets/js/all.js"></script>

--- a/src/views/water/returns/internal/form.html
+++ b/src/views/water/returns/internal/form.html
@@ -2,9 +2,9 @@
 <main id="content" tabindex="-1">
   {{>element-phase-tag}}{{>element-main-nav}}
 
-  {{>form-errors form }}
-
   <a data-no-js href="{{ back }}" class="link-back link-back--space-above">Back</a>
+
+  {{>form-errors form }}
 
   {{>return-header }}
 

--- a/test/modules/returns/controllers/edit.js
+++ b/test/modules/returns/controllers/edit.js
@@ -1,5 +1,5 @@
 const { expect } = require('code');
-const { experiment, test, beforeEach, afterEach, fail } = exports.lab = require('lab').script();
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('lab').script();
 const sinon = require('sinon');
 const controller = require('../../../../src/modules/returns/controllers/edit');
 const { returns } = require('../../../../src/lib/connectors/water');
@@ -256,6 +256,7 @@ experiment('edit controller', () => {
 
       expect(template).to.equal('nunjucks/returns/form.njk');
       expect(view.return).to.equal(request.returns.data);
+      expect(view.back).to.equal('/returns');
     });
   });
 
@@ -406,6 +407,7 @@ experiment('edit controller', () => {
 
       expect(getNextPathCalled).to.be.true();
     });
+
     test('it should render same page if form is not valid', async () => {
       forms.handleRequest.returns({ isValid: false });
       const request = createRequest();
@@ -415,6 +417,7 @@ experiment('edit controller', () => {
 
       expect(template).to.equal('nunjucks/returns/form.njk');
       expect(view.return).to.equal(request.returns.data);
+      expect(view.back).to.equal(`/return?returnId=${request.returns.data.returnId}`);
     });
   });
 
@@ -497,7 +500,9 @@ experiment('edit controller', () => {
 
       expect(getNextPathCalled).to.be.true();
     });
-    test('it should render same page if form is not valid', async () => {
+
+    test('renders the same page if form is not valid', async () => {
+      permissions.isInternal.returns(true);
       forms.handleRequest.returns({ isValid: false });
       const request = createRequest();
 
@@ -701,6 +706,7 @@ experiment('edit controller', () => {
 
       expect(getNextPathCalled).to.be.true();
     });
+
     test('it should render same page if form is not valid', async () => {
       forms.handleRequest.returns({ isValid: false });
       const request = createRequest();
@@ -710,6 +716,7 @@ experiment('edit controller', () => {
 
       expect(template).to.equal('nunjucks/returns/meter-reset.njk');
       expect(view.return).to.equal(request.returns.data);
+      expect(view.back).to.startWith('/return/method?returnId=');
     });
   });
 
@@ -745,6 +752,7 @@ experiment('edit controller', () => {
 
       expect(getNextPathCalled).to.be.true();
     });
+
     test('it should render same page if form is not valid', async () => {
       forms.handleRequest.returns({ isValid: false });
       const request = createRequest();
@@ -754,6 +762,7 @@ experiment('edit controller', () => {
 
       expect(template).to.equal('nunjucks/returns/form.njk');
       expect(view.return).to.equal(request.returns.data);
+      expect(view.back).to.startWith('/return/units?returnId');
     });
   });
 
@@ -788,8 +797,9 @@ experiment('edit controller', () => {
       forms.handleRequest.returns({ isValid: false });
       const request = createRequest(true);
       await controller.postMeterUsed(request, h);
-      const [template] = h.view.lastCall.args;
+      const [template, view] = h.view.lastCall.args;
       expect(template).to.equal('water/returns/internal/form');
+      expect(view.back).to.startWith('/admin/return/meter/details-provided?returnId=');
     });
 
     test('it should call getNextPath with STEP_METER_USED, request', async () => {

--- a/test/modules/returns/controllers/internal.js
+++ b/test/modules/returns/controllers/internal.js
@@ -260,6 +260,11 @@ experiment('internal returns controller', () => {
         const [view] = h.view.lastCall.args;
         expect(view).to.equal('water/returns/internal/form');
       });
+
+      test('the back link is configured', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.startWith('/admin/return/internal');
+      });
     });
   });
 
@@ -605,6 +610,11 @@ experiment('internal returns controller', () => {
       test('the view is shown again', async () => {
         const [view] = h.view.lastCall.args;
         expect(view).to.equal('water/returns/internal/form');
+      });
+
+      test('the back link is configured', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.startWith('/admin/return/single-total?returnId');
       });
     });
   });


### PR DESCRIPTION
WATER-2054

Fixes issues with the post handlers for some of the returns flow pages
by adding the correct value for `back` when configuring the view context
ready to re-render the form.