### PR TITLE
Feat: Show expired licences in search

### DIFF
--- a/src/assets/sass/v2/application.scss
+++ b/src/assets/sass/v2/application.scss
@@ -19,5 +19,6 @@ $govuk-global-styles: true;
 @import "blocks/search";
 @import "blocks/subnav";
 @import "blocks/text";
+@import "blocks/warning";
 
 @import "utils";

--- a/src/assets/sass/v2/blocks/_badge.scss
+++ b/src/assets/sass/v2/blocks/_badge.scss
@@ -53,6 +53,11 @@
   color: #6f777b;
 }
 
+.badge--expired {
+  border-color: $govuk-text-colour;
+  color: $govuk-text-colour;
+}
+
 .badge--no-wrap {
   white-space: nowrap;
 }

--- a/src/assets/sass/v2/blocks/_warning.scss
+++ b/src/assets/sass/v2/blocks/_warning.scss
@@ -1,0 +1,10 @@
+.warning {
+  @include govuk-responsive-padding(6); // 20px small, 30px larger
+  border: 5px solid $govuk-text-colour;
+}
+
+// Remove the margin at the bottom originally supplied by
+// the govuk-warning-text.
+.warning > .govuk-warning-text {
+  margin: 0;
+}

--- a/src/lib/connectors/crm/documents.js
+++ b/src/lib/connectors/crm/documents.js
@@ -101,13 +101,14 @@ client.setLicenceName = function (documentId, name) {
  * @param {String} licenceRef - the licence number
  * @return {Promise} resolves with document header
  */
-client.getWaterLicence = async (licenceRef) => {
+client.getWaterLicence = async (licenceRef, includeExpired = false) => {
   if (!licenceRef) {
     throw Boom.badImplementation('Licence number is required');
   }
   const filter = {
     regime_entity_id: waterRegimeEntityId,
-    system_external_id: licenceRef
+    system_external_id: licenceRef,
+    includeExpired
   };
   const { error, data: [document] } = await client.findMany(filter);
   if (error) {

--- a/src/lib/connectors/water-service/licences.js
+++ b/src/lib/connectors/water-service/licences.js
@@ -1,25 +1,29 @@
 const serviceRequest = require('../service-request');
-const { partialRight } = require('lodash');
 const config = require('../../../../config');
 
-const get = (documentId, tail) => {
+const get = (documentId, tail, includeExpired = false) => {
   const baseUrl = `${config.services.water}/documents/${documentId}/licence`;
 
-  const url = tail ? `${baseUrl}/${tail}` : baseUrl;
+  let url = tail ? `${baseUrl}/${tail}` : baseUrl;
+
+  if (includeExpired) {
+    url += '?includeExpired=true';
+  }
+
   return serviceRequest.get(url);
 };
 
-const getLicenceByDocumentId = documentId => get(documentId);
+const getLicenceByDocumentId = (documentId, includeExpired) => get(documentId, null, includeExpired);
 
-const getLicenceConditionsByDocumentId = partialRight(get, 'conditions');
+const getLicenceConditionsByDocumentId = documentId => get(documentId, 'conditions');
 
-const getLicencePointsByDocumentId = partialRight(get, 'points');
+const getLicencePointsByDocumentId = documentId => get(documentId, 'points');
 
-const getLicenceUsersByDocumentId = partialRight(get, 'users');
+const getLicenceUsersByDocumentId = (documentId, includeExpired) => get(documentId, 'users', includeExpired);
 
-const getLicencePrimaryUserByDocumentId = async documentId => {
+const getLicencePrimaryUserByDocumentId = async (documentId, includeExpired = false) => {
   try {
-    const userResponse = await getLicenceUsersByDocumentId(documentId);
+    const userResponse = await getLicenceUsersByDocumentId(documentId, includeExpired);
     const users = userResponse.data || [];
     return users.find(user => user.roles.includes('primary_user'));
   } catch (error) {
@@ -29,9 +33,9 @@ const getLicencePrimaryUserByDocumentId = async documentId => {
   }
 };
 
-const getLicenceSummaryByDocumentId = partialRight(get, 'summary');
+const getLicenceSummaryByDocumentId = documentId => get(documentId, 'summary');
 
-const getLicenceCommunicationsByDocumentId = partialRight(get, 'communications');
+const getLicenceCommunicationsByDocumentId = (documentId, includeExpired = false) => get(documentId, 'communications', includeExpired);
 
 module.exports = {
   getLicenceByDocumentId,

--- a/src/modules/returns/controllers/view.js
+++ b/src/modules/returns/controllers/view.js
@@ -65,7 +65,7 @@ const getReturn = async (request, h) => {
 
   // Load licence from CRM to check user has access
   const isInternalUser = isInternal(request);
-  const [ documentHeader ] = await getLicenceNumbers(request, { system_external_id: licenceNumber });
+  const [ documentHeader ] = await getLicenceNumbers(request, { system_external_id: licenceNumber, includeExpired: isInternalUser });
 
   const canView = documentHeader && (isInternalUser || (data.isCurrent && data.metadata.isCurrent));
 

--- a/src/modules/returns/lib/helpers.js
+++ b/src/modules/returns/lib/helpers.js
@@ -8,7 +8,7 @@ const { isInternal: isInternalUser, isExternalReturns } = require('../../../lib/
 const { documents } = require('../../../lib/connectors/crm');
 const { returns, versions } = require('../../../lib/connectors/returns');
 const config = require('../../../../config');
-const { getWaterLicence } = require('../../../lib/connectors/crm/documents');
+const crmConnector = require('../../../lib/connectors/crm');
 
 const { getReturnPath } = require('./return-path');
 const { throwIfError } = require('@envage/hapi-pg-rest-api');
@@ -22,7 +22,7 @@ const { throwIfError } = require('@envage/hapi-pg-rest-api');
 const getLicenceNumbers = (request, filter = {}) => {
   const f = documents.createFilter(request, filter);
   const sort = {};
-  const columns = ['system_external_id', 'document_name', 'document_id'];
+  const columns = ['system_external_id', 'document_name', 'document_id', 'metadata'];
   return documents.findAll(f, sort, columns);
 };
 
@@ -296,7 +296,8 @@ const getScopedPath = (request, path) => isInternalUser(request) ? `/admin${path
  * @return {Promise} resolves with view data
  */
 const getViewData = async (request, data) => {
-  const documentHeader = await getWaterLicence(data.licenceNumber);
+  const isInternal = isInternalUser(request);
+  const documentHeader = await crmConnector.documents.getWaterLicence(data.licenceNumber, isInternal);
   return {
     ...request.view,
     documentHeader,

--- a/src/modules/view-licences/routes-admin.js
+++ b/src/modules/view-licences/routes-admin.js
@@ -98,6 +98,30 @@ const getLicenceCommunication = {
   }
 };
 
+const getExpiredLicence = {
+  method: 'GET',
+  path: '/admin/expired-licences/{documentId}',
+  handler: controller.getExpiredLicence,
+  config: {
+    pre: [
+      { method: preInternalView }
+    ],
+    description: 'Shows expired licence details to internal users',
+    validate: {
+      params: {
+        documentId: VALID_GUID
+      }
+    },
+    plugins: {
+      viewContext: {
+        activeNavLink: 'view'
+      }
+    },
+    auth: { scope: allAdmin }
+  }
+};
+
+exports.getExpiredLicence = getExpiredLicence;
 exports.getLicenceAdmin = getLicenceAdmin;
 exports.getLicenceContactAdmin = getLicenceContactAdmin;
 exports.getLicencePurposesAdmin = getLicencePurposesAdmin;

--- a/src/views/nunjucks/internal-search/index.njk
+++ b/src/views/nunjucks/internal-search/index.njk
@@ -36,9 +36,7 @@
     {% if doc.documentName %}
       <span class="govuk-caption-m link--no-underline">{{ doc.documentName }}</span>
     {% endif %}
-    <a href="/admin/licences/{{ doc.documentId }}">
-      {{ doc.licenceNumber }}
-    </a>
+    {{ documentLink(doc) }}
   </h3>
   <p>{{ doc.licenceHolder }}</p>
 
@@ -56,6 +54,12 @@
   <p>Licence number {{ return.licence_ref }}</p>
   {{ badge(return.badge.text, return.badge.status) }}
 </div>
+{% endmacro %}
+
+{% macro documentLink(doc) %}
+  <a href="/admin/{{ "expired-" if not doc.isCurrent }}licences/{{ doc.documentId }}">
+    {{ doc.licenceNumber }}
+  </a>
 {% endmacro %}
 
 {% block content %}
@@ -81,7 +85,6 @@
       {% if noResults %}
       <p>No results found.<p>
       {% endif %}
-
 
       <!-- User accounts -->
       {% if users %}
@@ -150,28 +153,22 @@
         <tbody class="govuk-table__body">
           {% for doc in documents %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <a href="/admin/licences/{{ doc.documentId }}">{{ doc.licenceNumber }}</a>
-            </td>
+            <td class="govuk-table__cell">{{ documentLink(doc) }}</td>
             <td class="govuk-table__cell">{{ doc.documentName }}</td>
             <td class="govuk-table__cell">{{ doc.licenceHolder }}</td>
-            <td class="govuk-table__cell">{{ doc.expires | date }}</td>
+            <td class="govuk-table__cell">
+              {{ doc.expires | date if doc.isCurrent else badge("Expired", "expired") }}
+            </td>
           </tr>
           {% endfor %}
         </tbody>
       </table>
       {% endif %}
 
-
-
-
       <!-- Pagination -->
       {{ paginate(pagination, '/admin/licences', { query : form.fields[0].value }) }}
 
-
-
+  </div>
 </div>
-</div>
-
 
 {% endblock %}

--- a/src/views/nunjucks/returns/macros/return-header.njk
+++ b/src/views/nunjucks/returns/macros/return-header.njk
@@ -78,7 +78,7 @@
     </dl>
 
     <p class="medium-space">
-      <a href="{%if isAdmin %}/admin{%endif%}/licences/{{ documentHeader.document_id }}">View this licence</a>
+      <a href="{%if isAdmin %}/admin{%endif%}/{{ "expired-" if not documentHeader.metadata.IsCurrent }}licences/{{ documentHeader.document_id }}">View this licence</a>
     </p>
 
   {%endif%}

--- a/src/views/nunjucks/view-licences/expired-licence.njk
+++ b/src/views/nunjucks/view-licences/expired-licence.njk
@@ -1,0 +1,53 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "./tabs/macro.njk" import govukTabs %}
+{% from "badge.njk" import badge %}
+{% from "nunjucks/view-licences/macros/ended-licence-warning.njk" import endedLicenceWarning %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if not primaryUser %}
+        {{ title(licence.licenceNumber, 'Unregistered licence') }}
+      {% else %}
+        {{ title('Licence number ' + licence.licenceNumber, licence.documentName ) }}
+      {% endif %}
+    </div>
+  </div>
+
+  {{ endedLicenceWarning(licence.expiryReason, licence.expiryDate) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if primaryUser %}
+        <p>Registered to <a href="/admin/user/{{primaryUser.userId}}/status">{{primaryUser.userName}}</a></p>
+      {% endif %}
+
+      {% set returnsHtml %}
+        {% include "nunjucks/view-licences/tabs/returns.njk" %}
+      {% endset %}
+
+      {% set communicationsHtml %}
+        {% include "nunjucks/view-licences/tabs/communications.njk" %}
+      {% endset %}
+
+      <div class="govuk-tabs" data-module="tabs">
+        <h2 class="govuk-tabs__title">Contents</h2>
+        <ul class="govuk-tabs__list">
+          <li class="govuk-tabs__list-item">
+            <a class="govuk-tabs__tab" href="#returns">Returns</a>
+          </li>
+          <li class="govuk-tabs__list-item">
+            <a class="govuk-tabs__tab" href="#communications">Communications</a>
+          </li>
+        </ul>
+
+        <section class="govuk-tabs__panel" id="returns">
+          {% include "nunjucks/view-licences/tabs/returns.njk" %}
+        </section>
+        <section class="govuk-tabs__panel" id="communications">
+          {% include "nunjucks/view-licences/tabs/communications.njk" %}
+        </section>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/views/nunjucks/view-licences/macros/ended-licence-warning.njk
+++ b/src/views/nunjucks/view-licences/macros/ended-licence-warning.njk
@@ -1,0 +1,20 @@
+{% from "warning-text/macro.njk" import govukWarningText %}
+
+{% macro endedLicenceWarning(reason, endDate) %}
+  
+  {% set reasonText = reason %}
+  {% if reason === 'revoked' %}
+    {% set reasonText = 'was revoked' %}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-8">
+      <div class="warning">
+        {{ govukWarningText({
+          text: 'This licence ' + reasonText + ' on ' + endDate + '.',
+          iconFallbackText: 'Warning'
+        }) }}
+      </div>
+    </div>
+  </div>
+{% endmacro %}

--- a/src/views/partials/return-header.html
+++ b/src/views/partials/return-header.html
@@ -1,17 +1,16 @@
 
 {{#if documentHeader.document_name }}
-<h1 class="heading-large">
+  <h1 class="heading-large">
     <span class="heading-secondary">Abstraction return for {{ documentHeader.system_external_id }}</span>
     {{ documentHeader.document_name }}
   </h1>
 {{else}}
-<h1 class="heading-large">Abstraction return for {{ documentHeader.system_external_id }}</h1>
+  <h1 class="heading-large">Abstraction return for {{ documentHeader.system_external_id }}</h1>
 {{/if}}
 
 {{#if showMeta }}
 
 <dl class="meta small-space">
-
 
   {{#if isAdmin }}
   <dt class="meta__label">
@@ -66,8 +65,8 @@
 
   </dl>
 
-<p class="medium-space">
-  <a href="{{#if isAdmin }}/admin{{/if}}/licences/{{ documentHeader.document_id }}">View this licence</a>
-</p>
+  <p class="medium-space">
+    <a href="{{#if isAdmin }}/admin{{/if}}/{{#unless documentHeader.metadata.IsCurrent}}expired-{{/unless}}licences/{{ documentHeader.document_id }}">View this licence</a>
+  </p>
 
 {{/if}}

--- a/src/views/water/returns/return.html
+++ b/src/views/water/returns/return.html
@@ -24,7 +24,6 @@
     </div>
   {{/ifNot }}
 
-
   {{>return-header}}
 
   {{# if isVoid }}
@@ -86,8 +85,5 @@
 
 </main>
 
-
 {{> footerjs}}
-
-
 {{> debug}}

--- a/test/lib/connectors/crm/documents.js
+++ b/test/lib/connectors/crm/documents.js
@@ -9,6 +9,7 @@ const companyId = 'company_1';
 
 const responses = {
   ok: {
+    data: [{ doc: true }],
     pagination: {
       totalRows: 15
     }
@@ -44,5 +45,29 @@ experiment('getLicenceCount', () => {
     documents.findMany.resolves(responses.error);
     const func = () => documents.getLicenceCount(companyId);
     expect(func()).to.reject(); ;
+  });
+});
+
+experiment('getWaterLicence', async () => {
+  beforeEach(async () => {
+    sandbox.stub(documents, 'findMany').resolves(responses.ok);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('includeExpired is false by default', async () => {
+    await documents.getWaterLicence('test');
+    const [filter] = documents.findMany.lastCall.args;
+    expect(filter.system_external_id).to.equal('test');
+    expect(filter.includeExpired).to.be.false();
+  });
+
+  test('includeExpired is true if set', async () => {
+    await documents.getWaterLicence('test', true);
+    const [filter] = documents.findMany.lastCall.args;
+    expect(filter.system_external_id).to.equal('test');
+    expect(filter.includeExpired).to.be.true();
   });
 });

--- a/test/lib/connectors/water-service/licences.js
+++ b/test/lib/connectors/water-service/licences.js
@@ -25,6 +25,13 @@ experiment('getLicenceByDocumentId', () => {
     const [url] = serviceRequest.get.lastCall.args;
     expect(url).to.equal(expectedUrl);
   });
+
+  test('allows expired licences to be included', async () => {
+    await licencesConnector.getLicenceByDocumentId('test-id', true);
+    const expectedUrl = `${config.services.water}/documents/test-id/licence?includeExpired=true`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
 });
 
 experiment('getLicenceUsersByDocumentId', () => {
@@ -111,5 +118,29 @@ experiment('getLicencePrimaryUserByDocumentId', async () => {
       userName: 'test4@example.com',
       roles: ['primary_user']
     });
+  });
+});
+
+experiment('getLicenceCommunicationsByDocumentId', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get').resolves({});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    await licencesConnector.getLicenceCommunicationsByDocumentId('test-id');
+    const expectedUrl = `${config.services.water}/documents/test-id/licence/communications`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
+  });
+
+  test('allows expired licences to be included', async () => {
+    await licencesConnector.getLicenceCommunicationsByDocumentId('test-id', true);
+    const expectedUrl = `${config.services.water}/documents/test-id/licence/communications?includeExpired=true`;
+    const [url] = serviceRequest.get.lastCall.args;
+    expect(url).to.equal(expectedUrl);
   });
 });

--- a/test/modules/view-licences/controller.js
+++ b/test/modules/view-licences/controller.js
@@ -9,6 +9,8 @@ const communicationResponses = require('../../responses/water-service/communicat
 
 const controller = require('../../../src/modules/view-licences/controller');
 const { scope } = require('../../../src/lib/constants');
+const returnsConnector = require('../../../src/lib/connectors/returns');
+const licenceConnector = require('../../../src/lib/connectors/water-service/licences');
 
 experiment('getLicences', () => {
   test('redirects to security code page if no licences but outstanding verifications', async () => {
@@ -155,5 +157,130 @@ experiment('getLicenceCommunication', () => {
   test('requests the layout renders the back link', async () => {
     const [, view] = await controller.getLicenceCommunication(request, h);
     expect(view.back).to.equal('/licences/doc-id-1#communications');
+  });
+});
+
+experiment('getExpiredLicence', () => {
+  let request;
+  let h;
+
+  beforeEach(async () => {
+    h = {
+      view: sandbox.spy()
+    };
+
+    sandbox.stub(licenceConnector, 'getLicenceByDocumentId').resolves({
+      data: {
+        document: {
+          name: 'test-doc-name'
+        },
+        licence_ref: 'test-licence-ref',
+        earliestEndDate: '20190101',
+        earliestEndDateReason: 'expired'
+      }
+    });
+
+    sandbox.stub(returnsConnector.returns, 'findMany').resolves({
+      data: [{ return_id: 'test-return' }],
+      pagination: { pageCount: 1 }
+    });
+
+    sandbox.stub(licenceConnector, 'getLicenceCommunicationsByDocumentId').resolves({
+      data: [{ id: 'test-message' }]
+    });
+
+    sandbox.stub(licenceConnector, 'getLicencePrimaryUserByDocumentId').resolves({
+      userId: 1234,
+      entityId: 'test-entity-id',
+      userName: 'test-user@example.com',
+      roles: [ 'primary_user' ]
+    });
+
+    request = {
+      params: { documentId: 'test-doc-id' },
+      view: {
+        primaryUser: false,
+        verifications: []
+      },
+      auth: {
+        credentials: {
+          scope: ['internal']
+        }
+      }
+    };
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('uses the correct template', async () => {
+    await controller.getExpiredLicence(request, h);
+    const [template] = h.view.lastCall.args;
+    expect(template).to.equal('nunjucks/view-licences/expired-licence.njk');
+  });
+
+  experiment('the view context contains', () => {
+    test('the document id', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.documentId).to.equal('test-doc-id');
+    });
+
+    test('the expected licence details', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.licence.primaryUser.userName).to.equal('test-user@example.com');
+      expect(view.licence.licenceNumber).to.equal('test-licence-ref');
+      expect(view.licence.documentName).to.equal('test-doc-name');
+      expect(view.licence.expiryDate).to.equal('1 January 2019');
+    });
+
+    test('the returns', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.returns[0].return_id).to.equal('test-return');
+      expect(view.hasMoreReturns).to.be.false();
+    });
+
+    test('the messages', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.messages[0].id).to.equal('test-message');
+    });
+
+    test('the page title including the document name when present', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.pageTitle).to.equal('Licence name test-doc-name');
+    });
+
+    test('the page title including the licence number when no document name', async () => {
+      licenceConnector.getLicenceByDocumentId.resolves({
+        data: {
+          document: {
+          },
+          licence_ref: 'test-licence-ref',
+          earliestEndDate: '20190101',
+          earliestEndDateReason: 'expired'
+        }
+      });
+
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.pageTitle).to.equal('Licence number test-licence-ref');
+    });
+
+    test('the link back to the search including the licence number', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.back).to.equal('/admin/licences?query=test-licence-ref');
+    });
+
+    test('the isInternal value set to true', async () => {
+      await controller.getExpiredLicence(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.isInternal).to.be.true();
+    });
   });
 });


### PR DESCRIPTION
WATER-1976

 - Show expired licences in search results
 - Add expired badge in expiry date column of search results
 - Adds expired licences route to view details of expired licence
 - Adds new badge and warning styles
 - Updates view templates to handle links to expired licences
 - Updates returns flow to direct user to expired, or current licence.