### PR TITLE
WATER-2087

### DIFF
--- a/src/lib/connectors/water-service/batch-notifications.js
+++ b/src/lib/connectors/water-service/batch-notifications.js
@@ -1,0 +1,24 @@
+const serviceRequest = require('../service-request');
+const config = require('../../../../config');
+
+const getBaseUrl = () => `${config.services.water}/batch-notifications`;
+
+const prepareReturnsReminders = (issuer, excludeLicences) => {
+  const url = `${getBaseUrl()}/prepare/returnReminder`;
+  return serviceRequest.post(url, {
+    body: {
+      issuer,
+      data: {
+        excludeLicences
+      }
+    }
+  });
+};
+
+const sendReturnsReminders = eventId => {
+  const url = `${getBaseUrl()}/send/${eventId}`;
+  return serviceRequest.post(url);
+};
+
+exports.prepareReturnsReminders = prepareReturnsReminders;
+exports.sendReturnsReminders = sendReturnsReminders;

--- a/src/lib/connectors/water-service/batch-notifications.js
+++ b/src/lib/connectors/water-service/batch-notifications.js
@@ -15,9 +15,13 @@ const prepareReturnsReminders = (issuer, excludeLicences) => {
   });
 };
 
-const sendReturnsReminders = eventId => {
+const sendReturnsReminders = (eventId, issuer) => {
   const url = `${getBaseUrl()}/send/${eventId}`;
-  return serviceRequest.post(url);
+  return serviceRequest.post(url, {
+    body: {
+      issuer
+    }
+  });
 };
 
 exports.prepareReturnsReminders = prepareReturnsReminders;

--- a/src/lib/string-formatter.js
+++ b/src/lib/string-formatter.js
@@ -10,6 +10,21 @@ const splitString = (value, index = 0, separator = ',') => {
   return segments[index];
 };
 
+/**
+ * Takes in a string of comma and/or line separated values, and creates
+ * a unique array of trimmed items separated by commas
+ * @param  {string} str The input string
+ * @return {string}     A comma separated string of the unique values
+ */
+const commaOrLineSeparatedValuesToCsv = str => {
+  return (str || '')
+    .split(/[ \n\r,\t;]+/ig)
+    .filter(s => s)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .join(',');
+};
+
 module.exports = {
-  splitString
+  splitString,
+  commaOrLineSeparatedValuesToCsv
 };

--- a/src/lib/string-formatter.js
+++ b/src/lib/string-formatter.js
@@ -10,21 +10,4 @@ const splitString = (value, index = 0, separator = ',') => {
   return segments[index];
 };
 
-/**
- * Takes in a string of comma and/or line separated values, and creates
- * a unique array of trimmed items separated by commas
- * @param  {string} str The input string
- * @return {string}     A comma separated string of the unique values
- */
-const commaOrLineSeparatedValuesToCsv = str => {
-  return (str || '')
-    .split(/[ \n\r,\t;]+/ig)
-    .filter(s => s)
-    .filter((v, i, a) => a.indexOf(v) === i)
-    .join(',');
-};
-
-module.exports = {
-  splitString,
-  commaOrLineSeparatedValuesToCsv
-};
+exports.splitString = splitString;

--- a/src/modules/notifications/lib/notifications-list.js
+++ b/src/modules/notifications/lib/notifications-list.js
@@ -44,6 +44,7 @@ const getNotificationsList = (tasks, request) => {
 
   if (isInternalReturns(request)) {
     notifications.push(createNotificationType('Returns: send paper forms', '/admin/returns-notifications/forms'));
+    notifications.push(createNotificationType('Returns: send reminders', '/admin/returns-notifications/reminders'));
     notifications.push(createNotificationType('Returns: send final reminder', '/admin/returns-notifications/final-reminder'));
   }
 

--- a/src/modules/returns-notifications/controller.js
+++ b/src/modules/returns-notifications/controller.js
@@ -11,7 +11,6 @@ const { sendRemindersForm, sendRemindersSchema } = require('./forms/send-reminde
 
 const notificationsConnector = require('../../lib/connectors/water-service/returns-notifications');
 const batchNotificationsConnector = require('../../lib/connectors/water-service/batch-notifications');
-const stringFormatter = require('../../lib/string-formatter');
 
 const { getFinalReminderConfig } = require('./lib/helpers');
 
@@ -197,7 +196,7 @@ const postReturnsReminderStart = async (request, h) => {
   // get the event id from the water service and redirect
   const { data: event } = await batchNotificationsConnector.prepareReturnsReminders(
     issuer,
-    stringFormatter.commaOrLineSeparatedValuesToCsv(excludeLicences)
+    excludeLicences
   );
 
   return h.redirect(`/admin/waiting/${event.eventId}`);

--- a/src/modules/returns-notifications/controller.js
+++ b/src/modules/returns-notifications/controller.js
@@ -6,9 +6,12 @@ const { csvDownload } = require('../../lib/csv-download');
 const licenceNumbersForm = require('./forms/licence-numbers');
 const confirmLicenceNumbersForm = require('./forms/licence-numbers-confirm');
 const { schema } = require('./forms/licence-numbers');
-const { sendRemindersForm } = require('./forms/send-reminders');
+const { sendFinalRemindersForm } = require('./forms/send-final-reminders');
+const { sendRemindersForm, sendRemindersSchema } = require('./forms/send-reminders');
 
 const notificationsConnector = require('../../lib/connectors/water-service/returns-notifications');
+const batchNotificationsConnector = require('../../lib/connectors/water-service/batch-notifications');
+const stringFormatter = require('../../lib/string-formatter');
 
 const { getFinalReminderConfig } = require('./lib/helpers');
 
@@ -144,7 +147,7 @@ const getSendFormsSuccess = (request, h) => {
 const getFinalReminder = async (request, h) => {
   const view = {
     ...request.view,
-    form: sendRemindersForm(request),
+    form: sendFinalRemindersForm(request),
     back: `/admin/notifications`
   };
   const options = { layout: false };
@@ -175,12 +178,38 @@ const postSendFinalReminder = async (request, h) => {
   return h.view('nunjucks/returns-notifications/final-reminder-confirmation.njk', view, { layout: false });
 };
 
-module.exports = {
-  getSendForms,
-  postPreviewRecipients,
-  postSendForms,
-  getSendFormsSuccess,
-  getFinalReminder,
-  getFinalReminderCSV,
-  postSendFinalReminder
+const getReturnsReminderStart = async (request, h) => {
+  const view = {
+    ...request.view,
+    form: sendRemindersForm(request),
+    back: `/admin/notifications`
+  };
+  const options = { layout: false };
+  return h.view('nunjucks/returns-notifications/reminders.njk', view, options);
 };
+
+const postReturnsReminderStart = async (request, h) => {
+  const form = handleRequest(sendRemindersForm(request), request, sendRemindersSchema);
+
+  const { excludeLicences } = getValues(form);
+  const { username: issuer } = request.auth.credentials;
+
+  // get the event id from the water service and redirect
+  const { data: event } = await batchNotificationsConnector.prepareReturnsReminders(
+    issuer,
+    stringFormatter.commaOrLineSeparatedValuesToCsv(excludeLicences)
+  );
+
+  return h.redirect(`/admin/waiting/${event.eventId}`);
+};
+
+exports.getSendForms = getSendForms;
+exports.postPreviewRecipients = postPreviewRecipients;
+exports.postSendForms = postSendForms;
+exports.getSendFormsSuccess = getSendFormsSuccess;
+exports.getFinalReminder = getFinalReminder;
+exports.getFinalReminderCSV = getFinalReminderCSV;
+exports.postSendFinalReminder = postSendFinalReminder;
+
+exports.getReturnsReminderStart = getReturnsReminderStart;
+exports.postReturnsReminderStart = postReturnsReminderStart;

--- a/src/modules/returns-notifications/forms/send-final-reminders.js
+++ b/src/modules/returns-notifications/forms/send-final-reminders.js
@@ -1,0 +1,20 @@
+const { formFactory, fields } = require('../../../lib/forms');
+
+/**
+ * Creates a form object containing a single button and hidden CSRF token field
+ * @param  {Object} request - current HAPI request
+ * @return {Object}         - form object
+ */
+const sendFinalRemindersForm = (request) => {
+  const { csrfToken } = request.view;
+
+  const action = `/admin/returns-notifications/final-reminder`;
+
+  const f = formFactory(action);
+  f.fields.push(fields.button(null, { label: 'Send reminders' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return f;
+};
+
+exports.sendFinalRemindersForm = sendFinalRemindersForm;

--- a/src/modules/returns-notifications/forms/send-reminders.js
+++ b/src/modules/returns-notifications/forms/send-reminders.js
@@ -11,7 +11,8 @@ const sendRemindersForm = (request) => {
   f.fields.push(fields.text('excludeLicences', {
     label: 'Exclude licences',
     multiline: true,
-    hint: 'Separate licence numbers with a comma or new line'
+    hint: 'Separate licence numbers with a comma or new line',
+    mapper: 'licenceNumbersMapper'
   }));
   f.fields.push(fields.button(null, { label: 'Send reminders' }));
 

--- a/src/modules/returns-notifications/forms/send-reminders.js
+++ b/src/modules/returns-notifications/forms/send-reminders.js
@@ -1,23 +1,27 @@
-// const { cloneDeep, set } = require('lodash');
+const Joi = require('joi');
 const { formFactory, fields } = require('../../../lib/forms');
 
-/**
- * Creates a form object containing a single button and hidden CSRF token field
- * @param  {Object} request - current HAPI request
- * @return {Object}         - form object
- */
 const sendRemindersForm = (request) => {
   const { csrfToken } = request.view;
 
-  const action = `/admin/returns-notifications/final-reminder`;
+  const action = `/admin/returns-notifications/reminders`;
 
   const f = formFactory(action);
-  f.fields.push(fields.button(null, { label: 'Send reminders' }));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+  f.fields.push(fields.text('excludeLicences', {
+    label: 'Exclude licences',
+    multiline: true,
+    hint: 'Separate licence numbers with a comma or new line'
+  }));
+  f.fields.push(fields.button(null, { label: 'Send reminders' }));
 
   return f;
 };
 
-module.exports = {
-  sendRemindersForm
+const schema = {
+  excludeLicences: Joi.string().allow(''),
+  csrf_token: Joi.string().guid().required()
 };
+
+exports.sendRemindersForm = sendRemindersForm;
+exports.sendRemindersSchema = schema;

--- a/src/modules/returns-notifications/routes.js
+++ b/src/modules/returns-notifications/routes.js
@@ -117,5 +117,39 @@ module.exports = {
       }
     },
     handler: controller.postSendFinalReminder
+  },
+
+  getReturnsReminderStart: {
+    method: 'GET',
+    path: '/admin/returns-notifications/reminders',
+    config: {
+      auth: {
+        scope: returns
+      },
+      plugins: {
+        viewContext: {
+          activeNavLink: 'notifications',
+          pageTitle: 'Send returns reminders'
+        }
+      }
+    },
+    handler: controller.getReturnsReminderStart
+  },
+
+  postReturnsReminderStart: {
+    method: 'POST',
+    path: '/admin/returns-notifications/reminders',
+    config: {
+      auth: {
+        scope: returns
+      },
+      plugins: {
+        viewContext: {
+          activeNavLink: 'notifications',
+          pageTitle: 'Send returns reminders'
+        }
+      }
+    },
+    handler: controller.postReturnsReminderStart
   }
 };

--- a/src/modules/routes.js
+++ b/src/modules/routes.js
@@ -19,6 +19,7 @@ const returnNotificationRoutes = require('./returns-notifications/routes');
 const cspRoutes = require('./csp/routes');
 const returnsReports = require('./returns-reports/routes');
 const internalSearch = require('./internal-search/routes');
+const waiting = require('./waiting/routes');
 
 module.exports = [
   ...Object.values(addLicencesRoutes),
@@ -41,5 +42,6 @@ module.exports = [
   ...Object.values(returnNotificationRoutes),
   ...Object.values(cspRoutes),
   ...Object.values(returnsReports),
-  ...Object.values(internalSearch)
+  ...Object.values(internalSearch),
+  ...Object.values(waiting)
 ];

--- a/src/modules/waiting/controller.js
+++ b/src/modules/waiting/controller.js
@@ -1,0 +1,6 @@
+const getWaiting = (request, h) => {
+  const { eventId } = request.params;
+  return `Waiting for event ${eventId}`;
+};
+
+exports.getWaiting = getWaiting;

--- a/src/modules/waiting/routes.js
+++ b/src/modules/waiting/routes.js
@@ -1,0 +1,29 @@
+const Joi = require('joi');
+const controller = require('./controller');
+
+const { scope } = require('../../lib/constants');
+
+exports.getWaiting = {
+  method: 'GET',
+  path: '/admin/waiting/{eventId}',
+  handler: controller.getWaiting,
+  config: {
+    auth: {
+      scope: scope.internal
+    },
+    description: 'Generic waiting page for event processing',
+    validate: {
+      params: {
+        eventId: Joi.string().uuid().required()
+      }
+    },
+    plugins: {
+      config: {
+        view: 'water/view-licences/licence'
+      },
+      viewContext: {
+        activeNavLink: 'view'
+      }
+    }
+  }
+};

--- a/src/views/nunjucks/returns-notifications/reminders.njk
+++ b/src/views/nunjucks/returns-notifications/reminders.njk
@@ -1,0 +1,8 @@
+{% from "button/macro.njk" import govukButton %}
+{% extends "./nunjucks/layout.njk" %}
+{% from "forms/index.njk" import formRender %}
+
+{% block content %}
+  {{ title(pageTitle) }}
+  {{ formRender(form) }}
+{% endblock %}

--- a/test/lib/connectors/water-service/batch-notifications.js
+++ b/test/lib/connectors/water-service/batch-notifications.js
@@ -42,7 +42,7 @@ experiment('prepareReturnsReminders', () => {
 experiment('sendReturnsReminders', () => {
   beforeEach(async () => {
     sandbox.stub(serviceRequest, 'post').resolves({});
-    await batchNotificationsConnector.sendReturnsReminders('test-event-id');
+    await batchNotificationsConnector.sendReturnsReminders('test-event-id', 'issuer');
   });
 
   afterEach(async () => {
@@ -52,5 +52,10 @@ experiment('sendReturnsReminders', () => {
   test('passes the expected URL to the request', async () => {
     const [url] = serviceRequest.post.lastCall.args;
     expect(url).to.equal(`${config.services.water}/batch-notifications/send/test-event-id`);
+  });
+
+  test('includes the issuer in the request body', async () => {
+    const [, options] = serviceRequest.post.lastCall.args;
+    expect(options.body.issuer).to.equal('issuer');
   });
 });

--- a/test/lib/connectors/water-service/batch-notifications.js
+++ b/test/lib/connectors/water-service/batch-notifications.js
@@ -1,0 +1,56 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { expect } = require('code');
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('lab').script();
+
+const config = require('../../../../config');
+const serviceRequest = require('../../../../src/lib/connectors/service-request');
+const batchNotificationsConnector = require('../../../../src/lib/connectors/water-service/batch-notifications');
+
+experiment('prepareReturnsReminders', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'post').resolves({});
+    await batchNotificationsConnector.prepareReturnsReminders('issuer', '1,2');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    const [url] = serviceRequest.post.lastCall.args;
+    expect(url).to.equal(`${config.services.water}/batch-notifications/prepare/returnReminder`);
+  });
+
+  test('adds the issuer to the request body', async () => {
+    const [, options] = serviceRequest.post.lastCall.args;
+    expect(options.body.issuer).to.equal('issuer');
+  });
+
+  test('adds the exclude licences values to the request body', async () => {
+    const [, options] = serviceRequest.post.lastCall.args;
+    expect(options.body.data.excludeLicences).to.equal('1,2');
+  });
+});
+
+experiment('sendReturnsReminders', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'post').resolves({});
+    await batchNotificationsConnector.sendReturnsReminders('test-event-id');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('passes the expected URL to the request', async () => {
+    const [url] = serviceRequest.post.lastCall.args;
+    expect(url).to.equal(`${config.services.water}/batch-notifications/send/test-event-id`);
+  });
+});

--- a/test/lib/string-formatter.js
+++ b/test/lib/string-formatter.js
@@ -1,10 +1,7 @@
 const { experiment, test } = exports.lab = require('lab').script();
 const { expect } = require('code');
 
-const {
-  commaOrLineSeparatedValuesToCsv,
-  splitString
-} = require('../../src/lib/string-formatter.js');
+const { splitString } = require('../../src/lib/string-formatter.js');
 
 experiment('splitString', () => {
   test('splits string by commas and return first element by default', async () => {
@@ -29,49 +26,5 @@ experiment('splitString', () => {
 
   test('defaults to empty string if none supplied', async () => {
     expect(splitString('', 1)).to.equal(undefined);
-  });
-});
-
-experiment('commaOrLineSeparatedValuesToCsv', () => {
-  test('handles line separated values', async () => {
-    const values = '123\r\n234';
-    const asCsv = commaOrLineSeparatedValuesToCsv(values);
-    expect(asCsv).to.equal('123,234');
-  });
-
-  test('handles comma separated values', async () => {
-    const values = '123,234';
-    const asCsv = commaOrLineSeparatedValuesToCsv(values);
-    expect(asCsv).to.equal('123,234');
-  });
-
-  test('handles a mix of line and comma separated values', async () => {
-    const values = '1,2\r\n3\r\n4,5';
-    const asCsv = commaOrLineSeparatedValuesToCsv(values);
-    expect(asCsv).to.equal('1,2,3,4,5');
-  });
-
-  test('trims each item', async () => {
-    const values = ' 1 , 2\r\n3 \r\n 4 , 5';
-    const asCsv = commaOrLineSeparatedValuesToCsv(values);
-    expect(asCsv).to.equal('1,2,3,4,5');
-  });
-
-  test('handes a single item', async () => {
-    const values = '1';
-    const asCsv = commaOrLineSeparatedValuesToCsv(values);
-    expect(asCsv).to.equal('1');
-  });
-
-  test('handles an empty string', async () => {
-    expect(commaOrLineSeparatedValuesToCsv('')).to.equal('');
-  });
-
-  test('handles undefined input', async () => {
-    expect(commaOrLineSeparatedValuesToCsv()).to.equal('');
-  });
-
-  test('handles null input', async () => {
-    expect(commaOrLineSeparatedValuesToCsv(null)).to.equal('');
   });
 });

--- a/test/lib/string-formatter.js
+++ b/test/lib/string-formatter.js
@@ -1,33 +1,77 @@
-const Lab = require('lab');
-const lab = Lab.script();
+const { experiment, test } = exports.lab = require('lab').script();
 const { expect } = require('code');
 
-const { splitString } = require('../../src/lib/string-formatter.js');
+const {
+  commaOrLineSeparatedValuesToCsv,
+  splitString
+} = require('../../src/lib/string-formatter.js');
 
-lab.experiment('Test splitString', () => {
-  lab.test('Should split string by commas and return first element by default', async () => {
+experiment('splitString', () => {
+  test('splits string by commas and return first element by default', async () => {
     expect(splitString('some,string,here')).to.equal('some');
   });
 
-  lab.test('Should return element by index', async () => {
+  test('returns element by index', async () => {
     expect(splitString('some,string,here', 2)).to.equal('here');
   });
 
-  lab.test('Should return undefined if index outside range', async () => {
+  test('returns undefined if index outside range', async () => {
     expect(splitString('some,string,here', 3)).to.equal(undefined);
   });
 
-  lab.test('Should support custom separator', async () => {
+  test('supports custom separator', async () => {
     expect(splitString('some,string,here|hello', 1, '|')).to.equal('hello');
   });
 
-  lab.test('Should default to empty string if none supplied', async () => {
+  test('defaults to empty string if none supplied', async () => {
     expect(splitString()).to.equal('');
   });
 
-  lab.test('Should default to empty string if none supplied', async () => {
+  test('defaults to empty string if none supplied', async () => {
     expect(splitString('', 1)).to.equal(undefined);
   });
 });
 
-exports.lab = lab;
+experiment('commaOrLineSeparatedValuesToCsv', () => {
+  test('handles line separated values', async () => {
+    const values = '123\r\n234';
+    const asCsv = commaOrLineSeparatedValuesToCsv(values);
+    expect(asCsv).to.equal('123,234');
+  });
+
+  test('handles comma separated values', async () => {
+    const values = '123,234';
+    const asCsv = commaOrLineSeparatedValuesToCsv(values);
+    expect(asCsv).to.equal('123,234');
+  });
+
+  test('handles a mix of line and comma separated values', async () => {
+    const values = '1,2\r\n3\r\n4,5';
+    const asCsv = commaOrLineSeparatedValuesToCsv(values);
+    expect(asCsv).to.equal('1,2,3,4,5');
+  });
+
+  test('trims each item', async () => {
+    const values = ' 1 , 2\r\n3 \r\n 4 , 5';
+    const asCsv = commaOrLineSeparatedValuesToCsv(values);
+    expect(asCsv).to.equal('1,2,3,4,5');
+  });
+
+  test('handes a single item', async () => {
+    const values = '1';
+    const asCsv = commaOrLineSeparatedValuesToCsv(values);
+    expect(asCsv).to.equal('1');
+  });
+
+  test('handles an empty string', async () => {
+    expect(commaOrLineSeparatedValuesToCsv('')).to.equal('');
+  });
+
+  test('handles undefined input', async () => {
+    expect(commaOrLineSeparatedValuesToCsv()).to.equal('');
+  });
+
+  test('handles null input', async () => {
+    expect(commaOrLineSeparatedValuesToCsv(null)).to.equal('');
+  });
+});

--- a/test/modules/notifications/lib/notifications-list.js
+++ b/test/modules/notifications/lib/notifications-list.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const { experiment, test } = exports.lab = require('lab').script();
 
 const { expect } = require('code');
 
@@ -22,7 +21,7 @@ const createReturnsRequest = () => {
   return createRequest([scope.internal, scope.returns]);
 };
 
-lab.experiment('getNotificationsList', () => {
+experiment('getNotificationsList', () => {
   const tasks = [{
     task_config_id: '123',
     config: {
@@ -34,47 +33,48 @@ lab.experiment('getNotificationsList', () => {
     newWindow: false
   };
 
-  lab.test('It should only return task notifications when user doesnt have returns scope', async () => {
+  test('It should only return task notifications when user doesnt have returns scope', async () => {
     const request = createRequest();
     const result = getNotificationsList(tasks, request);
     expect(result).to.equal([ { name: 'Test', path: '/admin/notifications/123?start=1', options } ]);
   });
 
-  lab.test('It should include returns task notifications when user has returns scope', async () => {
+  test('It should include returns task notifications when user has returns scope', async () => {
     const request = createReturnsRequest();
     const result = getNotificationsList(tasks, request);
     const names = result.map(row => row.name);
     expect(names).to.equal([
       'Test',
       'Returns: send paper forms',
+      'Returns: send reminders',
       'Returns: send final reminder'
     ]);
   });
 });
 
-lab.experiment('getReportsList', () => {
-  lab.test('It should not include AR report link for AR user scope', async () => {
+experiment('getReportsList', () => {
+  test('It should not include AR report link for AR user scope', async () => {
     const request = createRequest(scope.abstractionReformUser);
     const reports = getReportsList(request);
     const paths = reports.map(item => item.path);
     expect(paths.includes('/admin/digitise/report')).to.equal(false);
   });
 
-  lab.test('It should include AR report link in list for AR approver scope', async () => {
+  test('It should include AR report link in list for AR approver scope', async () => {
     const request = createRequest(scope.abstractionReformApprover);
     const reports = getReportsList(request);
     const paths = reports.map(item => item.path);
     expect(paths.includes('/admin/digitise/report')).to.equal(true);
   });
 
-  lab.test('It includes returns overview link for returns user', async () => {
+  test('It includes returns overview link for returns user', async () => {
     const request = createReturnsRequest();
     const reports = getReportsList(request);
     const paths = reports.map(item => item.path);
     expect(paths.includes('/admin/returns-reports')).to.equal(true);
   });
 
-  lab.test('It does not include returns overview link for other internal users', async () => {
+  test('It does not include returns overview link for other internal users', async () => {
     const request = createRequest();
     const reports = getReportsList(request);
     const paths = reports.map(item => item.path);

--- a/test/modules/returns-notifications/controller.js
+++ b/test/modules/returns-notifications/controller.js
@@ -218,7 +218,7 @@ experiment('postReturnsReminderStart', () => {
   test('the excluded licences are passed as csv', async () => {
     await controller.postReturnsReminderStart(request, h);
     const [, excludeLicences] = batchNotificationsConnector.prepareReturnsReminders.lastCall.args;
-    expect(excludeLicences).to.equal('123,456');
+    expect(excludeLicences).to.equal(['123', '456']);
   });
 
   test('the user is redirected to the event waiting page', async () => {

--- a/test/modules/returns-notifications/forms/send-final-reminders.js
+++ b/test/modules/returns-notifications/forms/send-final-reminders.js
@@ -1,0 +1,39 @@
+const { find } = require('lodash');
+const { expect } = require('code');
+const { experiment, test, beforeEach } = exports.lab = require('lab').script();
+const { sendRemindersForm } = require('../../../../src/modules/returns-notifications/forms/send-reminders');
+
+const request = {
+  view: {
+    csrfToken: 'abc'
+  }
+};
+
+experiment('sendRemindersForm', () => {
+  let form;
+
+  beforeEach(async () => {
+    form = sendRemindersForm(request);
+  });
+
+  test('has the CSRF token set from the request', async () => {
+    const csrfField = find(form.fields, field => field.name === 'csrf_token');
+    expect(csrfField.value).to.equal(request.view.csrfToken);
+  });
+
+  test('posts to the correct URL', async () => {
+    expect(form.action).to.equal('/admin/returns-notifications/reminders');
+    expect(form.method).to.equal('POST');
+  });
+
+  test('contains the exclude licences field', async () => {
+    const excludeLicencesField = find(form.fields, f => f.name === 'excludeLicences');
+    expect(excludeLicencesField.options.label).to.equal('Exclude licences');
+    expect(excludeLicencesField.options.multiline).to.be.true();
+  });
+
+  test('has the correct button text', async () => {
+    const button = find(form.fields, field => field.options.widget === 'button');
+    expect(button.options.label).to.equal('Send reminders');
+  });
+});

--- a/test/modules/returns-notifications/forms/send-reminders.js
+++ b/test/modules/returns-notifications/forms/send-reminders.js
@@ -1,7 +1,7 @@
 const { find } = require('lodash');
 const { expect } = require('code');
 const { experiment, test } = exports.lab = require('lab').script();
-const { sendRemindersForm } = require('../../../../src/modules/returns-notifications/forms/send-reminders');
+const { sendFinalRemindersForm } = require('../../../../src/modules/returns-notifications/forms/send-final-reminders');
 
 const request = {
   view: {
@@ -9,8 +9,8 @@ const request = {
   }
 };
 
-experiment('sendRemindersForm', () => {
-  const f = sendRemindersForm(request);
+experiment('sendFinalRemindersForm', () => {
+  const f = sendFinalRemindersForm(request);
 
   test('it should have the CSRF token set from the request', async () => {
     const csrfField = find(f.fields, field => field.name === 'csrf_token');


### PR DESCRIPTION
WATER-2087

Creates new page that starts the processing of the returns reminders.

 - Adds new link to the reports and notifications page
 - Create new page to start the process
 - Adds placeholder route/controller for the waiting page
 - Renames existing `send-reminders` form to `send-final-reminders`

Implementation of waiting page to be done in story 2089