### PR TITLE
Chore: Move static assets to shared plugin

### DIFF
--- a/src/external/lib/hapi-plugins/index.js
+++ b/src/external/lib/hapi-plugins/index.js
@@ -16,5 +16,7 @@ module.exports = {
   anonGoogleAnalytics: require('./anon-google-analytics'),
   authCredentials: require('./auth-credentials'),
   companySelection: require('./company-selection'),
-  error: require('./error')
+  error: require('./error'),
+  noRobots: require('../../../shared/lib/plugins/no-robots'),
+  staticAssets: require('../../../shared/lib/plugins/static-assets')
 };

--- a/src/external/modules/core/routes.js
+++ b/src/external/modules/core/routes.js
@@ -15,63 +15,6 @@ module.exports = {
     }
   },
 
-  staticAssets: {
-    method: 'GET',
-    path: '/public/{param*}',
-    config: {
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      directory: {
-        path: 'public/',
-        listing: false
-      }
-    }
-  },
-
-  govUkFrontendAssets: {
-    method: 'GET',
-    path: '/assets/{param*}',
-    config: {
-      description: 'Serve static assets for GOV.UK frontend',
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      directory: {
-        path: 'node_modules/govuk-frontend/assets/',
-        listing: false
-      }
-    }
-  },
-
-  govUkFrontendJS: {
-    method: 'GET',
-    path: '/assets/js/all.js',
-    config: {
-      description: 'Serve static assets for GOV.UK frontend',
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      file: 'node_modules/govuk-frontend/all.js'
-    }
-  },
-
-  robots: {
-    method: 'GET',
-    path: '/robots.txt',
-    handler: () => 'User-agent: * Disallow: /',
-    config: { auth: false, description: 'Ooh. Robots' }
-  },
-
   404: {
     method: 'GET',
     path: '/{all*}',

--- a/src/internal/lib/hapi-plugins/index.js
+++ b/src/internal/lib/hapi-plugins/index.js
@@ -15,5 +15,7 @@ module.exports = {
   anonGoogleAnalytics: require('./anon-google-analytics'),
   authCredentials: require('./auth-credentials'),
   companySelection: require('./company-selection'),
-  error: require('./error')
+  error: require('./error'),
+  noRobots: require('../../../shared/lib/plugins/no-robots'),
+  staticAssets: require('../../../shared/lib/plugins/static-assets')
 };

--- a/src/internal/modules/core/routes.js
+++ b/src/internal/modules/core/routes.js
@@ -15,63 +15,6 @@ module.exports = {
     }
   },
 
-  staticAssets: {
-    method: 'GET',
-    path: '/public/{param*}',
-    config: {
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      directory: {
-        path: 'public/',
-        listing: false
-      }
-    }
-  },
-
-  govUkFrontendAssets: {
-    method: 'GET',
-    path: '/assets/{param*}',
-    config: {
-      description: 'Serve static assets for GOV.UK frontend',
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      directory: {
-        path: 'node_modules/govuk-frontend/assets/',
-        listing: false
-      }
-    }
-  },
-
-  govUkFrontendJS: {
-    method: 'GET',
-    path: '/assets/js/all.js',
-    config: {
-      description: 'Serve static assets for GOV.UK frontend',
-      auth: false,
-      cache: {
-        expiresIn: 30 * 1000
-      }
-    },
-    handler: {
-      file: 'node_modules/govuk-frontend/all.js'
-    }
-  },
-
-  robots: {
-    method: 'GET',
-    path: '/robots.txt',
-    handler: () => 'User-agent: * Disallow: /',
-    config: { auth: false, description: 'Ooh. Robots' }
-  },
-
   404: {
     method: 'GET',
     path: '/{all*}',

--- a/src/shared/lib/plugins/no-robots/index.js
+++ b/src/shared/lib/plugins/no-robots/index.js
@@ -1,0 +1,15 @@
+const plugin = {
+  name: 'no-robots',
+  register: async function (server) {
+    server.route({
+      method: 'GET',
+      path: '/robots.txt',
+      handler: () => 'User-agent: * Disallow: /',
+      config: {
+        auth: false
+      }
+    });
+  }
+};
+
+module.exports = plugin;

--- a/src/shared/lib/plugins/static-assets/index.js
+++ b/src/shared/lib/plugins/static-assets/index.js
@@ -1,0 +1,10 @@
+const routes = require('./routes');
+
+const plugin = {
+  name: 'static-assets',
+  register: async function (server) {
+    Object.values(routes).forEach(route => server.route(route));
+  }
+};
+
+module.exports = plugin;

--- a/src/shared/lib/plugins/static-assets/routes.js
+++ b/src/shared/lib/plugins/static-assets/routes.js
@@ -1,0 +1,51 @@
+module.exports = {
+  staticAssets: {
+    method: 'GET',
+    path: '/public/{param*}',
+    config: {
+      auth: false,
+      cache: {
+        expiresIn: 30 * 1000
+      }
+    },
+    handler: {
+      directory: {
+        path: 'public/',
+        listing: false
+      }
+    }
+  },
+
+  govUkFrontendAssets: {
+    method: 'GET',
+    path: '/assets/{param*}',
+    config: {
+      description: 'Serve static assets for GOV.UK frontend',
+      auth: false,
+      cache: {
+        expiresIn: 30 * 1000
+      }
+    },
+    handler: {
+      directory: {
+        path: 'node_modules/govuk-frontend/assets/',
+        listing: false
+      }
+    }
+  },
+
+  govUkFrontendJS: {
+    method: 'GET',
+    path: '/assets/js/all.js',
+    config: {
+      description: 'Serve static assets for GOV.UK frontend',
+      auth: false,
+      cache: {
+        expiresIn: 30 * 1000
+      }
+    },
+    handler: {
+      file: 'node_modules/govuk-frontend/all.js'
+    }
+  }
+};

--- a/test/shared/lib/plugins/no-robots/index.js
+++ b/test/shared/lib/plugins/no-robots/index.js
@@ -1,0 +1,18 @@
+const Hapi = require('@hapi/hapi');
+
+const plugin = require('../../../../../src/shared/lib/plugins/no-robots');
+
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+experiment('no robots plugin', () => {
+  test('/robots.txt returns the expected response', async () => {
+    const server = new Hapi.Server();
+    server.register({ plugin });
+
+    const response = await server.inject('/robots.txt');
+
+    expect(response.payload).to.equal('User-agent: * Disallow: /');
+    expect(response.statusCode).to.equal(200);
+  });
+});


### PR DESCRIPTION
WATER-1799

Creates a static assets plugin to provide static asset routes to the
internal and external applications.

Create a noRobots plugin that can be shared between the internal and
external applications.