### PR TITLE
Fix: FAO page title now two-thirds width

### DIFF
--- a/src/external/views/nunjucks/form.njk
+++ b/src/external/views/nunjucks/form.njk
@@ -4,10 +4,12 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
     {{ formErrorSummary(form) }}
     {{ title(pageTitle) }}
-    {{ formRender(form) }}
+    </div>
+    <div class="govuk-grid-column-full">
+      {{ formRender(form) }}
     </div>
   </div>
 {% endblock %}

--- a/src/internal/views/nunjucks/form.njk
+++ b/src/internal/views/nunjucks/form.njk
@@ -4,10 +4,12 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
     {{ formErrorSummary(form) }}
     {{ title(pageTitle) }}
-    {{ formRender(form) }}
+    </div>
+    <div class="govuk-grid-column-full">
+      {{ formRender(form) }}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
WATER-2142

Add div to make the title two-thirds width