### PR TITLE
Fix: Returns header title

### DIFF
--- a/src/external/views/nunjucks/returns/macros/return-header.njk
+++ b/src/external/views/nunjucks/returns/macros/return-header.njk
@@ -2,9 +2,9 @@
 
 {% macro returnHeader(return, documentHeader, showMeta, isAdmin) %}
   {% if documentHeader.document_name %}
-    {{ title(documentHeader.document_name, 'Abstraction return for ' + documentHeader.system_external_id) }}
+    {{ title(documentHeader.document_name, 'Abstraction return for licence number ' + documentHeader.system_external_id) }}
   {% else %}
-    {{ title('Abstraction return for ' + documentHeader.system_external_id) }}
+    {{ title('Abstraction return', 'Licence number ' + documentHeader.system_external_id) }}
   {% endif %}
 
   {%if showMeta %}

--- a/src/internal/views/nunjucks/returns/macros/return-header.njk
+++ b/src/internal/views/nunjucks/returns/macros/return-header.njk
@@ -2,9 +2,9 @@
 
 {% macro returnHeader(return, documentHeader, showMeta, isAdmin) %}
   {% if documentHeader.document_name %}
-    {{ title(documentHeader.document_name, 'Abstraction return for ' + documentHeader.system_external_id) }}
+    {{ title(documentHeader.document_name, 'Abstraction return for licence number ' + documentHeader.system_external_id) }}
   {% else %}
-    {{ title('Abstraction return for ' + documentHeader.system_external_id) }}
+    {{ title('Abstraction return', 'Licence number ' + documentHeader.system_external_id) }}
   {% endif %}
 
   {%if showMeta %}


### PR DESCRIPTION
WATER-2144

Fix returns header title to use h1 and h2 headings regardless of whether a licence has been given a name.