### PR TITLE
Feat: Change email UI

### DIFF
--- a/src/external/config.js
+++ b/src/external/config.js
@@ -50,7 +50,8 @@ module.exports = {
     isSameSite: 'Lax',
     ttl: 24 * 60 * 60 * 1000, // Set session to 1 day,
     redirectTo: '/welcome',
-    isHttpOnly: true
+    isHttpOnly: true,
+    keepAlive: true
   },
 
   idm: {
@@ -100,14 +101,16 @@ module.exports = {
 
   yar: {
     maxCookieSize: 0,
+    cache: {
+      expiresIn: 10 * 365 * 24 * 60 * 60 * 1000
+    },
     cookieOptions: {
       password: process.env.COOKIE_SECRET,
       isSecure: !isLocal,
       isSameSite: 'Lax',
-      ttl: 24 * 60 * 60 * 1000, // Set session to 1 day,
-      isHttpOnly: true
+      isHttpOnly: true,
+      ttl: 10 * 365 * 24 * 60 * 60 * 1000
     },
     storeBlank: false
-
   }
 };

--- a/src/external/lib/view/proposition-links.js
+++ b/src/external/lib/view/proposition-links.js
@@ -7,7 +7,7 @@ const createPropositionLink = (label, path, id) => {
   return createLink(label, path, id, { id });
 };
 
-const changePasswordLink = createPropositionLink('Change password', '/update_password', 'change-password');
+const accountSettingsLink = createPropositionLink('Account settings', '/account', 'account-settings');
 const signoutLink = createPropositionLink('Sign out', '/signout', 'signout');
 
 /**
@@ -21,13 +21,11 @@ const getPropositionLinks = (request) => {
     return [];
   }
 
-  const links = [changePasswordLink, signoutLink];
+  const links = [accountSettingsLink, signoutLink];
 
   // Add active boolean to correct link
   const activeNavLink = get(request, 'view.activeNavLink');
   return setActiveLink(links, activeNavLink);
 };
 
-module.exports = {
-  getPropositionLinks
-};
+exports.getPropositionLinks = getPropositionLinks;

--- a/src/external/modules/account/controller.js
+++ b/src/external/modules/account/controller.js
@@ -1,0 +1,38 @@
+const { confirmPasswordForm } = require('./forms/confirm-password');
+const { handleRequest, setValues } = require('shared/lib/forms');
+
+const getAccount = async (request, h) => {
+  const view = {
+    ...request.view,
+    userName: request.defra.userName
+  };
+  return h.view('nunjucks/account/entry.njk', view, { layout: false });
+};
+
+const getConfirmPassword = async (request, h, form) => {
+  const passwordForm = confirmPasswordForm(request);
+  const view = {
+    ...request.view,
+    form: passwordForm,
+    back: '/account'
+  };
+  return h.view('nunjucks/form.njk', view, { layout: false });
+};
+
+const postConfirmPassword = async (request, h) => {
+  const data = request.payload;
+  const form = handleRequest(setValues(confirmPasswordForm(request), data), request);
+
+  if (form.isValid) {
+    return h.redirect('/account/change-email/enter-new-email');
+  }
+
+  return getConfirmPassword(request, h, form);
+};
+
+const getEnterNewEmail = () => 'Under construction';
+
+exports.getAccount = getAccount;
+exports.getConfirmPassword = getConfirmPassword;
+exports.postConfirmPassword = postConfirmPassword;
+exports.getEnterNewEmail = getEnterNewEmail;

--- a/src/external/modules/account/forms/confirm-password.js
+++ b/src/external/modules/account/forms/confirm-password.js
@@ -1,0 +1,24 @@
+const { formFactory, fields } = require('shared/lib/forms');
+
+const confirmPasswordForm = request => {
+  const { csrfToken } = request.view;
+
+  const f = formFactory('/account/change-email/confirm-password');
+
+  f.fields.push(fields.text('password', {
+    type: 'password',
+    label: 'Your account password',
+    controlClass: 'govuk-input--width-20',
+    errors: {
+      'any.empty': {
+        message: 'Please enter your password'
+      }
+    }
+  }));
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return f;
+};
+
+exports.confirmPasswordForm = confirmPasswordForm;

--- a/src/external/modules/account/routes.js
+++ b/src/external/modules/account/routes.js
@@ -1,0 +1,59 @@
+const controller = require('./controller');
+
+module.exports = {
+  getAccount: {
+    method: 'GET',
+    path: '/account',
+    handler: controller.getAccount,
+    config: {
+      description: 'Get the account settings entry page',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Account settings'
+        }
+      }
+    }
+  },
+
+  getConfirmPassword: {
+    method: 'GET',
+    path: '/account/change-email/confirm-password',
+    handler: controller.getConfirmPassword,
+    config: {
+      description: 'Gets page to confirm the users password',
+      plugins: {
+        viewContext: {
+          pageTitle: 'For security, confirm your password first'
+        }
+      }
+    }
+  },
+
+  postConfirmPassword: {
+    method: 'POST',
+    path: '/account/change-email/confirm-password',
+    handler: controller.postConfirmPassword,
+    config: {
+      description: 'Endpoint to post password data to for changing email',
+      plugins: {
+        viewContext: {
+          pageTitle: 'For security, confirm your password first'
+        }
+      }
+    }
+  },
+
+  getEnterNewEmail: {
+    method: 'GET',
+    path: '/account/change-email/enter-new-email',
+    handler: controller.getEnterNewEmail,
+    config: {
+      description: 'Gets page to confirm the users new email',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Change your email address'
+        }
+      }
+    }
+  }
+};

--- a/src/external/modules/routes.js
+++ b/src/external/modules/routes.js
@@ -8,6 +8,7 @@ const registrationRoutes = require('./registration/routes');
 const serviceStatusRoutes = require('./service-status/routes');
 const returnsRoutes = require('./returns/routes');
 const companySelector = require('./company-selector/routes');
+// const accountRoutes = require('./account/routes');
 
 module.exports = [
   ...Object.values(addLicencesRoutes),
@@ -20,4 +21,5 @@ module.exports = [
   ...Object.values(serviceStatusRoutes),
   ...Object.values(returnsRoutes),
   ...Object.values(companySelector)
+  // ...Object.values(accountRoutes)
 ];

--- a/src/external/views/nunjucks/account/entry.njk
+++ b/src/external/views/nunjucks/account/entry.njk
@@ -1,0 +1,16 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "title.njk" import title %}
+
+{% block content %}
+  {{ title(pageTitle) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="sr-only">Email address</h2>
+      <div class="govuk-body-m">
+        <div>{{ userName }}</div>
+        <a class="govuk-link" href="/account/change-email/confirm-password">Change your email address</a>
+      </div>
+      <a class="govuk-link govuk-body-m" href="/update_password">Change your password</a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/shared/lib/AuthConfig.js
+++ b/src/shared/lib/AuthConfig.js
@@ -22,6 +22,7 @@ class AuthConfig {
     request.cookieAuth.set({ userId });
 
     // Set session
+    request.yar.reset();
     request.yar.set('csrfToken', uuid());
     request.yar.set('userId', userId);
     request.yar.set('ip', get(request, 'info.remoteAddress'));

--- a/test/external/lib/view/proposition-links.js
+++ b/test/external/lib/view/proposition-links.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const { find } = require('lodash');
-const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const { experiment, test } = exports.lab = require('lab').script();
 
 const { expect } = require('code');
 
@@ -12,7 +11,7 @@ const { scope } = require('external/lib/constants');
 const getAuthenticatedRequest = () => {
   return {
     view: {
-      activeNavLink: 'change-password'
+      activeNavLink: 'account-settings'
     },
     state: {
       sid: '00000000-0000-0000-0000-000000000000'
@@ -26,38 +25,38 @@ const getAuthenticatedRequest = () => {
   };
 };
 
-lab.experiment('getPropositionLinks', () => {
-  lab.test('It should not display any links if the user is not authenticated', async () => {
+experiment('getPropositionLinks', () => {
+  test('It should not display any links if the user is not authenticated', async () => {
     const request = {};
     const result = getPropositionLinks(request);
     expect(result.length).to.equal(0);
   });
 
-  lab.test('It should display change password and signout links for all authenticated users', async () => {
+  test('displays account settings and signout links for all authenticated users', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
     const ids = links.map(link => link.id);
-    expect(ids).to.equal(['change-password', 'signout']);
+    expect(ids).to.equal(['account-settings', 'signout']);
   });
 
-  lab.test('It should set the active nav link flag', async () => {
+  test('sets the active nav link flag', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
-    const link = find(links, { id: 'change-password' });
+    const link = find(links, { id: 'account-settings' });
     expect(link.active).to.equal(true);
   });
 
-  lab.test('Non-active links should have the active flag set to false', async () => {
+  test('Non-active links should have the active flag set to false', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
-    const flags = links.filter(link => (link.id !== 'change-password')).map(link => link.active);
+    const flags = links.filter(link => (link.id !== 'account-settings')).map(link => link.active);
     expect(flags).to.equal([false]);
   });
 
-  lab.test('It should set ID attributes', async () => {
+  test('It should set ID attributes', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
     const idAttributes = links.map(link => link.attributes.id);
-    expect(idAttributes).to.equal(['change-password', 'signout']);
+    expect(idAttributes).to.equal(['account-settings', 'signout']);
   });
 });

--- a/test/external/modules/account/controller.js
+++ b/test/external/modules/account/controller.js
@@ -1,0 +1,118 @@
+const { expect } = require('code');
+const { experiment, test, beforeEach } = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const controller = require('external/modules/account/controller');
+
+experiment('modules/account/controller', () => {
+  experiment('.getAccount', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        defra: { userName: 'test-user' }
+      };
+
+      await controller.getAccount(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/account/entry.njk');
+    });
+
+    test('the userName is added to the view context', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.userName).to.equal('test-user');
+    });
+  });
+
+  experiment('.getConfirmPassword', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: { csrfToken: 'token' }
+      };
+
+      await controller.getConfirmPassword(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/form.njk');
+    });
+
+    test('the view data is passed through to the view', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.csrfToken).to.equal('token');
+    });
+
+    test('the back link is setup to return to /account', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.back).to.equal('/account');
+    });
+  });
+
+  experiment('.postConfirmPassword', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = {
+        view: sandbox.spy(),
+        redirect: sandbox.spy()
+      };
+    });
+
+    experiment('when the data is valid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            csrf_token: 'token',
+            password: 'secrets'
+          }
+        };
+
+        await controller.postConfirmPassword(request, h);
+      });
+
+      test('the user is redirected to the next step', async () => {
+        const [url] = h.redirect.lastCall.args;
+        expect(url).to.equal('/account/change-email/enter-new-email');
+      });
+    });
+
+    experiment('when the data is invalid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: { password: '' }
+        };
+
+        await controller.postConfirmPassword(request, h);
+      });
+
+      test('the expected view template is used', async () => {
+        const [template] = h.view.lastCall.args;
+        expect(template).to.equal('nunjucks/form.njk');
+      });
+
+      test('the view data is passed through to the view', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.csrfToken).to.equal('token');
+      });
+
+      test('the back link is setup to return to /account', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.equal('/account');
+      });
+    });
+  });
+});


### PR DESCRIPTION
WATER-2154

First screens for the update email flow.

 - Includes new account-setting landing page
 - Includes confirm password page
 - Updates the session cookies so that the session lasts 10 years but is
removed on sign in and sign out. The auth cookie is set to keep alive
for 24 hours.