### PR TITLE
Feat: Change email UI

### DIFF
--- a/.codeclimate.json
+++ b/.codeclimate.json
@@ -8,6 +8,7 @@
     "test",
     "src/**/*routes.js",
     "src/internal/config.js",
-    "src/external/config.js"
+    "src/external/config.js",
+    "src/shared/public/javascripts"
   ]
 }

--- a/src/external/lib/hapi-plugins/company-selection.js
+++ b/src/external/lib/hapi-plugins/company-selection.js
@@ -7,18 +7,22 @@
  * add-licences route.
  *
  * Both of the above redirections will only take place if the user is
- * attempting to access a route that is configured with an access scope.
+ * attempting to access a route that has not opted out by setting
+ * config.plugins.companySelector.ignore to true.
  */
-const { get, isEmpty } = require('lodash');
+const { get } = require('lodash');
 const SELECT_COMPANY_PATH = '/select-company';
 const ADD_LICENCES_PATH = '/add-licences';
 
 const shouldRedirect = request => {
-  const { companyId } = request.defra;
-  const { path } = request;
-  const access = get(request, 'route.settings.auth.access', {});
+  if (request.method.toLowerCase() === 'get' && request.defra) {
+    const { companyId } = request.defra;
+    const { path } = request;
+    const ignoreRoute = get(request, 'route.settings.plugins.companySelector.ignore', false);
 
-  return (isEmpty(access) && !companyId && path !== SELECT_COMPANY_PATH);
+    return (!ignoreRoute && !companyId && path !== SELECT_COMPANY_PATH);
+  }
+  return false;
 };
 
 const getRedirectPath = companyCount => {
@@ -26,7 +30,7 @@ const getRedirectPath = companyCount => {
 };
 
 const handler = (request, h) => {
-  if (request.auth.isAuthenticated && shouldRedirect(request)) {
+  if (shouldRedirect(request)) {
     const path = getRedirectPath(request.defra.companyCount);
     return h.redirect(path).takeover();
   }

--- a/src/external/lib/view/proposition-links.js
+++ b/src/external/lib/view/proposition-links.js
@@ -7,7 +7,7 @@ const createPropositionLink = (label, path, id) => {
   return createLink(label, path, id, { id });
 };
 
-const changePasswordLink = createPropositionLink('Change password', '/update_password', 'change-password');
+const accountSettingsLink = createPropositionLink('Account settings', '/account', 'account-settings');
 const signoutLink = createPropositionLink('Sign out', '/signout', 'signout');
 
 /**
@@ -21,13 +21,11 @@ const getPropositionLinks = (request) => {
     return [];
   }
 
-  const links = [changePasswordLink, signoutLink];
+  const links = [accountSettingsLink, signoutLink];
 
   // Add active boolean to correct link
   const activeNavLink = get(request, 'view.activeNavLink');
   return setActiveLink(links, activeNavLink);
 };
 
-module.exports = {
-  getPropositionLinks
-};
+exports.getPropositionLinks = getPropositionLinks;

--- a/src/external/modules/account/controller.js
+++ b/src/external/modules/account/controller.js
@@ -1,0 +1,102 @@
+const { confirmPasswordForm } = require('./forms/confirm-password');
+const {
+  enterNewEmailForm,
+  enterNewEmailSchema
+} = require('./forms/enter-new-email');
+const { verifyNewEmailForm } = require('./forms/verify-new-email');
+
+const { handleRequest, setValues } = require('shared/lib/forms');
+
+const getAccount = async (request, h) => {
+  const view = {
+    ...request.view,
+    userName: request.defra.userName
+  };
+  return h.view('nunjucks/account/entry.njk', view, { layout: false });
+};
+
+const getConfirmPassword = async (request, h, form) => {
+  const passwordForm = form || confirmPasswordForm(request);
+  const view = {
+    ...request.view,
+    form: passwordForm,
+    back: '/account'
+  };
+  return h.view('nunjucks/form.njk', view, { layout: false });
+};
+
+const postConfirmPassword = async (request, h) => {
+  const data = request.payload;
+  const form = handleRequest(setValues(confirmPasswordForm(request), data), request);
+
+  if (form.isValid) {
+    return h.redirect('/account/change-email/enter-new-email');
+  }
+
+  return getConfirmPassword(request, h, form);
+};
+
+const getEnterNewEmail = async (request, h, form) => {
+  const emailForm = form || enterNewEmailForm(request);
+  const view = {
+    ...request.view,
+    form: emailForm,
+    back: '/account'
+  };
+  return h.view('nunjucks/form.njk', view, { layout: false });
+};
+
+const postEnterNewEmail = async (request, h) => {
+  const data = request.payload;
+  const form = handleRequest(
+    enterNewEmailForm(request, data),
+    request,
+    enterNewEmailSchema
+  );
+
+  if (form.isValid) {
+    return h.redirect('/account/change-email/verify-new-email');
+  }
+
+  return getEnterNewEmail(request, h, form);
+};
+
+const getVerifyEmail = async (request, h, form) => {
+  const verifyForm = form || verifyNewEmailForm(request);
+  const view = {
+    ...request.view,
+    form: verifyForm,
+    back: '/account',
+    newEmail: 'test@example.com'
+  };
+  return h.view('nunjucks/account/verify.njk', view, { layout: false });
+};
+
+const postVerifyEmail = async (request, h) => {
+  const data = request.payload;
+  const form = handleRequest(verifyNewEmailForm(request, data), request);
+
+  if (form.isValid) {
+    return h.redirect('/account/change-email/success');
+  }
+
+  return getVerifyEmail(request, h, form);
+};
+
+const getSuccess = async (request, h) => {
+  return h.view('nunjucks/account/success.njk', request.view, { layout: false });
+};
+
+const getTryAgainLater = async (request, h) => {
+  return h.view('nunjucks/account/try-again-later.njk', request.view, { layout: false });
+};
+
+exports.getAccount = getAccount;
+exports.getConfirmPassword = getConfirmPassword;
+exports.postConfirmPassword = postConfirmPassword;
+exports.getEnterNewEmail = getEnterNewEmail;
+exports.postEnterNewEmail = postEnterNewEmail;
+exports.getVerifyEmail = getVerifyEmail;
+exports.postVerifyEmail = postVerifyEmail;
+exports.getSuccess = getSuccess;
+exports.getTryAgainLater = getTryAgainLater;

--- a/src/external/modules/account/forms/confirm-password.js
+++ b/src/external/modules/account/forms/confirm-password.js
@@ -12,7 +12,7 @@ const confirmPasswordForm = request => {
     controlClass: 'govuk-input--width-20',
     errors: {
       'any.empty': {
-        message: 'Please enter your password'
+        message: 'Check your password'
       }
     }
   }));

--- a/src/external/modules/account/forms/confirm-password.js
+++ b/src/external/modules/account/forms/confirm-password.js
@@ -1,0 +1,25 @@
+const { formFactory, fields } = require('shared/lib/forms');
+
+const confirmPasswordForm = request => {
+  const { csrfToken } = request.view;
+
+  const f = formFactory('/account/change-email/confirm-password');
+
+  f.fields.push(fields.text('password', {
+    type: 'password',
+    autoComplete: 'current-password',
+    label: 'Your account password',
+    controlClass: 'govuk-input--width-20',
+    errors: {
+      'any.empty': {
+        message: 'Please enter your password'
+      }
+    }
+  }));
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return f;
+};
+
+exports.confirmPasswordForm = confirmPasswordForm;

--- a/src/external/modules/account/forms/enter-new-email.js
+++ b/src/external/modules/account/forms/enter-new-email.js
@@ -1,0 +1,52 @@
+const { formFactory, fields, setValues } = require('shared/lib/forms');
+const Joi = require('joi');
+
+const createError = (key, message) => ({
+  [key]: { message }
+});
+
+const createEmailField = (name, label, errors) => {
+  return fields.text(name, {
+    type: 'email',
+    label,
+    autoComplete: 'email',
+    controlClass: 'govuk-input--width-20',
+    errors
+  });
+};
+
+const enterNewEmailForm = (request, data = {}) => {
+  const { csrfToken } = request.view;
+
+  const f = formFactory('/account/change-email/enter-new-email');
+
+  f.fields.push(createEmailField('email', 'Your new email address', {
+    ...createError('any.allowOnly', 'Email addresses must match'),
+    ...createError('string.email', 'Enter a valid email'),
+    ...createError('any.empty', 'Enter your email')
+  }));
+
+  f.fields.push(createEmailField('confirm-email', 'Confirm your new email address', {
+    ...createError('string.email', 'Enter a valid email'),
+    ...createError('any.empty', 'Confirm your new email address')
+
+  }));
+
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return setValues(f, data);
+};
+
+const enterNewEmailSchema = {
+  email: Joi
+    .string()
+    .email()
+    .valid(Joi.ref('confirm-email'))
+    .required(),
+  'confirm-email': Joi.string().email().required(),
+  csrf_token: Joi.string().required()
+};
+
+exports.enterNewEmailForm = enterNewEmailForm;
+exports.enterNewEmailSchema = enterNewEmailSchema;

--- a/src/external/modules/account/forms/enter-new-email.js
+++ b/src/external/modules/account/forms/enter-new-email.js
@@ -21,7 +21,7 @@ const enterNewEmailForm = (request, data = {}) => {
   const f = formFactory('/account/change-email/enter-new-email');
 
   f.fields.push(createEmailField('email', 'Your new email address', {
-    ...createError('any.allowOnly', 'Email addresses must match'),
+    ...createError('any.allowOnly', 'The email addresses must match'),
     ...createError('string.email', 'Enter a valid email'),
     ...createError('any.empty', 'Enter your email')
   }));

--- a/src/external/modules/account/forms/verify-new-email.js
+++ b/src/external/modules/account/forms/verify-new-email.js
@@ -15,7 +15,7 @@ const verifyNewEmailForm = (request, data = {}) => {
     controlClass: 'govuk-input--width-4',
     errors: {
       'any.empty': {
-        message: 'Enter the verification code'
+        message: 'Check your code'
       }
     }
   }));

--- a/src/external/modules/account/forms/verify-new-email.js
+++ b/src/external/modules/account/forms/verify-new-email.js
@@ -1,0 +1,29 @@
+const { formFactory, fields, setValues } = require('shared/lib/forms');
+
+const verifyNewEmailForm = (request, data = {}) => {
+  const { csrfToken } = request.view;
+
+  const f = formFactory('/account/change-email/verify-new-email');
+
+  f.fields.push(fields.text('verification-code', {
+    type: 'text',
+    label: 'Enter the code',
+    attr: {
+      maxlength: 6
+    },
+    autoComplete: 'one-time-code',
+    controlClass: 'govuk-input--width-4',
+    errors: {
+      'any.empty': {
+        message: 'Enter the verification code'
+      }
+    }
+  }));
+
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+
+  return setValues(f, data);
+};
+
+exports.verifyNewEmailForm = verifyNewEmailForm;

--- a/src/external/modules/account/routes.js
+++ b/src/external/modules/account/routes.js
@@ -1,0 +1,144 @@
+const controller = require('./controller');
+
+module.exports = {
+  getAccount: {
+    method: 'GET',
+    path: '/account',
+    handler: controller.getAccount,
+    config: {
+      description: 'Get the account settings entry page',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Account settings'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  },
+
+  getConfirmPassword: {
+    method: 'GET',
+    path: '/account/change-email/confirm-password',
+    handler: controller.getConfirmPassword,
+    config: {
+      description: 'Gets page to confirm the users password',
+      plugins: {
+        viewContext: {
+          pageTitle: 'For security, confirm your password first'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  },
+
+  postConfirmPassword: {
+    method: 'POST',
+    path: '/account/change-email/confirm-password',
+    handler: controller.postConfirmPassword,
+    config: {
+      plugins: {
+        viewContext: {
+          pageTitle: 'For security, confirm your password first'
+        }
+      }
+    }
+  },
+
+  getEnterNewEmail: {
+    method: 'GET',
+    path: '/account/change-email/enter-new-email',
+    handler: controller.getEnterNewEmail,
+    config: {
+      description: 'Gets page to confirm the users new email',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Change your email address'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  },
+
+  postEnterNewEmail: {
+    method: 'POST',
+    path: '/account/change-email/enter-new-email',
+    handler: controller.postEnterNewEmail,
+    config: {
+      plugins: {
+        viewContext: {
+          pageTitle: 'Change your email address'
+        }
+      }
+    }
+  },
+
+  getVerifyEmail: {
+    method: 'GET',
+    path: '/account/change-email/verify-new-email',
+    handler: controller.getVerifyEmail,
+    config: {
+      description: 'Gets page to enter the code sent to the proposed email',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Verify your email address'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  },
+
+  postVerifyEmail: {
+    method: 'POST',
+    path: '/account/change-email/verify-new-email',
+    handler: controller.postVerifyEmail,
+    config: {
+      plugins: {
+        viewContext: {
+          pageTitle: 'Verify your email address'
+        }
+      }
+    }
+  },
+
+  getSuccess: {
+    method: 'GET',
+    path: '/account/change-email/success',
+    handler: controller.getSuccess,
+    config: {
+      description: 'Gets the success page for the change password flow',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Your email address is changed'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  },
+
+  getTryAgainLater: {
+    method: 'GET',
+    path: '/account/change-email/try-again-later',
+    handler: controller.getTryAgainLater,
+    config: {
+      description: 'Gets the page after too many password attempts',
+      plugins: {
+        viewContext: {
+          pageTitle: 'Try again later'
+        },
+        companySelector: {
+          ignore: true
+        }
+      }
+    }
+  }
+};

--- a/src/external/modules/add-licences/routes.js
+++ b/src/external/modules/add-licences/routes.js
@@ -9,7 +9,12 @@ module.exports = {
     path: '/add-licences',
     handler: controller.getLicenceAdd,
     config: {
-      description: 'Start flow to add licences'
+      description: 'Start flow to add licences',
+      plugins: {
+        companySelector: {
+          ignore: true
+        }
+      }
     }
   },
   postLicenceAdd: {

--- a/src/external/modules/content/routes.js
+++ b/src/external/modules/content/routes.js
@@ -18,6 +18,9 @@ module.exports = {
         },
         config: {
           view: 'nunjucks/content/accessibility.njk'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     },
@@ -40,6 +43,9 @@ module.exports = {
         },
         config: {
           view: 'nunjucks/content/cookies.njk'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     },
@@ -61,6 +67,9 @@ module.exports = {
         },
         config: {
           view: 'nunjucks/content/feedback.njk'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     },
@@ -82,6 +91,9 @@ module.exports = {
         },
         config: {
           view: 'nunjucks/content/privacy-policy.njk'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     },

--- a/src/external/modules/core/routes.js
+++ b/src/external/modules/core/routes.js
@@ -23,6 +23,11 @@ module.exports = {
       auth: {
         strategy: 'standard',
         mode: 'try'
+      },
+      plugins: {
+        companySelector: {
+          ignore: true
+        }
       }
     }
   },
@@ -40,6 +45,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Sign in or create an account'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     }
@@ -53,6 +61,11 @@ module.exports = {
       auth: {
         strategy: 'standard',
         mode: 'try'
+      },
+      plugins: {
+        companySelector: {
+          ignore: true
+        }
       }
     }
   }

--- a/src/external/modules/registration/routes.js
+++ b/src/external/modules/registration/routes.js
@@ -17,6 +17,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Create an account to manage your water abstraction licence online'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     }
@@ -35,6 +38,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Create an account'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     }
@@ -67,6 +73,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Confirm your email address'
+        },
+        companySelector: {
+          ignore: true
         }
       },
       validate: {
@@ -90,6 +99,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Request another email'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     }
@@ -122,6 +134,9 @@ module.exports = {
       plugins: {
         viewContext: {
           pageTitle: 'Confirm your email address'
+        },
+        companySelector: {
+          ignore: true
         }
       }
     }

--- a/src/external/modules/routes.js
+++ b/src/external/modules/routes.js
@@ -8,6 +8,7 @@ const registrationRoutes = require('./registration/routes');
 const serviceStatusRoutes = require('./service-status/routes');
 const returnsRoutes = require('./returns/routes');
 const companySelector = require('./company-selector/routes');
+const accountRoutes = require('./account/routes');
 
 module.exports = [
   ...Object.values(addLicencesRoutes),
@@ -19,5 +20,6 @@ module.exports = [
   ...Object.values(viewLicencesRoutes),
   ...Object.values(serviceStatusRoutes),
   ...Object.values(returnsRoutes),
-  ...Object.values(companySelector)
+  ...Object.values(companySelector),
+  ...Object.values(accountRoutes)
 ];

--- a/src/external/views/nunjucks/account/entry.njk
+++ b/src/external/views/nunjucks/account/entry.njk
@@ -1,0 +1,17 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "title.njk" import title %}
+
+{% block content %}
+  {{ title(pageTitle) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="sr-only">Email address</h2>
+      <div class="govuk-body-m">
+        <div>{{ userName }}</div>
+        {# Enable this when the feature is integrated with backend #}
+        {# <a class="govuk-link" href="/account/change-email/confirm-password">Change your email address</a> #}
+      </div>
+      <a class="govuk-link govuk-body-m" href="/update_password">Change your password</a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/external/views/nunjucks/account/success.njk
+++ b/src/external/views/nunjucks/account/success.njk
@@ -1,0 +1,11 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "title.njk" import title %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ title(pageTitle) }}
+      <a class="govuk-link" href="/licences">View licences</a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/external/views/nunjucks/account/try-again-later.njk
+++ b/src/external/views/nunjucks/account/try-again-later.njk
@@ -1,0 +1,13 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "title.njk" import title %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ title(pageTitle) }}
+      <p class="govuk-body">You have tried to enter a code too many times.</p>
+      <p class="govuk-body">To change your email address please try again in 24 hours.</p>
+      <a class="govuk-link" href="/licences">View licences</a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/external/views/nunjucks/account/verify.njk
+++ b/src/external/views/nunjucks/account/verify.njk
@@ -1,0 +1,27 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "forms/index.njk" import formRender, formErrorSummary %}
+{% from "title.njk" import title %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    {{ formErrorSummary(form) }}
+    {{ title(pageTitle) }}
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <p>We sent a code to
+        <span class="govuk-!-font-weight-bold">{{ newEmail }}</span>.
+      </p>
+    </div>
+    <div class="govuk-grid-column-full">
+      {{ formRender(form) }}
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <p>Check your spam folder if you have not received the email within a few minutes.</p>
+      <p>
+        If the email hasn’t arrived you can
+        <a href="/account/change-email/enter-new-email">request another code.</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/src/internal/modules/core/routes.js
+++ b/src/internal/modules/core/routes.js
@@ -10,6 +10,11 @@ module.exports = {
     config: {
       validate: {
         query: VALID_UTM
+      },
+      plugins: {
+        companySelector: {
+          ignore: true
+        }
       }
     }
   },
@@ -37,5 +42,4 @@ module.exports = {
       }
     }
   }
-
 };

--- a/src/shared/plugins/auth/routes.js
+++ b/src/shared/plugins/auth/routes.js
@@ -24,6 +24,11 @@ module.exports = [
         viewContext: {
           pageTitle: 'Sign in',
           customTitle: 'Sign in - Manage your water abstraction or impoundment licence'
+        },
+        plugins: {
+          companySelector: {
+            ignore: true
+          }
         }
       }
     }

--- a/src/shared/view/nunjucks/filters/form.js
+++ b/src/shared/view/nunjucks/filters/form.js
@@ -41,7 +41,8 @@ const mapFormField = (field) => {
     },
     classes: field.options.controlClass,
     attributes: field.options.attr || {},
-    suffix: field.options.suffix
+    suffix: field.options.suffix,
+    autocomplete: field.options.autoComplete
   };
 
   return applyErrors(options, field.errors);

--- a/test/external/lib/view/proposition-links.js
+++ b/test/external/lib/view/proposition-links.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const { find } = require('lodash');
-const Lab = require('lab');
-const lab = exports.lab = Lab.script();
+const { experiment, test } = exports.lab = require('lab').script();
 
 const { expect } = require('code');
 
@@ -12,7 +11,7 @@ const { scope } = require('external/lib/constants');
 const getAuthenticatedRequest = () => {
   return {
     view: {
-      activeNavLink: 'change-password'
+      activeNavLink: 'account-settings'
     },
     state: {
       sid: '00000000-0000-0000-0000-000000000000'
@@ -26,38 +25,38 @@ const getAuthenticatedRequest = () => {
   };
 };
 
-lab.experiment('getPropositionLinks', () => {
-  lab.test('It should not display any links if the user is not authenticated', async () => {
+experiment('getPropositionLinks', () => {
+  test('It should not display any links if the user is not authenticated', async () => {
     const request = {};
     const result = getPropositionLinks(request);
     expect(result.length).to.equal(0);
   });
 
-  lab.test('It should display change password and signout links for all authenticated users', async () => {
+  test('displays account settings and signout links for all authenticated users', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
     const ids = links.map(link => link.id);
-    expect(ids).to.equal(['change-password', 'signout']);
+    expect(ids).to.equal(['account-settings', 'signout']);
   });
 
-  lab.test('It should set the active nav link flag', async () => {
+  test('sets the active nav link flag', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
-    const link = find(links, { id: 'change-password' });
+    const link = find(links, { id: 'account-settings' });
     expect(link.active).to.equal(true);
   });
 
-  lab.test('Non-active links should have the active flag set to false', async () => {
+  test('Non-active links should have the active flag set to false', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
-    const flags = links.filter(link => (link.id !== 'change-password')).map(link => link.active);
+    const flags = links.filter(link => (link.id !== 'account-settings')).map(link => link.active);
     expect(flags).to.equal([false]);
   });
 
-  lab.test('It should set ID attributes', async () => {
+  test('It should set ID attributes', async () => {
     const request = getAuthenticatedRequest();
     const links = getPropositionLinks(request);
     const idAttributes = links.map(link => link.attributes.id);
-    expect(idAttributes).to.equal(['change-password', 'signout']);
+    expect(idAttributes).to.equal(['account-settings', 'signout']);
   });
 });

--- a/test/external/modules/account/controller.js
+++ b/test/external/modules/account/controller.js
@@ -1,0 +1,360 @@
+const { expect } = require('code');
+const { experiment, test, beforeEach } = exports.lab = require('lab').script();
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const controller = require('external/modules/account/controller');
+
+experiment('modules/account/controller', () => {
+  experiment('.getAccount', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        defra: { userName: 'test-user' }
+      };
+
+      await controller.getAccount(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/account/entry.njk');
+    });
+
+    test('the userName is added to the view context', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.userName).to.equal('test-user');
+    });
+  });
+
+  experiment('.getConfirmPassword', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: { csrfToken: 'token' }
+      };
+
+      await controller.getConfirmPassword(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/form.njk');
+    });
+
+    test('the view data is passed through to the view', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.csrfToken).to.equal('token');
+    });
+
+    test('the back link is setup to return to /account', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.back).to.equal('/account');
+    });
+  });
+
+  experiment('.postConfirmPassword', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = {
+        view: sandbox.spy(),
+        redirect: sandbox.spy()
+      };
+    });
+
+    experiment('when the data is valid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            csrf_token: 'token',
+            password: 'secrets'
+          }
+        };
+
+        await controller.postConfirmPassword(request, h);
+      });
+
+      test('the user is redirected to the next step', async () => {
+        const [url] = h.redirect.lastCall.args;
+        expect(url).to.equal('/account/change-email/enter-new-email');
+      });
+    });
+
+    experiment('when the data is invalid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: { password: '' }
+        };
+
+        await controller.postConfirmPassword(request, h);
+      });
+
+      test('the expected view template is used', async () => {
+        const [template] = h.view.lastCall.args;
+        expect(template).to.equal('nunjucks/form.njk');
+      });
+
+      test('the view data is passed through to the view', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.csrfToken).to.equal('token');
+      });
+
+      test('the back link is setup to return to /account', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.equal('/account');
+      });
+    });
+  });
+
+  experiment('.getEnterNewEmail', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: { csrfToken: 'token' }
+      };
+
+      await controller.getEnterNewEmail(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/form.njk');
+    });
+
+    test('the view data is passed through to the view', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.csrfToken).to.equal('token');
+    });
+
+    test('the back link is setup to return to /account', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.back).to.equal('/account');
+    });
+  });
+
+  experiment('.postEnterNewEmail', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = {
+        view: sandbox.spy(),
+        redirect: sandbox.spy()
+      };
+    });
+
+    experiment('when the data is valid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            csrf_token: 'token',
+            email: 'user@example.com',
+            'confirm-email': 'user@example.com'
+          }
+        };
+
+        await controller.postEnterNewEmail(request, h);
+      });
+
+      test('the user is redirected to the next step', async () => {
+        const [url] = h.redirect.lastCall.args;
+        expect(url).to.equal('/account/change-email/verify-new-email');
+      });
+    });
+
+    experiment('when the data is invalid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            email: '',
+            'confirm-password': ''
+          }
+        };
+
+        await controller.postEnterNewEmail(request, h);
+      });
+
+      test('the expected view template is used', async () => {
+        const [template] = h.view.lastCall.args;
+        expect(template).to.equal('nunjucks/form.njk');
+      });
+
+      test('the view contains a form with errors', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.form.errors).to.not.be.empty();
+      });
+
+      test('the view data is passed through to the view', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.csrfToken).to.equal('token');
+      });
+
+      test('the back link is setup to return to /account', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.equal('/account');
+      });
+    });
+  });
+
+  experiment('.getVerifyEmail', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: {
+          newEmail: 'test@example.com',
+          csrfToken: 'token'
+        }
+      };
+
+      await controller.getVerifyEmail(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/account/verify.njk');
+    });
+
+    test('the view data is passed through to the view', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.newEmail).to.equal('test@example.com');
+    });
+
+    test('the back link is setup to return to /account', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.back).to.equal('/account');
+    });
+  });
+
+  experiment('.postVerifyEmail', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = {
+        view: sandbox.spy(),
+        redirect: sandbox.spy()
+      };
+    });
+
+    experiment('when the data is valid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            csrf_token: 'token',
+            'verification-code': '12345'
+          }
+        };
+
+        await controller.postVerifyEmail(request, h);
+      });
+
+      test('the user is redirected to the next step', async () => {
+        const [url] = h.redirect.lastCall.args;
+        expect(url).to.equal('/account/change-email/success');
+      });
+    });
+
+    experiment('when the data is invalid', () => {
+      beforeEach(async () => {
+        const request = {
+          view: { csrfToken: 'token' },
+          payload: {
+            csrf_token: 'token',
+            'verification-code': ''
+          }
+        };
+
+        await controller.postVerifyEmail(request, h);
+      });
+
+      test('the expected view template is used', async () => {
+        const [template] = h.view.lastCall.args;
+        expect(template).to.equal('nunjucks/account/verify.njk');
+      });
+
+      test('the view contains a form with errors', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.form.errors).to.not.be.empty();
+      });
+
+      test('the view data is passed through to the view', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.csrfToken).to.equal('token');
+      });
+
+      test('the back link is setup to return to /account', async () => {
+        const [, context] = h.view.lastCall.args;
+        expect(context.back).to.equal('/account');
+      });
+    });
+  });
+
+  experiment('.getSuccess', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: {
+          pageTitle: 'test'
+        }
+      };
+
+      await controller.getSuccess(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/account/success.njk');
+    });
+
+    test('the view context is passed through', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.pageTitle).to.equal('test');
+    });
+  });
+
+  experiment('.getTryAgainLater', () => {
+    let h;
+
+    beforeEach(async () => {
+      h = { view: sandbox.spy() };
+
+      const request = {
+        view: {
+          pageTitle: 'test'
+        }
+      };
+
+      await controller.getTryAgainLater(request, h);
+    });
+
+    test('the expected view template is used', async () => {
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/account/try-again-later.njk');
+    });
+
+    test('the view context is passed through', async () => {
+      const [, context] = h.view.lastCall.args;
+      expect(context.pageTitle).to.equal('test');
+    });
+  });
+});

--- a/test/external/modules/account/forms/confirm-password.js
+++ b/test/external/modules/account/forms/confirm-password.js
@@ -1,7 +1,7 @@
 const { expect } = require('code');
 const { experiment, test } = exports.lab = require('lab').script();
 
-const { verifyNewEmailForm } = require('external/modules/account/forms/verify-new-email');
+const { confirmPasswordForm } = require('external/modules/account/forms/confirm-password');
 
 const { handleRequest } = require('shared/lib/forms');
 
@@ -16,21 +16,21 @@ const createRequest = () => {
   };
 };
 
-experiment('verifyNewEmailForm', () => {
-  test('has a verification code field', async () => {
-    const form = verifyNewEmailForm(createRequest());
-    const verify = form.fields.find(x => x.name === 'verification-code');
-    expect(verify).to.exist();
+experiment('confirmPasswordForm', () => {
+  test('has an password field', async () => {
+    const form = confirmPasswordForm(createRequest());
+    const email = form.fields.find(x => x.name === 'password');
+    expect(email).to.exist();
   });
 
   test('has a hidden csrf field', async () => {
-    const form = verifyNewEmailForm(createRequest());
+    const form = confirmPasswordForm(createRequest());
     const csrf = form.fields.find(x => x.name === 'csrf_token');
     expect(csrf.value).to.equal('test-csrf-token');
   });
 
   test('has a continue button', async () => {
-    const form = verifyNewEmailForm(createRequest());
+    const form = confirmPasswordForm(createRequest());
     const button = form.fields.find(f => {
       return f.options.widget === 'button' && f.options.label === 'Continue';
     });
@@ -38,18 +38,18 @@ experiment('verifyNewEmailForm', () => {
   });
 
   experiment('errors', () => {
-    test('returns an error if the verification code field is missing', async () => {
+    test('returns an error if the password field is missing', async () => {
       const request = createRequest();
-      request.payload['verification-code'] = '';
+      request.payload.password = '';
 
-      const form = verifyNewEmailForm(request);
+      const form = confirmPasswordForm(request);
       const validated = handleRequest(form, request);
 
       expect(validated.isValid).to.be.false();
 
       expect(validated.errors.find(f => {
-        return f.name === 'verification-code' &&
-          f.message === 'Check your code';
+        return f.name === 'password' &&
+          f.message === 'Check your password';
       })).to.exist();
     });
   });

--- a/test/external/modules/account/forms/enter-new-email.js
+++ b/test/external/modules/account/forms/enter-new-email.js
@@ -1,0 +1,127 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const {
+  enterNewEmailForm,
+  enterNewEmailSchema
+} = require('external/modules/account/forms/enter-new-email');
+
+const { handleRequest } = require('shared/lib/forms');
+
+const createRequest = () => {
+  return {
+    view: {
+      csrfToken: 'test-csrf-token'
+    },
+    payload: {
+      csrf_token: 'test-csrf-token'
+    }
+  };
+};
+
+experiment('enterNewEmailForm', () => {
+  test('has an email field', async () => {
+    const form = enterNewEmailForm(createRequest());
+    const email = form.fields.find(x => x.name === 'email');
+    expect(email).to.exist();
+  });
+
+  test('has an email confirmation field', async () => {
+    const form = enterNewEmailForm(createRequest());
+    const email = form.fields.find(x => x.name === 'confirm-email');
+    expect(email).to.exist();
+  });
+
+  test('has a hidden csrf field', async () => {
+    const form = enterNewEmailForm(createRequest());
+    const csrf = form.fields.find(x => x.name === 'csrf_token');
+    expect(csrf.value).to.equal('test-csrf-token');
+  });
+
+  test('has a continue button', async () => {
+    const form = enterNewEmailForm(createRequest());
+    const button = form.fields.find(f => {
+      return f.options.widget === 'button' && f.options.label === 'Continue';
+    });
+    expect(button).to.exist();
+  });
+
+  experiment('errors', () => {
+    test('returns an error if the email field is missing', async () => {
+      const request = createRequest();
+      request.payload.email = '';
+      request.payload['confirm-email'] = 'user@example.com';
+
+      const form = enterNewEmailForm(request);
+      const validated = handleRequest(form, request, enterNewEmailSchema);
+
+      expect(validated.isValid).to.be.false();
+
+      expect(validated.errors.find(f => {
+        return f.name === 'email' &&
+          f.message === 'Enter your email';
+      })).to.exist();
+    });
+
+    test('returns an error if the confirm email field is missing', async () => {
+      const request = createRequest();
+      request.payload.email = 'user@example.com';
+      request.payload['confirm-email'] = '';
+
+      const form = enterNewEmailForm(request);
+      const validated = handleRequest(form, request, enterNewEmailSchema);
+
+      expect(validated.isValid).to.be.false();
+
+      expect(validated.errors.find(f => {
+        return f.name === 'confirm-email' &&
+          f.message === 'Confirm your new email address';
+      })).to.exist();
+    });
+
+    test('returns an error if the email values do not match', async () => {
+      const request = createRequest();
+      request.payload.email = 'aaaaa@example.com';
+      request.payload['confirm-email'] = 'bbbbb@example.com';
+
+      const form = enterNewEmailForm(request);
+      const validated = handleRequest(form, request, enterNewEmailSchema);
+
+      expect(validated.isValid).to.be.false();
+      expect(validated.errors.find(f => {
+        return f.name === 'email' &&
+          f.message === 'Email addresses must match';
+      })).to.exist();
+    });
+
+    test('returns an error if the email is not an email', async () => {
+      const request = createRequest();
+      request.payload.email = 'not-an-email';
+      request.payload['confirm-email'] = 'user@example.com';
+
+      const form = enterNewEmailForm(request);
+      const validated = handleRequest(form, request, enterNewEmailSchema);
+
+      expect(validated.isValid).to.be.false();
+      expect(validated.errors.find(f => {
+        return f.name === 'email' &&
+          f.message === 'Enter a valid email';
+      })).to.exist();
+    });
+
+    test('returns an error if the confirmation email is not an email', async () => {
+      const request = createRequest();
+      request.payload.email = 'user@example.com';
+      request.payload['confirm-email'] = 'not-an-email';
+
+      const form = enterNewEmailForm(request);
+      const validated = handleRequest(form, request, enterNewEmailSchema);
+
+      expect(validated.isValid).to.be.false();
+      expect(validated.errors.find(f => {
+        return f.name === 'confirm-email' &&
+          f.message === 'Enter a valid email';
+      })).to.exist();
+    });
+  });
+});

--- a/test/external/modules/account/forms/enter-new-email.js
+++ b/test/external/modules/account/forms/enter-new-email.js
@@ -90,7 +90,7 @@ experiment('enterNewEmailForm', () => {
       expect(validated.isValid).to.be.false();
       expect(validated.errors.find(f => {
         return f.name === 'email' &&
-          f.message === 'Email addresses must match';
+          f.message === 'The email addresses must match';
       })).to.exist();
     });
 

--- a/test/external/modules/account/forms/verify-new-email.js
+++ b/test/external/modules/account/forms/verify-new-email.js
@@ -1,0 +1,56 @@
+const { expect } = require('code');
+const { experiment, test } = exports.lab = require('lab').script();
+
+const { verifyNewEmailForm } = require('external/modules/account/forms/verify-new-email');
+
+const { handleRequest } = require('shared/lib/forms');
+
+const createRequest = () => {
+  return {
+    view: {
+      csrfToken: 'test-csrf-token'
+    },
+    payload: {
+      csrf_token: 'test-csrf-token'
+    }
+  };
+};
+
+experiment('verifyNewEmailForm', () => {
+  test('has a verification code field', async () => {
+    const form = verifyNewEmailForm(createRequest());
+    const verify = form.fields.find(x => x.name === 'verification-code');
+    expect(verify).to.exist();
+  });
+
+  test('has a hidden csrf field', async () => {
+    const form = verifyNewEmailForm(createRequest());
+    const csrf = form.fields.find(x => x.name === 'csrf_token');
+    expect(csrf.value).to.equal('test-csrf-token');
+  });
+
+  test('has a continue button', async () => {
+    const form = verifyNewEmailForm(createRequest());
+    const button = form.fields.find(f => {
+      return f.options.widget === 'button' && f.options.label === 'Continue';
+    });
+    expect(button).to.exist();
+  });
+
+  experiment('errors', () => {
+    test('returns an error if the verification code field is missing', async () => {
+      const request = createRequest();
+      request.payload['verification-code'] = '';
+
+      const form = verifyNewEmailForm(request);
+      const validated = handleRequest(form, request);
+
+      expect(validated.isValid).to.be.false();
+
+      expect(validated.errors.find(f => {
+        return f.name === 'verification-code' &&
+          f.message === 'Enter the verification code';
+      })).to.exist();
+    });
+  });
+});


### PR DESCRIPTION
WATER-2154

Update email UI and company selector update

 - Includes new account-setting landing page
   - Update email link commented out at this stage
 - Includes confirm password page
 - Adds page for adding new email address
 - Adds page for email verification code
 - Adds success page
 - Adds the try again page for failed password attempts

Reworks the logic for the company selector which can now use the
`request.defra` object to help determine if a user should be redirected,
and also adds a settings item to allow a route to opt out of company
selector redirection. This came about because the user is logged in when
updating their account details so the existing mechanism of checking if
the route did not require authentication was no longer relevant.