### PR TITLE
Feat: Charge versions in licence page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,7 +872,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -4554,8 +4554,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4573,13 +4572,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4592,18 +4589,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4706,8 +4700,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4717,7 +4710,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4730,20 +4722,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4760,7 +4749,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4833,8 +4821,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4844,7 +4831,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4920,8 +4906,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4951,7 +4936,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4969,7 +4953,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5008,13 +4991,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/external/lib/licence-data-config.js
+++ b/src/external/lib/licence-data-config.js
@@ -1,6 +1,11 @@
 const services = require('./connectors/services');
 
 exports.getLicenceData = (method, documentId, request) => {
+  // To be added soon, but currently only for internal users.
+  if (method === 'getChargeVersionsByDocumentId') {
+    return [];
+  }
+
   const { companyId } = request.defra;
   const options = companyId ? { companyId } : {};
 

--- a/src/external/lib/view-licence-config.js
+++ b/src/external/lib/view-licence-config.js
@@ -14,3 +14,13 @@ exports.getReturnPath = getReturnPath;
 exports.getLicenceSummaryReturns = getLicenceSummaryReturns;
 exports.getCommunication = services.water.communications.getCommunication.bind(services.water.communications);
 exports.getRiverLevel = services.water.riverLevels.getRiverLevel.bind(services.water.riverLevels);
+
+/**
+ * Should the licence view show charging information to this external user?
+ *
+ * Always set to false for now whilst under construction.
+ *
+ * @param {Object} request The HAPI request object
+ * @returns {Boolean} True if this user can see charging details
+ */
+exports.canShowCharging = request => false;

--- a/src/internal/lib/connectors/services/water/index.js
+++ b/src/internal/lib/connectors/services/water/index.js
@@ -5,6 +5,7 @@ const LicencesService = require('shared/lib/connectors/services/water/LicencesSe
 const RiverLevelsService = require('shared/lib/connectors/services/water/RiverLevelsService');
 const ServiceStatusService = require('shared/lib/connectors/services/water/ServiceStatusService');
 const UsersService = require('shared/lib/connectors/services/water/UsersService');
+const ChargeVersionsService = require('shared/lib/connectors/services/water/ChargeVersionsService');
 
 // Internal services (possibly unique, or overriding shared)
 const ReturnsService = require('./ReturnsService');
@@ -35,6 +36,7 @@ module.exports = config => ({
   riverLevels: new RiverLevelsService(config.services.water, logger),
   serviceStatus: new ServiceStatusService(config.services.water, logger),
   users: new UsersService(config.services.water, logger),
+  chargeVersions: new ChargeVersionsService(config.services.water, logger),
 
   // Internal services
   returns: new ReturnsService(config.services.water, logger),

--- a/src/internal/lib/constants.js
+++ b/src/internal/lib/constants.js
@@ -5,6 +5,7 @@ const SCOPE_ABSTRACTION_REFORM_APPROVER = 'ar_approver';
 const SCOPE_HOF_NOTIFICATIONS = 'hof_notifications';
 const SCOPE_RENEWAL_NOTIFICATIONS = 'renewal_notifications';
 const SCOPE_MANAGE_ACCOUNTS = 'manage_accounts';
+const SCOPE_CHARGING = 'charging';
 
 module.exports = {
   scope: {
@@ -28,6 +29,7 @@ module.exports = {
       SCOPE_RENEWAL_NOTIFICATIONS,
       SCOPE_BULK_RETURNS_NOTIFICATIONS
     ],
-    manageAccounts: SCOPE_MANAGE_ACCOUNTS
+    manageAccounts: SCOPE_MANAGE_ACCOUNTS,
+    charging: SCOPE_CHARGING
   }
 };

--- a/src/internal/lib/licence-data-config.js
+++ b/src/internal/lib/licence-data-config.js
@@ -1,5 +1,8 @@
 const services = require('./connectors/services');
 
 exports.getLicenceData = (method, documentId) => {
+  if (method === 'getChargeVersionsByDocumentId') {
+    return services.water.chargeVersions[method](documentId);
+  }
   return services.water.licences[method](documentId, { includeExpired: true });
 };

--- a/src/internal/lib/permissions.js
+++ b/src/internal/lib/permissions.js
@@ -47,6 +47,8 @@ const isManageTab = request => hasScope(request, scope.hasManageTab);
 
 const isManageAccounts = request => hasScope(request, scope.manageAccounts);
 
+const isCharging = request => hasScope(request, scope.charging);
+
 exports.hasScope = hasScope;
 exports.isAuthenticated = isAuthenticated;
 exports.isInternalReturns = isInternalReturns;
@@ -59,3 +61,4 @@ exports.isAnyNotifications = isAnyNotifications;
 exports.isBasicUser = isBasicUser;
 exports.isManageTab = isManageTab;
 exports.isManageAccounts = isManageAccounts;
+exports.isCharging = isCharging;

--- a/src/internal/lib/view-engine/filters/index.js
+++ b/src/internal/lib/view-engine/filters/index.js
@@ -2,6 +2,7 @@ module.exports = {
   ...require('./abstraction-reform'),
   ...require('./most-significant-entity-role'),
   ...require('shared/view/nunjucks/filters/abstraction-period'),
+  ...require('shared/view/nunjucks/filters/charge-version-badge'),
   ...require('shared/view/nunjucks/filters/date'),
   ...require('shared/view/nunjucks/filters/fixed'),
   ...require('shared/view/nunjucks/filters/flow-converter'),

--- a/src/internal/lib/view-licence-config.js
+++ b/src/internal/lib/view-licence-config.js
@@ -1,6 +1,7 @@
 const { getReturnPath } = require('./return-path');
 
 const services = require('./connectors/services');
+const permissions = require('./permissions');
 
 const getLicenceSummaryReturns = licenceNumber => {
   return services.returns.returns.getLicenceReturns([licenceNumber], {
@@ -13,3 +14,13 @@ exports.getReturnPath = getReturnPath;
 exports.getLicenceSummaryReturns = getLicenceSummaryReturns;
 exports.getCommunication = services.water.communications.getCommunication.bind(services.water.communications);
 exports.getRiverLevel = services.water.riverLevels.getRiverLevel.bind(services.water.riverLevels);
+
+/**
+ * Should the licence view show charging information to this user?
+ *
+ * Will be true of the user has the charging role.
+ *
+ * @param {Object} request The HAPI request object
+ * @returns {Boolean} True if this user can see charging details
+ */
+exports.canShowCharging = request => permissions.isCharging(request);

--- a/src/internal/views/nunjucks/view-licences/licence.njk
+++ b/src/internal/views/nunjucks/view-licences/licence.njk
@@ -18,23 +18,8 @@
         <p>Registered to <a href="/user/{{primaryUser.userId}}/status">{{primaryUser.userName}}</a></p>
       {% endif %}
 
-      {% set summaryHtml %}
-
-      {% endset %}
-
-      {% set returnsHtml %}
-        {% include "nunjucks/view-licences/tabs/returns.njk" %}
-      {% endset %}
-
-      {% set communicationsHtml %}
-        {% include "nunjucks/view-licences/tabs/communications.njk" %}
-      {% endset %}
-
-
       <div class="govuk-tabs" data-module="tabs">
-        <h2 class="govuk-tabs__title">
-          Contents
-        </h2>
+        <h2 class="govuk-tabs__title">Contents</h2>
 
         <ul class="govuk-tabs__list">
           <li class="govuk-tabs__list-item">
@@ -42,34 +27,45 @@
               Summary
             </a>
           </li>
+
           {% if returns.length %}
-          <li class="govuk-tabs__list-item">
-            <a class="govuk-tabs__tab" href="#returns">
-              Returns
-            </a>
-          </li>
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="#returns">Returns</a>
+            </li>
           {% endif %}
+
           <li class="govuk-tabs__list-item">
-            <a class="govuk-tabs__tab" href="#communications">
-              Communications
-            </a>
+            <a class="govuk-tabs__tab" href="#communications">Communications</a>
           </li>
+
+          {% if showChargeVersions %}
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="#charge">Charge</a>
+            </li>
+          {% endif %}
         </ul>
 
         <section class="govuk-tabs__panel" id="summary">
           {% include "nunjucks/view-licences/tabs/summary.njk" %}
         </section>
+
         {% if returns.length %}
-        <section class="govuk-tabs__panel" id="returns">
-          {% include "nunjucks/view-licences/tabs/returns.njk" %}
-        </section>
+          <section class="govuk-tabs__panel" id="returns">
+            {% include "nunjucks/view-licences/tabs/returns.njk" %}
+          </section>
         {% endif %}
+
         <section class="govuk-tabs__panel" id="communications">
           {% include "nunjucks/view-licences/tabs/communications.njk" %}
         </section>
+
+        {% if showChargeVersions %}
+          <section class="govuk-tabs__panel" id="charge">
+            {% include "nunjucks/view-licences/tabs/charge.njk" %}
+          </section>
+        {% endif %}
+
       </div>
-
-
     </div>
   </div>
 {% endblock %}

--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -1,0 +1,56 @@
+<h2 class="govuk-heading-m">Charge versions</h2>
+
+{% macro chargeVersionLink(chargeVersion) %}
+  Version {{ chargeVersion.versionNumber }}
+  {# <a class="govuk-link" href="/licences/{{ documentId }}/charge-version/{{ chargeVersion.chargeVersionId }}">Version {{ chargeVersion.versionNumber }}</a> #}
+{% endmacro %}
+
+{% macro chargeVersionRowMobile(chargeVersion) %}
+  <div class="phone--show">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+      {{ chargeVersionLink(chargeVersion) }}
+    </h3>
+
+    <p>Effective from: {{ chargeVersion.startDate | date }}</p>
+    <p>Effective to: {{ chargeVersion.endDate | date }}</p>
+    {{ badge(chargeVersion | chargeVersionBadge) }}
+  </div>
+{% endmacro %}
+
+{% macro chargeVersionRow(chargeVersion) %}
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell" scope="row">
+      {{ chargeVersionLink(chargeVersion) }}
+    </td>
+    <td class="govuk-table__cell">
+      {{ chargeVersion.startDate | date }}
+    </td>
+    <td class="govuk-table__cell">
+      {{ chargeVersion.endDate | date }}
+    </td>
+    <td class="govuk-table__cell">
+      {{ badge(chargeVersion | chargeVersionBadge) }}
+    </td>
+  </tr>
+{% endmacro %}
+
+{% for chargeVersion in chargeVersions %}
+  {{ chargeVersionRowMobile(chargeVersion) }}
+{% endfor %}
+
+<table class="govuk-table phone--hide">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Version</th>
+      <th class="govuk-table__header" scope="col">Effective from</th>
+      <th class="govuk-table__header" scope="col">Effective to</th>
+      <th class="govuk-table__header" scope="col">Status</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for chargeVersion in chargeVersions %}
+      {{ chargeVersionRow(chargeVersion) }}
+    {% endfor %}
+  </tbody>
+</table>

--- a/src/shared/lib/connectors/services/water/ChargeVersionsService.js
+++ b/src/shared/lib/connectors/services/water/ChargeVersionsService.js
@@ -1,0 +1,41 @@
+const ServiceClient = require('../ServiceClient');
+
+class ChargeVersionsService extends ServiceClient {
+  /**
+   * Gets the charge versions for the given licence
+   * @param {String} licenceRef The licence id
+   * @return {Promise} resolves with the charge versions data
+   */
+  getChargeVersionsByLicenceRef (licenceRef) {
+    const url = this.joinUrl('charge-versions');
+    const options = {
+      qs: {
+        licenceRef
+      }
+    };
+
+    return this.serviceRequest.get(url, options);
+  };
+
+  /**
+   * Gets the charge versions for the given licence as represented
+   * by a CRM document id
+   * @param {String} documentId The CRM document id
+   * @return {Promise} resolves with the charge versions data
+   */
+  getChargeVersionsByDocumentId (documentId) {
+    const url = this.joinUrl('charge-versions/document', documentId);
+    return this.serviceRequest.get(url);
+  };
+
+  /**
+   * Gets full information for a given charge version id
+   * @param {String} chargeVersionId The charge version id
+   */
+  getChargeVersion (chargeVersionId) {
+    const url = this.joinUrl('charge-versions', chargeVersionId);
+    return this.serviceRequest.get(url);
+  }
+}
+
+module.exports = ChargeVersionsService;

--- a/src/shared/plugins/licence-data/index.js
+++ b/src/shared/plugins/licence-data/index.js
@@ -10,7 +10,8 @@ const routeConfigSchema = Joi.object().keys({
     summary: Joi.boolean().valid(true),
     communications: Joi.boolean().valid(true),
     users: Joi.boolean().valid(true),
-    primaryUser: Joi.boolean().valid(true)
+    primaryUser: Joi.boolean().valid(true),
+    chargeVersions: Joi.boolean().valid(true)
   })
 });
 
@@ -19,7 +20,8 @@ const waterMethods = {
   summary: 'getSummaryByDocumentId',
   communications: 'getCommunicationsByDocumentId',
   users: 'getUsersByExternalId',
-  primaryUser: 'getPrimaryUserByDocumentId'
+  primaryUser: 'getPrimaryUserByDocumentId',
+  chargeVersions: 'getChargeVersionsByDocumentId'
 };
 
 /**

--- a/src/shared/plugins/view-licence/controller.js
+++ b/src/shared/plugins/view-licence/controller.js
@@ -1,5 +1,5 @@
 const Boom = require('@hapi/boom');
-const { trim } = require('lodash');
+const { trim, sortBy } = require('lodash');
 const { selectRiverLevelMeasure } = require('./lib/river-level');
 const { getLicencePageTitle, getCommonViewContext } = require('./lib/view-helpers');
 const { getCommonBackLink } = require('shared/lib/view-licence-helpers');
@@ -97,7 +97,7 @@ const hasMultiplePages = pagination => pagination.pageCount > 1;
 const getLicence = async (request, h) => {
   const { licenceNumber } = request.licence.summary;
 
-  const { getLicenceSummaryReturns, getReturnPath } = h.realm.pluginOptions;
+  const { getLicenceSummaryReturns, getReturnPath, canShowCharging } = h.realm.pluginOptions;
 
   const returns = await getLicenceSummaryReturns(licenceNumber);
 
@@ -106,7 +106,9 @@ const getLicence = async (request, h) => {
     pageTitle: `Licence number ${licenceNumber}`,
     returns: returns.data.map(ret => ({ ...ret, ...getReturnPath(ret, request) })),
     hasMoreReturns: hasMultiplePages(returns.pagination),
-    back: '/licences'
+    back: '/licences',
+    showChargeVersions: canShowCharging(request),
+    chargeVersions: sortBy(request.licence.chargeVersions, 'versionNumber').reverse()
   };
 
   return h.view('nunjucks/view-licences/licence.njk', view, { layout: false });

--- a/src/shared/plugins/view-licence/routes.js
+++ b/src/shared/plugins/view-licence/routes.js
@@ -25,7 +25,8 @@ module.exports = allowedScopes => [
           load: {
             summary: true,
             communications: true,
-            primaryUser: true
+            primaryUser: true,
+            chargeVersions: true
           }
         },
         viewContext: {

--- a/src/shared/view/nunjucks/filters/charge-version-badge.js
+++ b/src/shared/view/nunjucks/filters/charge-version-badge.js
@@ -1,0 +1,20 @@
+const titleCase = require('title-case');
+
+/**
+ * Gets badge object to render for charge version status
+ */
+const chargeVersionBadge = chargeVersion => {
+  const { status } = chargeVersion;
+
+  const styles = {
+    current: 'completed',
+    draft: 'void'
+  };
+
+  return {
+    text: titleCase(status),
+    status: styles[status]
+  };
+};
+
+exports.chargeVersionBadge = chargeVersionBadge;

--- a/test/internal/lib/permissions.js
+++ b/test/internal/lib/permissions.js
@@ -268,4 +268,21 @@ experiment('permissions', () => {
       expect(permissions.isManageAccounts(request)).to.equal(true);
     });
   });
+
+  experiment('isCharging', async () => {
+    test('returns false if scopes empty', async () => {
+      const request = createRequest([]);
+      expect(permissions.isCharging(request)).to.equal(false);
+    });
+
+    test('it should return true if scopes "charging"', async () => {
+      const request = createRequest(['charging']);
+      expect(permissions.isCharging(request)).to.equal(true);
+    });
+
+    test('it should return true if scopes contains "charging"', async () => {
+      const request = createRequest(['charging', 'manage_accounts']);
+      expect(permissions.isCharging(request)).to.equal(true);
+    });
+  });
 });

--- a/test/internal/lib/view-licence-config.js
+++ b/test/internal/lib/view-licence-config.js
@@ -1,0 +1,30 @@
+const {
+  experiment,
+  test
+} = exports.lab = require('@hapi/lab').script();
+
+const { expect } = require('@hapi/code');
+
+const internalViewLicenceConfig = require('internal/lib/view-licence-config');
+
+const getRequestWithScopes = (scopes = []) => ({
+  auth: {
+    credentials: {
+      scope: scopes
+    }
+  }
+});
+
+experiment('internal/lib/view-licence-config', () => {
+  experiment('canShowCharging', () => {
+    test('returns false if user does not have charging role', async () => {
+      const request = getRequestWithScopes('returns');
+      expect(internalViewLicenceConfig.canShowCharging(request)).to.be.false();
+    });
+
+    test('returns true if user has the charging role', async () => {
+      const request = getRequestWithScopes('charging');
+      expect(internalViewLicenceConfig.canShowCharging(request)).to.be.true();
+    });
+  });
+});

--- a/test/shared/lib/connectors/services/water/ChargeVersionsService.js
+++ b/test/shared/lib/connectors/services/water/ChargeVersionsService.js
@@ -1,0 +1,62 @@
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const {
+  experiment,
+  beforeEach,
+  afterEach,
+  test
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+const ChargeVersionsService = require('shared/lib/connectors/services/water/ChargeVersionsService');
+const { serviceRequest } = require('@envage/water-abstraction-helpers');
+
+experiment('services/water/ChargeVersionsService', () => {
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'get');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('.getChargeVersionsByLicenceRef', () => {
+    test('passes the expected URL to the service request', async () => {
+      const service = new ChargeVersionsService('http://127.0.0.1:8001/water/1.0');
+      await service.getChargeVersionsByLicenceRef('licence-ref');
+      const expectedUrl = `http://127.0.0.1:8001/water/1.0/charge-versions`;
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal(expectedUrl);
+    });
+
+    test('passes the expected options to the service request', async () => {
+      const service = new ChargeVersionsService('http://127.0.0.1:8001/water/1.0');
+      await service.getChargeVersionsByLicenceRef('licence-ref');
+
+      const [, { qs }] = serviceRequest.get.lastCall.args;
+
+      expect(qs.licenceRef).to.equal('licence-ref');
+    });
+  });
+
+  experiment('.getChargeVersionsByDocumentId', () => {
+    test('passes the expected URL to the service request', async () => {
+      const service = new ChargeVersionsService('http://127.0.0.1:8001/water/1.0');
+      await service.getChargeVersionsByDocumentId('doc-id');
+      const expectedUrl = `http://127.0.0.1:8001/water/1.0/charge-versions/document/doc-id`;
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal(expectedUrl);
+    });
+  });
+
+  experiment('.getChargeVersion', () => {
+    test('passes the expected URL to the service request', async () => {
+      const service = new ChargeVersionsService('http://127.0.0.1:8001/water/1.0');
+      await service.getChargeVersion('charge-version-id');
+      const expectedUrl = `http://127.0.0.1:8001/water/1.0/charge-versions/charge-version-id`;
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal(expectedUrl);
+    });
+  });
+});

--- a/test/shared/view/nunjucks/filters/charge-version-badge.js
+++ b/test/shared/view/nunjucks/filters/charge-version-badge.js
@@ -1,0 +1,40 @@
+const { chargeVersionBadge } = require('shared/view/nunjucks/filters/charge-version-badge');
+
+const { experiment, test } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+
+experiment('shared/view/nunjucks/filters/charge-version-badge', () => {
+  test('The status text is returned using title casing', async () => {
+    const chargeVersion = { status: 'titleCasePlease' };
+    const { text } = chargeVersionBadge(chargeVersion);
+    expect(text).to.equal('Title Case Please');
+  });
+
+  experiment('for a status of current', () => {
+    test('the style is set to "completed"', async () => {
+      const chargeVersion = { status: 'current' };
+      const { status } = chargeVersionBadge(chargeVersion);
+      expect(status).to.equal('completed');
+    });
+
+    test('the text is set to "Current"', async () => {
+      const chargeVersion = { status: 'current' };
+      const { text } = chargeVersionBadge(chargeVersion);
+      expect(text).to.equal('Current');
+    });
+  });
+
+  experiment('for a status of draft', () => {
+    test('the style is set to "void"', async () => {
+      const chargeVersion = { status: 'draft' };
+      const { status } = chargeVersionBadge(chargeVersion);
+      expect(status).to.equal('void');
+    });
+
+    test('the text is set to "Draft"', async () => {
+      const chargeVersion = { status: 'draft' };
+      const { text } = chargeVersionBadge(chargeVersion);
+      expect(text).to.equal('Draft');
+    });
+  });
+});


### PR DESCRIPTION
WATER-2267

 - Adds the charge versions to the view-licence page.
 - Adds a new tab if the user is authorised to view charge versions
 - Handles the new 'charging' role in the permissions.