### PR TITLE
Feat: Refine/reduce error logs

### DIFF
--- a/src/external/modules/add-licences/routes.js
+++ b/src/external/modules/add-licences/routes.js
@@ -52,6 +52,7 @@ module.exports = {
           error: Joi.string().max(32)
         }
       },
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Confirm your licences',
@@ -73,6 +74,7 @@ module.exports = {
           csrf_token: Joi.string().guid().required()
         }
       },
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Confirm your licences',
@@ -103,6 +105,7 @@ module.exports = {
     handler: controller.getAddressSelect,
     config: {
       description: 'Select the address to send postal verification letter',
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Where should we send your security code?',
@@ -123,6 +126,7 @@ module.exports = {
     handler: controller.postAddressSelect,
     config: {
       description: 'Post handler for select address form',
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Where should we send your security code?',
@@ -144,6 +148,7 @@ module.exports = {
     handler: controller.getFAO,
     config: {
       description: 'Specify a name or department for security code letter',
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Tell us if you want the security code marked for someone’s attention',
@@ -165,6 +170,7 @@ module.exports = {
           csrf_token: Joi.string().guid().required()
         }
       },
+      pre: [{ method: controller.ensureSessionDataPreHandler }],
       plugins: {
         viewContext: {
           pageTitle: 'Tell us if you want the security code marked for someone’s attention',

--- a/src/external/modules/returns/lib/helpers.js
+++ b/src/external/modules/returns/lib/helpers.js
@@ -330,22 +330,6 @@ const isReturnId = (returnId) => {
 };
 
 /**
- * Get field suffix - this is the units used for this return
- * @param {String} unit - internal SI unit or gal
- * @return {String} suffix - human readable unit
- */
-const getSuffix = (unit) => {
-  const u = unit.replace('³', '3');
-  const units = {
-    m3: 'cubic metres',
-    l: 'litres',
-    gal: 'gallons',
-    Ml: 'megalitres'
-  };
-  return units[u];
-};
-
-/**
  * Gets badge object to render for return row
  * @param  {String}  status    - return status
  * @param  {Boolean} isPastDue - whether return is past due
@@ -380,6 +364,5 @@ exports.getViewData = getViewData;
 exports.isReturnPastDueDate = isReturnPastDueDate;
 exports.getRedirectPath = getRedirectPath;
 exports.isReturnId = isReturnId;
-exports.getSuffix = getSuffix;
 exports.getBadge = getBadge;
 exports.mapReturns = mapReturns;

--- a/src/internal/modules/abstraction-reform/lib/map-condition.js
+++ b/src/internal/modules/abstraction-reform/lib/map-condition.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const parse = require('csv-parse/lib/sync');
 const csvData = fs.readFileSync('./data/condition_titles.csv');
 const conditionTitles = parse(csvData, { columns: true });
+const { logger } = require('../../../logger');
 
 /**
  * Given a condition object returned from the water service API,
@@ -12,11 +13,18 @@ const conditionTitles = parse(csvData, { columns: true });
  */
 const mapConditionText = (condition) => {
   const query = pick(condition, ['code', 'subCode']);
-  const { displayTitle } = find(conditionTitles, query);
+  const conditionTitle = find(conditionTitles, query);
+
+  if (!conditionTitle) {
+    const message = 'Could not find condition title';
+    const error = new Error(message);
+    logger.error(message, error, condition);
+    throw error;
+  }
+
+  const { displayTitle } = conditionTitle;
   const id = condition.id.split('/').pop();
   return `${id}: ${displayTitle}`;
 };
 
-module.exports = {
-  mapConditionText
-};
+exports.mapConditionText = mapConditionText;

--- a/src/internal/modules/returns/lib/helpers.js
+++ b/src/internal/modules/returns/lib/helpers.js
@@ -327,22 +327,6 @@ const isReturnId = (returnId) => {
 };
 
 /**
- * Get field suffix - this is the units used for this return
- * @param {String} unit - internal SI unit or gal
- * @return {String} suffix - human readable unit
- */
-const getSuffix = (unit) => {
-  const u = unit.replace('³', '3');
-  const units = {
-    m3: 'cubic metres',
-    l: 'litres',
-    gal: 'gallons',
-    Ml: 'megalitres'
-  };
-  return units[u];
-};
-
-/**
  * Gets badge object to render for return row
  * @param  {String}  status    - return status
  * @param  {Boolean} isPastDue - whether return is past due
@@ -381,7 +365,6 @@ exports.getViewData = getViewData;
 exports.isReturnPastDueDate = isReturnPastDueDate;
 exports.getRedirectPath = getRedirectPath;
 exports.isReturnId = isReturnId;
-exports.getSuffix = getSuffix;
 exports.getBadge = getBadge;
 exports.mapReturns = mapReturns;
 exports.endReadingKey = endReadingKey;

--- a/src/shared/plugins/reset-password/controller.js
+++ b/src/shared/plugins/reset-password/controller.js
@@ -35,7 +35,7 @@ async function postResetPassword (request, h) {
   } catch (error) {
     // Note: we don't do anything differently as we don't wish to reveal if
     // account exists
-    request.log('error', 'Reset password error', { error });
+    request.log('debug', 'Reset password error', { error });
   }
   return h.redirect(request.config.redirect);
 }

--- a/test/external/modules/add-licences/controller.js
+++ b/test/external/modules/add-licences/controller.js
@@ -237,3 +237,42 @@ experiment('postFAO', () => {
       .to.be.true();
   });
 });
+
+experiment('ensureSessionDataPreHandler', () => {
+  let request;
+  let h;
+  let takeoverSpy;
+
+  beforeEach(async () => {
+    takeoverSpy = sinon.spy();
+    request = {
+      yar: {
+        get: sinon.stub().returns()
+      }
+    };
+
+    h = {
+      continue: Symbol('test-continue'),
+      redirect: sinon.stub().returns({
+        takeover: takeoverSpy
+      })
+    };
+  });
+
+  experiment('when the data is in session', () => {
+    test('continue is returned', async () => {
+      request.yar.get.returns({ test: true });
+      const result = controller.ensureSessionDataPreHandler(request, h);
+      expect(result).to.equal(h.continue);
+    });
+  });
+
+  experiment('when the data is not found in the session', () => {
+    test('the user is redirected to the add-licences page', async () => {
+      controller.ensureSessionDataPreHandler(request, h);
+      const [redirect] = h.redirect.lastCall.args;
+      expect(redirect).to.equal('/add-licences');
+      expect(takeoverSpy.called).to.be.true();
+    });
+  });
+});

--- a/test/external/modules/returns/lib/helpers.js
+++ b/test/external/modules/returns/lib/helpers.js
@@ -99,13 +99,6 @@ experiment('getLicenceReturns', () => {
   });
 });
 
-experiment('getSuffix', () => {
-  test('handles superscript', async () => {
-    expect(helpers.getSuffix('m³')).to.equal('cubic metres');
-    expect(helpers.getSuffix('m3')).to.equal('cubic metres');
-  });
-});
-
 experiment('getBadge', () => {
   test('If return is overdue, return overdue badge', async () => {
     expect(helpers.getBadge('due', true)).to.equal({

--- a/test/internal/modules/abstraction-reform/lib/map-condition.js
+++ b/test/internal/modules/abstraction-reform/lib/map-condition.js
@@ -5,9 +5,27 @@ const {
 } = require('internal/modules/abstraction-reform/lib/map-condition');
 const { expect } = require('@hapi/code');
 
-const { experiment, test } = exports.lab = require('@hapi/lab').script();
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
 
-experiment('Test mapConditionText', () => {
+const { logger } = require('internal/logger');
+
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+experiment('.mapConditionText', () => {
+  beforeEach(async () => {
+    sandbox.stub(logger, 'error');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
   test('It should generate text for a condition', async () => {
     const condition = {
       id: 'nald://conditions/6/123456',
@@ -16,5 +34,20 @@ experiment('Test mapConditionText', () => {
     };
     const text = mapConditionText(condition);
     expect(text).to.equal(`123456: Flow cessation condition`);
+  });
+
+  test('logs an error if the condition title is not found', async () => {
+    const condition = {
+      id: 'nald://conditions/6/123456',
+      code: 'NOT_A_REAL_CODE',
+      subCode: 'NOT_A_REAL_SUB_CODE'
+    };
+
+    expect(() => mapConditionText(condition)).to.throw();
+    const [message, error, params] = logger.error.lastCall.args;
+
+    expect(message).to.equal('Could not find condition title');
+    expect(error).to.be.an.error();
+    expect(params).to.equal(condition);
   });
 });

--- a/test/internal/modules/returns/lib/helpers.js
+++ b/test/internal/modules/returns/lib/helpers.js
@@ -93,13 +93,6 @@ experiment('getLicenceReturns', () => {
   });
 });
 
-experiment('getSuffix', () => {
-  test('handles superscript', async () => {
-    expect(helpers.getSuffix('m³')).to.equal('cubic metres');
-    expect(helpers.getSuffix('m3')).to.equal('cubic metres');
-  });
-});
-
 experiment('getBadge', () => {
   test('If return is overdue, return overdue badge', async () => {
     expect(helpers.getBadge('due', true)).to.equal({

--- a/test/shared/modules/returns/forms/common.js
+++ b/test/shared/modules/returns/forms/common.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { expect } = require('@hapi/code');
+const { experiment, test } = exports.lab = require('@hapi/lab').script();
+
+const helpers = require('shared/modules/returns/forms/common');
+
+experiment('shared/modules/returns/forms/common', () => {
+  experiment('.getSuffix', () => {
+    test('handles superscript', async () => {
+      expect(helpers.getSuffix('m³')).to.equal('cubic metres');
+      expect(helpers.getSuffix('m3')).to.equal('cubic metres');
+    });
+  });
+});

--- a/test/shared/plugins/reset-password/controller.js
+++ b/test/shared/plugins/reset-password/controller.js
@@ -155,7 +155,7 @@ experiment('reset password controller', () => {
 
       test('a message is logged with request.log', async () => {
         const [level, message, error] = request.log.lastCall.args;
-        expect(level).to.equal('error');
+        expect(level).to.equal('debug');
         expect(message).to.equal('Reset password error');
         expect(error).to.be.an.object();
       });


### PR DESCRIPTION
WATER-2212

Reduces the noise in the errbit logs.

1) Downgrade a incorrect email as part of the reset password from error
to debug.

2) Downgrade an add licence error to a info log (LicenceSimilarityError,

LicenceMissingError)
3) Handles cleared session in the add licence flow

Deals with the user pressing back or refresh at the end of the add
licence flow which would attempt to extract data from a null session.
Instead now the user is redirected back to the start of the flow.

4) Adds more logging for map condition error

Current logging does not supply enough information to diagnose this so
added more logging to the `mapCondition` function to aid a fix in the
future.