### PR TITLE
Chore: Add cookie message to Nunjucks pages

### DIFF
--- a/src/external/lib/hapi-plugins/index.js
+++ b/src/external/lib/hapi-plugins/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   config: require('shared/plugins/config'),
   csrf: require('shared/plugins/csrf'),
+  cookieMessage: require('shared/plugins/cookie-message'),
   metaRedirect: require('shared/plugins/meta-redirect'),
   redirect: require('shared/plugins/redirect'),
   secureHeaders: require('shared/plugins/secure-headers'),

--- a/src/external/lib/view.js
+++ b/src/external/lib/view.js
@@ -74,6 +74,7 @@ function viewContextDefaults (request) {
   viewContext.mainNavLinks = getMainNav(request);
   viewContext.propositionLinks = getPropositionLinks(request);
 
+  viewContext.showCookieMessage = !(request.state.seen_cookie_message === 'yes');
   viewContext.user = request.auth.credentials;
 
   viewContext.tracking = getTracking(request.defra);

--- a/src/external/views/nunjucks/layout.njk
+++ b/src/external/views/nunjucks/layout.njk
@@ -28,6 +28,12 @@
 {% endblock %}
 
 {% block header %}
+  {% if showCookieMessage %}
+    <div id="cookie-message">
+      GOV.UK use cookies to make the site simpler. <a href="/cookies">Find out more about cookies.</a>
+    </div>
+  {% endif %}
+
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",

--- a/src/external/views/nunjucks/layout.njk
+++ b/src/external/views/nunjucks/layout.njk
@@ -29,7 +29,7 @@
 
 {% block header %}
   {% if showCookieMessage %}
-    <div id="cookie-message">
+    <div class="cookie-message">
       GOV.UK use cookies to make the site simpler. <a href="/cookies">Find out more about cookies.</a>
     </div>
   {% endif %}

--- a/src/internal/lib/hapi-plugins/index.js
+++ b/src/internal/lib/hapi-plugins/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   config: require('shared/plugins/config'),
   csrf: require('shared/plugins/csrf'),
+  cookieMessage: require('shared/plugins/cookie-message'),
   metaRedirect: require('shared/plugins/meta-redirect'),
   redirect: require('shared/plugins/redirect'),
   secureHeaders: require('shared/plugins/secure-headers'),

--- a/src/internal/lib/view.js
+++ b/src/internal/lib/view.js
@@ -71,6 +71,7 @@ function viewContextDefaults (request) {
   viewContext.mainNavLinks = getMainNav(request);
   viewContext.propositionLinks = getPropositionLinks(request);
 
+  viewContext.showCookieMessage = !(request.state.seen_cookie_message === 'yes');
   viewContext.user = request.auth.credentials;
 
   viewContext.tracking = getTracking(request.defra);

--- a/src/internal/views/nunjucks/layout.njk
+++ b/src/internal/views/nunjucks/layout.njk
@@ -29,11 +29,11 @@
 
 {% block header %}
   {% if showCookieMessage %}
-    <div id="cookie-message">
+    <div class="cookie-message">
       GOV.UK use cookies to make the site simpler. <a href="/cookies">Find out more about cookies.</a>
     </div>
   {% endif %}
-  
+
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",

--- a/src/internal/views/nunjucks/layout.njk
+++ b/src/internal/views/nunjucks/layout.njk
@@ -28,6 +28,12 @@
 {% endblock %}
 
 {% block header %}
+  {% if showCookieMessage %}
+    <div id="cookie-message">
+      GOV.UK use cookies to make the site simpler. <a href="/cookies">Find out more about cookies.</a>
+    </div>
+  {% endif %}
+  
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",

--- a/src/shared/assets/sass/v2/application.scss
+++ b/src/shared/assets/sass/v2/application.scss
@@ -8,6 +8,7 @@ $govuk-global-styles: true;
 @import "blocks/alert";
 @import "blocks/badge";
 @import "blocks/company-switcher";
+@import "blocks/cookie-message";
 @import "blocks/data-row";
 @import "blocks/flex";
 @import "blocks/input";

--- a/src/shared/assets/sass/v2/blocks/_cookie-message.scss
+++ b/src/shared/assets/sass/v2/blocks/_cookie-message.scss
@@ -1,4 +1,4 @@
-#cookie-message {
+.cookie-message {
   width: 100%;
   background-color: #d5e8f3;
   padding-top: 10px;

--- a/src/shared/assets/sass/v2/blocks/_cookie-message.scss
+++ b/src/shared/assets/sass/v2/blocks/_cookie-message.scss
@@ -1,0 +1,7 @@
+#cookie-message {
+  width: 100%;
+  background-color: #d5e8f3;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-family: "nta", Arial, sans-serif;
+}

--- a/src/shared/plugins/cookie-message/index.js
+++ b/src/shared/plugins/cookie-message/index.js
@@ -1,0 +1,42 @@
+/**
+ * HAPI Cookie Message plugin
+ *
+ * Checks whether the 'seen_cookie_message' cookie exists and has a value of 'yes',
+ * Otherwise, creates/set the value to 'yes'
+ *
+ * @module lib/hapi-plugins/cookie-message
+ */
+
+const setCookie = (request, h) => {
+  var cookieOptions = {
+    ttl: 28 * 24 * 60 * 60 * 1000, // expires in 28 days
+    isSecure: false,
+    isHttpOnly: false
+  };
+
+  h.state('seen_cookie_message', 'yes', cookieOptions);
+
+  return h.continue;
+};
+
+const _handler = async (request, h) => {
+  const { seen_cookie_message: seenCookieMessage } = request.state;
+  return (seenCookieMessage === 'yes') ? h.continue : setCookie(request, h);
+};
+
+const cookieMessagePlugin = {
+  register: (server, options) => {
+    server.ext({
+      type: 'onPreHandler',
+      method: _handler
+    });
+  },
+
+  pkg: {
+    name: 'cookieMessagePlugin',
+    version: '1.0.0'
+  }
+};
+
+module.exports = cookieMessagePlugin;
+module.exports._handler = _handler;

--- a/test/external/lib/hapi-plugins/error.js
+++ b/test/external/lib/hapi-plugins/error.js
@@ -26,6 +26,9 @@ const createRequest = (error = {}) => {
     },
     cookieAuth: {
       clear: sandbox.stub()
+    },
+    state: {
+      seen_cookie_message: 'yes'
     }
   };
 };

--- a/test/external/lib/view.js
+++ b/test/external/lib/view.js
@@ -51,6 +51,19 @@ experiment('lib/view.contextDefaults', () => {
     const viewContext = view.contextDefaults(request);
     expect(viewContext.surveyType).to.equal('external');
   });
+
+  test('showCookieMessage is true when the seen_cookie_message is not set', async () => {
+    const request = getBaseRequest();
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.showCookieMessage).to.be.true();
+  });
+
+  test('showCookieMessage is false when the seen_cookie_message is set to "yes"', async () => {
+    const request = getBaseRequest();
+    set(request, 'state.seen_cookie_message', 'yes');
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.showCookieMessage).to.be.false();
+  });
 });
 
 experiment('lib/view.getTracking', () => {

--- a/test/internal/lib/hapi-plugins/error.js
+++ b/test/internal/lib/hapi-plugins/error.js
@@ -27,6 +27,9 @@ const createRequest = (error = {}) => {
     cookieAuth: {
       clear: sandbox.stub()
     },
+    state: {
+      seen_cookie_message: 'yes'
+    },
     logOut: sandbox.stub()
   };
 };

--- a/test/internal/lib/view.js
+++ b/test/internal/lib/view.js
@@ -51,6 +51,19 @@ experiment('lib/view.contextDefaults', () => {
     const viewContext = view.contextDefaults(request);
     expect(viewContext.surveyType).to.equal('internal');
   });
+
+  test('showCookieMessage is true when the seen_cookie_message is not set', async () => {
+    const request = getBaseRequest();
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.showCookieMessage).to.be.true();
+  });
+
+  test('showCookieMessage is false when the seen_cookie_message is set to "yes"', async () => {
+    const request = getBaseRequest();
+    set(request, 'state.seen_cookie_message', 'yes');
+    const viewContext = view.contextDefaults(request);
+    expect(viewContext.showCookieMessage).to.be.false();
+  });
 });
 
 experiment('lib/view.getTracking', () => {

--- a/test/shared/plugins/cookie-message/index.js
+++ b/test/shared/plugins/cookie-message/index.js
@@ -1,0 +1,95 @@
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sandbox = require('sinon').createSandbox();
+const plugin = require('shared/plugins/cookie-message');
+
+const createRequest = seenCookieMessage => {
+  return {
+    state: {
+      seen_cookie_message: seenCookieMessage
+    }
+  };
+};
+
+const h = {
+  state: sandbox.stub(),
+  continue: sandbox.stub()
+};
+
+experiment('plugins/cookie-message/index', () => {
+  let server;
+  beforeEach(async () => {
+    server = {
+      ext: sandbox.stub()
+    };
+  });
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  test('includes package name and version', async () => {
+    expect(plugin.pkg).to.equal({
+      name: 'cookieMessagePlugin',
+      version: '1.0.0'
+    });
+  });
+
+  test('has a register function', async () => {
+    expect(plugin.register).to.be.a.function();
+  });
+
+  test('register function binds the onPreHandler', async () => {
+    plugin.register(server, {});
+    expect(
+      server.ext.calledWith({
+        type: 'onPreHandler',
+        method: plugin._handler
+      })
+    ).to.equal(true);
+  });
+
+  experiment('._handler', () => {
+    afterEach(async () => {
+      sandbox.restore();
+    });
+    experiment('when seen_cookie_message === "yes"', () => {
+      const request = createRequest('yes');
+
+      test('does not call h.state', async () => {
+        plugin._handler(request, h);
+        expect(h.state.callCount).to.equal(0);
+      });
+
+      test('returns h.continue', async () => {
+        const request = createRequest('yxes');
+        const response = await plugin._handler(request, h);
+        expect(response).to.equal(h.continue);
+      });
+    });
+
+    experiment('when seen_cookie_message !== "yes"', () => {
+      const request = createRequest();
+
+      test('calls h.state with expected arguments', async () => {
+        const options = {
+          ttl: 28 * 24 * 60 * 60 * 1000, // expires in 28 days
+          isSecure: false,
+          isHttpOnly: false
+        };
+
+        plugin._handler(request, h);
+        expect(h.state.calledWith(
+          'seen_cookie_message',
+          'yes',
+          options
+        )).to.be.true();
+      });
+
+      test('returns h.continue', async () => {
+        const request = createRequest('yxes');
+        const response = await plugin._handler(request, h);
+        expect(response).to.equal(h.continue);
+      });
+    });
+  });
+});


### PR DESCRIPTION
WATER-2233

Build cookie-message plugin to check for and add 'seen_cookie_message' cookie. Add seenCookieMessage to view context. Add cookie message to Nunjucks layouts.