### PR TITLE
Fix: Allow submission of expired licence returns

### DIFF
--- a/server-external.js
+++ b/server-external.js
@@ -54,7 +54,8 @@ async function start () {
       plugin: require('shared/plugins/returns'),
       options: {
         getDocumentHeader: connectors.crm.documents.getWaterLicence.bind(connectors.crm.documents),
-        checkAccess: true
+        checkAccess: true,
+        includeExpired: false
       }
     }, {
       plugin: require('shared/plugins/licence-data'),

--- a/server-internal.js
+++ b/server-internal.js
@@ -40,7 +40,8 @@ const pluginsArray = [
     plugin: require('shared/plugins/returns'),
     options: {
       getDocumentHeader: connectors.crm.documents.getWaterLicence.bind(connectors.crm.documents),
-      checkAccess: false
+      checkAccess: false,
+      includeExpired: true
     }
   }, {
     plugin: require('shared/plugins/licence-data'),

--- a/src/shared/plugins/returns/index.js
+++ b/src/shared/plugins/returns/index.js
@@ -35,15 +35,15 @@ const checkAccess = (request, documentHeader) => {
  */
 const preHandler = async (request, h) => {
   const { returnId } = request.query;
+  const licenceNumber = returnId.split(':')[2];
+  const { pluginOptions } = h.realm;
 
-  const [, , licenceNumber] = returnId.split(':');
-
-  const documentHeader = await h.realm.pluginOptions.getDocumentHeader(licenceNumber);
+  const documentHeader = await pluginOptions.getDocumentHeader(licenceNumber, pluginOptions.includeExpired);
   if (!documentHeader) {
     throw Boom.notFound(`Licence ${licenceNumber} not found in CRM`);
   }
 
-  if (h.realm.pluginOptions.checkAccess) {
+  if (pluginOptions.checkAccess) {
     checkAccess(request, documentHeader);
   }
 
@@ -62,7 +62,8 @@ const returnsPlugin = {
   register: (server, options) => {
     Joi.assert(options, {
       getDocumentHeader: Joi.func().required(),
-      checkAccess: Joi.boolean().required()
+      checkAccess: Joi.boolean().required(),
+      includeExpired: Joi.boolean().default(false)
     });
 
     server.ext({


### PR DESCRIPTION
WATER-2320

Allows an internal users to submit returns against expired licences