### PR TITLE
Chore: Proxy payload to acceptance tests routes

### DIFF
--- a/src/external/lib/hapi-plugins/index.js
+++ b/src/external/lib/hapi-plugins/index.js
@@ -29,7 +29,7 @@ module.exports = {
   acceptanceTestsProxy: {
     plugin: require('shared/plugins/acceptance-tests-proxy'),
     options: {
-      postToPath: path => services.water.acceptanceTests.postToPath(path)
+      postToPath: (path, payload) => services.water.acceptanceTests.postToPath(path, payload)
     }
   }
 };

--- a/src/shared/lib/connectors/services/water/AcceptanceTestsService.js
+++ b/src/shared/lib/connectors/services/water/AcceptanceTestsService.js
@@ -1,9 +1,9 @@
 const ServiceClient = require('../ServiceClient');
 
 class AcceptanceTestsService extends ServiceClient {
-  async postToPath (path) {
+  async postToPath (path, payload) {
     const url = this.joinUrl('acceptance-tests', path);
-    const result = await this.serviceRequest.post(url);
+    const result = await this.serviceRequest.post(url, { body: payload });
     return result;
   };
 }

--- a/src/shared/plugins/acceptance-tests-proxy/controller.js
+++ b/src/shared/plugins/acceptance-tests-proxy/controller.js
@@ -6,7 +6,7 @@
  */
 const proxyToWaterService = request => {
   const { postToPath } = request.route.realm.pluginOptions;
-  return postToPath(request.params.tail);
+  return postToPath(request.params.tail, request.payload);
 };
 
 exports.proxyToWaterService = proxyToWaterService;


### PR DESCRIPTION
WATER-2230

Allow the payload of a request to be proxied through to the water
service to allow the caller to request specific data creation.