### PR TITLE
Rename a licence text improved for screen readers following feedback from QA

### DIFF
--- a/src/external/modules/view-licences/forms/rename.js
+++ b/src/external/modules/view-licences/forms/rename.js
@@ -4,16 +4,16 @@ const { formFactory, fields } = require('../../../../shared/lib/forms');
 const createNameField = (name) => {
   return fields.text('name', {
     label: 'Licence name',
-    hint: 'You can give this licence a name to help you find it more easily. Choose a name that is 2-32 characters long.',
+    hint: 'You can give this licence a name to help you find it more easily. Choose a name that is between 2 and 32 characters long.',
     errors: {
       'any.empty': {
         message: 'Enter a licence name'
       },
       'string.min': {
-        message: 'Choose a name that is 2-32 characters long'
+        message: 'Choose a name that is between 2 and 32 characters long'
       },
       'string.max': {
-        message: 'Choose a name that is 2-32 characters long'
+        message: 'Choose a name that is between 2 and 32 characters long'
       }
     },
     controlClass: 'govuk-input--width-20'

--- a/src/shared/lib/view-licence-helpers.js
+++ b/src/shared/lib/view-licence-helpers.js
@@ -18,7 +18,7 @@ const getCommonBackLink = request => {
   const { licenceNumber } = request.licence.summary;
   return {
     back: `/licences/${documentId}`,
-    backText: `Licence number ${licenceNumber}`
+    backText: `Back`
   };
 };
 

--- a/src/shared/lib/view-licence-helpers.js
+++ b/src/shared/lib/view-licence-helpers.js
@@ -14,8 +14,7 @@ const getCommonViewContext = request => {
 };
 
 const getCommonBackLink = request => {
-  const { documentId } = request.params;
-  const { licenceNumber } = request.licence.summary;
+  const { documentId } = request.params;  
   return {
     back: `/licences/${documentId}`,
     backText: `Back`

--- a/test/external/modules/view-licences/forms/rename.js
+++ b/test/external/modules/view-licences/forms/rename.js
@@ -35,7 +35,7 @@ experiment('view licences rename form', () => {
     const input = form.fields.find(x => x.name === 'name');
     expect(input.options.widget).to.equal('text');
     expect(input.options.label).to.equal('Licence name');
-    expect(input.options.hint).to.equal('You can give this licence a name to help you find it more easily. Choose a name that is 2-32 characters long.');
+    expect(input.options.hint).to.equal('You can give this licence a name to help you find it more easily. Choose a name that is between 2 and 32 characters long.');
   });
 
   test('has a save button', async () => {


### PR DESCRIPTION
Feat/water 2330
-- text updated on the rename page for further clarity when using a screen reader
-- back link text for all subsidiary view licence details now fixed for all the pages