### PR TITLE
Fix: Remove call to logger.error

### DIFF
--- a/src/shared/lib/logger-factory.js
+++ b/src/shared/lib/logger-factory.js
@@ -9,7 +9,6 @@ const create = config => {
     const requestDetails = pick(request, ['method', 'params', 'query', 'payload', 'url']);
     const paramsToLog = Object.assign(params, userJourney, { requestDetails });
 
-    logger.error('Request details for error', JSON.stringify(requestDetails));
     logger.error(msg, error, paramsToLog);
   };
 


### PR DESCRIPTION
Removes a redundant call to logger.error that will not work due to the
position of the string in the arguments.