### PR TITLE
Fix spelling / sentence case of 'Cubic metres' heading

### DIFF
--- a/src/shared/view/nunjucks/macros/returns/return-quantities-table.njk
+++ b/src/shared/view/nunjucks/macros/returns/return-quantities-table.njk
@@ -20,7 +20,7 @@
         {% if return.reading.units == 'm³' %}Cubic metres{%endif%}
       </th>
       {% if return.reading.units != 'm³' %}
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Cubic Meters</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Cubic metres</th>
       {%endif%}
     </tr>
   </thead>


### PR DESCRIPTION
Fix spelling / sentence case of 'Cubic metres' heading in return quantities macro