### PR TITLE
Feat: Batch summary view

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -142,12 +142,13 @@ const getBillingBatchSummary = async (request, h) => {
     pageTitle: pageTitle,
     batch: {
       batchId: request.params.batchId,
-      billRunTotal: 12345.67,
-      invoices: { count: 12, total: 12345.67 + 987.65 },
+      billRunTotal: 12445.78,
+      invoices: { count: 12, total: 12445.78 + 987.65 },
       creditNotes: { count: 1, total: 987.65 },
       charges: [
         { account: 123, contact: 'Mr A Parson', licences: [ { licenceRef: '111' }, { licenceRef: '111/1' } ], total: 1234.56, isCredit: false },
-        { account: 1234, contact: 'Mrs B Darson', licences: [ { licenceRef: '222' }, { licenceRef: '222/1' } ], total: 1333.56, isCredit: true }
+        { account: 1234, contact: 'Mrs B Darson', licences: [ { licenceRef: '222' }, { licenceRef: '222/1' } ], total: 1333.56, isCredit: true },
+        { account: 1234, contact: 'Ms A Farson', licences: [ { licenceRef: '11' }, { licenceRef: '22' }, { licenceRef: '33' }, { licenceRef: '44' }, { licenceRef: '55' } ], total: 100.11, isCredit: false }
       ]
     }
   });

--- a/src/internal/views/nunjucks/billing/batch-summary.njk
+++ b/src/internal/views/nunjucks/billing/batch-summary.njk
@@ -2,6 +2,26 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "./nunjucks/billing/macros/totals.njk" import billRunTotal, invoicesTotal, creditNoteTotal %}
 
+{% macro batchLicenceNumbers(licences) %}
+  {% if licences.length > 4 %}
+    <p class="govuk-body govuk-!-margin-bottom-1">{{ licences.length }} licences</p>
+    <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">View licences</span>
+      </summary>
+      <div class="govuk-details__text">
+        {% for licence in licences %}
+          <div>{{ licence.licenceRef }}</div>
+        {% endfor %}
+      </div>
+    </details>
+  {% else %}
+    {% for licence in licences %}
+      <div>{{ licence.licenceRef }}</div>
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -71,9 +91,7 @@
                 </th>
                 <td class="govuk-table__cell">{{ charge.contact }}</td>
                 <td class="govuk-table__cell">
-                  {% for licence in charge.licences %}
-                    <div>{{ licence.licenceRef }}</div>
-                  {% endfor %}
+                  {{ batchLicenceNumbers(charge.licences) }}
                 </td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">
                   <span>£{{ charge.total | number}}</span>


### PR DESCRIPTION
WATER-2435

Adds another test row to the stubbed billing summary screen with an
account that has 5 licences. The licences are then hidden in a details
component as required in the story.

The text and presentation of the licences has not been clarified yet but
can easily be changed.