### PR TITLE
Feat: Back link on batch summary from list

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -135,6 +135,7 @@ const getBillingBatchSummary = async (request, h) => {
   // get the event date for the bill run date
   const billRunDate = moment();
   const pageTitle = 'Anglian supplementary bill run';
+  const { referer = '' } = request.headers;
 
   return h.view('nunjucks/billing/batch-summary', {
     ...request.view,
@@ -149,7 +150,11 @@ const getBillingBatchSummary = async (request, h) => {
         { account: 123, contact: 'Mr A Parson', licences: [ { licenceRef: '111' }, { licenceRef: '111/1' } ], total: 1234.56, isCredit: false },
         { account: 1234, contact: 'Mrs B Darson', licences: [ { licenceRef: '222' }, { licenceRef: '222/1' } ], total: 1333.56, isCredit: true }
       ]
-    }
+    },
+
+    // only show the back link from the list page, so not to offer the link
+    // as part of the batch creation flow.
+    back: referer.endsWith('/billing/batch/list') ? referer : false
   });
 };
 

--- a/test/internal/modules/billing/controller.js
+++ b/test/internal/modules/billing/controller.js
@@ -54,6 +54,7 @@ experiment('internal/modules/billing/controller', () => {
         params: {
           batchId: 'test-batch-id'
         },
+        headers: {},
         payload: {
           csrf_token: 'bfc56166-e983-4f01-90fe-f70c191017ca'
         },
@@ -298,6 +299,38 @@ experiment('internal/modules/billing/controller', () => {
     test('configures the expected view template', async () => {
       const [view] = h.view.lastCall.args;
       expect(view).to.equal('nunjucks/billing/batch-list');
+    });
+  });
+
+  experiment('.getBillingBatchSummary', () => {
+    test('does not include the back link if previous page was not /billing/batch/list', async () => {
+      const request = {
+        headers: {
+          referer: 'https://example.com/no/back/link/here/please'
+        },
+        params: {
+          batchId: 'test-batch'
+        }
+      };
+
+      await controller.getBillingBatchSummary(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.back).to.be.false();
+    });
+
+    test('includes the back link if previous page was /billing/batch/list', async () => {
+      const request = {
+        headers: {
+          referer: 'https://example.com/billing/batch/list'
+        },
+        params: {
+          batchId: 'test-batch'
+        }
+      };
+
+      await controller.getBillingBatchSummary(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.back).to.equal('https://example.com/billing/batch/list');
     });
   });
 });


### PR DESCRIPTION
WATER-2435

Missing requirement for an earlier story, this adds the back link to the
batch summary, if the user was previously on the batch list page.

Therefore not shown as part of the batch creation flow, because this
would sent the user back to the region selection page which is turn
could cause an error because two batches are not allowed to be
generated per region at a time.