### PR TITLE
Feat: Pass internal user id on outbound requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,33 +80,20 @@
       }
     },
     "@envage/water-abstraction-helpers": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-3.6.0.tgz",
-      "integrity": "sha512-bGDmwMShiJlw2pPcokkbYuCxiVOS/MDOSa1Flxb0L+WKYG5TXXv9c9hzbrMGtv6705BgwcO2INYd58yeM2zOJA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@envage/water-abstraction-helpers/-/water-abstraction-helpers-4.2.0.tgz",
+      "integrity": "sha512-0p0UOW1Qm72tXQs5kLDPv4Id5KnVA85o2aiXjj8bGXk5uL8wh3dYvNmBgR8OqfS9cCyGyOXtmMz23VlwOn8NIw==",
       "requires": {
-        "airbrake-js": "^1.6.4",
+        "@hapi/joi": "^15.1.1",
+        "airbrake-js": "^1.6.8",
         "cross-fetch": "^3.0.4",
+        "https-proxy-agent": "^2.2.4",
         "lodash": "^4.17.15",
         "moment": "^2.24.0",
         "moment-range": "^4.0.2",
         "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
+        "request-promise-native": "^1.0.8",
         "winston": "^2.4.4"
-      },
-      "dependencies": {
-        "winston": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-          "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
-          "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
-          }
-        }
       }
     },
     "@gulp-sourcemaps/identity-map": {
@@ -1252,7 +1239,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -2427,6 +2413,11 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -3013,13 +3004,6 @@
       "requires": {
         "node-fetch": "2.6.0",
         "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        }
       }
     },
     "cross-spawn": {
@@ -3599,14 +3583,12 @@
     "es6-promise": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
-      "dev": true
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -6132,7 +6114,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
       "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -6142,7 +6123,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6150,8 +6130,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -7702,8 +7681,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -8245,6 +8223,11 @@
         }
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -8427,6 +8410,78 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pg": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.1.tgz",
+      "integrity": "sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
+      }
+    },
+    "pg-boss": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-boss/-/pg-boss-3.2.2.tgz",
+      "integrity": "sha512-UL/F7coW1gtXNb/WzwqQ3Bv1wMsSH2oSpeAB9zCJ4RHZXZ0f6JNDMcUZPeXIyZdEIq3GjcqwYtJy4F/Z45pufQ==",
+      "requires": {
+        "bluebird": "^3.5.2",
+        "pg": "^7.12.0",
+        "uuid": "^3.2.1"
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
+    "pg-pool": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8497,6 +8552,29 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "preact": {
       "version": "8.4.2",
@@ -10564,6 +10642,14 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10962,8 +11048,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.3",
@@ -11829,8 +11914,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "https://github.com/DEFRA/hapi-pg-rest-api/archive/v4.3.0.tar.gz",
-    "@envage/water-abstraction-helpers": "^3.6.0",
+    "@envage/water-abstraction-helpers": "^4.2.0",
     "@hapi/boom": "^7.4.2",
     "@hapi/good": "^8.2.4",
     "@hapi/hapi": "^18.4.0",
@@ -93,6 +93,8 @@
     "moment-timezone": "^0.5.27",
     "nunjucks": "^3.2.0",
     "path": "^0.12.7",
+    "pg": "^7.18.1",
+    "pg-boss": "^3.2.2",
     "pluralize": "^7.0.0",
     "randomatic": "^3.1.1",
     "read-chunk": "^3.2.0",

--- a/src/internal/lib/hapi-plugins/index.js
+++ b/src/internal/lib/hapi-plugins/index.js
@@ -17,5 +17,6 @@ module.exports = {
   staticAssets: require('shared/plugins/static-assets'),
   anonGoogleAnalytics: require('shared/plugins/anon-google-analytics'),
   acceptanceTestsProxy: require('shared/plugins/acceptance-tests-proxy'),
-  csp: require('shared/plugins/csp')
+  csp: require('shared/plugins/csp'),
+  internalUserId: require('./internal-user-id')
 };

--- a/src/internal/lib/hapi-plugins/internal-user-id.js
+++ b/src/internal/lib/hapi-plugins/internal-user-id.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { get, set } = require('lodash');
+const { http } = require('@envage/water-abstraction-helpers');
+
+const getUserFromRequest = request => get(request, 'defra.user');
+
+/**
+ * Plugin that adds the currently logged in user id
+ * to the defra-internal-user-id header of an outgoing
+ * request.
+ */
+const internalUserId = {
+  register: server => {
+    server.ext({
+      type: 'onPreHandler',
+      method: async (request, h) => {
+        const user = getUserFromRequest(request);
+
+        if (user) {
+          http.onPreRequest(options => {
+            set(options, ['headers', 'defra-internal-user-id'], user.user_id);
+          });
+        }
+        return h.continue;
+      }
+    });
+
+    server.ext({
+      type: 'onPostHandler',
+      method: async (request, h) => {
+        const user = getUserFromRequest(request);
+
+        if (user) {
+          http.removePreRequestListener();
+        }
+        return h.continue;
+      }
+    });
+  },
+
+  pkg: {
+    name: 'internalUserId',
+    version: '1.0.0'
+  }
+};
+
+module.exports = internalUserId;

--- a/test/internal/lib/hapi-plugins/internal-user-id.js
+++ b/test/internal/lib/hapi-plugins/internal-user-id.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach,
+  afterEach
+} = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const { http } = require('@envage/water-abstraction-helpers');
+const plugin = require('../../../../src/internal/lib/hapi-plugins/internal-user-id');
+
+experiment('internal/lib/hapi-plugins/internal-user-id', () => {
+  let onPreHandler;
+  let onPostHandler;
+  let h;
+
+  beforeEach(async () => {
+    sandbox.stub(http, 'onPreRequest');
+    sandbox.stub(http, 'removePreRequestListener');
+
+    h = {
+      continue: Symbol('continue')
+    };
+
+    const server = {
+      ext: sandbox.spy()
+    };
+
+    await plugin.register(server);
+
+    onPreHandler = server.ext.firstCall.args[0].method;
+    onPostHandler = server.ext.secondCall.args[0].method;
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  experiment('onPreHandler', () => {
+    experiment('when the user is not on the request', () => {
+      let result;
+
+      beforeEach(async () => {
+        const request = {};
+        result = await onPreHandler(request, h);
+      });
+
+      test('the http.onPreRequest listener is not setup', async () => {
+        expect(http.onPreRequest.called).to.be.false();
+      });
+
+      test('the handler continues', async () => {
+        expect(result).to.equal(h.continue);
+      });
+    });
+
+    experiment('when the user is on the request', () => {
+      let result;
+
+      beforeEach(async () => {
+        const request = {
+          defra: {
+            user: {
+              user_id: 'test-user-id'
+            }
+          }
+        };
+        result = await onPreHandler(request, h);
+      });
+
+      test('the http.onPreRequest listener is setup', async () => {
+        expect(http.onPreRequest.called).to.be.true();
+      });
+
+      test('the listeners updates the headers to include the user id', async () => {
+        const [handler] = http.onPreRequest.lastCall.args;
+        const options = {};
+        handler(options);
+
+        expect(options.headers['defra-internal-user-id']).to.equal('test-user-id');
+      });
+
+      test('the handler continues', async () => {
+        expect(result).to.equal(h.continue);
+      });
+    });
+  });
+
+  experiment('onPostHandler', () => {
+    experiment('when the user is not on the request', () => {
+      let result;
+
+      beforeEach(async () => {
+        const request = {};
+        result = await onPostHandler(request, h);
+      });
+
+      test('the onPreRequest listener is not removed', async () => {
+        expect(http.removePreRequestListener.called).to.be.false();
+      });
+
+      test('the handler continues', async () => {
+        expect(result).to.equal(h.continue);
+      });
+    });
+
+    experiment('when the user is on the request', () => {
+      let result;
+
+      beforeEach(async () => {
+        const request = {
+          defra: {
+            user: {
+              user_id: 'test-user-id'
+            }
+          }
+        };
+        result = await onPostHandler(request, h);
+      });
+
+      test('the onPreRequest listener is removed', async () => {
+        expect(http.removePreRequestListener.called).to.be.true();
+      });
+
+      test('the handler continues', async () => {
+        expect(result).to.equal(h.continue);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds a plugin that will update the request headers of outbound requests
handled by the `http` object from water-abstraction-helpers.