### PR TITLE
Fix: Ensure 404 page title is correct

### DIFF
--- a/src/external/modules/core/controller.js
+++ b/src/external/modules/core/controller.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { withQueryStringSubset } = require('../../lib/url');
 
 /**

--- a/src/external/views/nunjucks/errors/404.njk
+++ b/src/external/views/nunjucks/errors/404.njk
@@ -6,10 +6,12 @@
   <p>Please check that the web address is correct, or you can:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    {% if user %}
-      <li class=""><a href="/licences">view</a> your licences</li>
-    {% else %}
-      <li><a href="/signin">sign in</a> to manage your water abstraction or impoundment licences</li>
-    {% endif %}
+    <li>
+      {% if user %}
+        <a href="/licences">view</a> your licences
+      {% else %}
+        <a href="/signin">sign in</a> to manage your water abstraction or impoundment licences
+      {% endif %}
+    </li>
   </ul>
 {% endblock %}

--- a/src/internal/views/nunjucks/errors/404.njk
+++ b/src/internal/views/nunjucks/errors/404.njk
@@ -1,17 +1,17 @@
 {% extends "./nunjucks/layout.njk" %}
 
-
-
 {% block content %}
   {{ title(pageTitle) }}
 
   <p>Please check that the web address is correct, or you can:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    {% if user %}
-      <li class=""><a href="/licences">view</a> licences</li>
-    {% else %}
-      <li><a href="/signin">sign in</a> to manage your water abstraction or impoundment licences</li>
-    {% endif %}
+    <li>
+      {% if user %}
+        <a href="/licences">view</a> licences
+      {% else %}
+        <a href="/signin">sign in</a> to manage your water abstraction or impoundment licences
+      {% endif %}
+    </li>
   </ul>
 {% endblock %}

--- a/test/shared/plugins/error/index.js
+++ b/test/shared/plugins/error/index.js
@@ -1,19 +1,18 @@
-const sinon = require('sinon');
+'use strict';
+
 const { set } = require('lodash');
 const { expect } = require('@hapi/code');
 const { beforeEach, experiment, test, afterEach } = exports.lab = require('@hapi/lab').script();
 const Boom = require('@hapi/boom');
 
-const sandbox = sinon.createSandbox();
+const sandbox = require('sinon').createSandbox();
 
 const plugin = require('shared/plugins/error');
 
 const createRequest = (error = {}) => {
   return {
     auth: {
-      credentials: {
-
-      }
+      credentials: {}
     },
     url: {
       path: '/some/path'
@@ -33,7 +32,7 @@ const createRequest = (error = {}) => {
   };
 };
 
-experiment('errors plugin', () => {
+experiment('shared/plugins/error', () => {
   let server, h, code;
 
   beforeEach(async () => {
@@ -104,8 +103,9 @@ experiment('errors plugin', () => {
       await plugin._handler(request, h);
 
       expect(h.view.callCount).to.equal(1);
-      const [template] = h.view.lastCall.args;
+      const [template, view] = h.view.lastCall.args;
       expect(template).to.equal('nunjucks/errors/404');
+      expect(view.pageTitle).to.equal('We cannot find that page');
       expect(h.realm.pluginOptions.logger.errorWithJourney.callCount).to.equal(1);
     });
 
@@ -114,8 +114,9 @@ experiment('errors plugin', () => {
       await plugin._handler(request, h);
 
       expect(h.view.callCount).to.equal(1);
-      const [ template ] = h.view.lastCall.args;
+      const [template, view] = h.view.lastCall.args;
       expect(template).to.equal('nunjucks/errors/error');
+      expect(view.pageTitle).to.equal('Something went wrong');
       expect(h.realm.pluginOptions.logger.errorWithJourney.callCount).to.equal(1);
     });
   });

--- a/test/shared/plugins/update-password/controller.js
+++ b/test/shared/plugins/update-password/controller.js
@@ -55,7 +55,6 @@ experiment('update password controller', () => {
       });
 
       test('the user is redirected to a success page', async () => {
-        console.log(h.redirect.lastCall.lastArg);
         const template = h.redirect.lastCall.lastArg;
         expect(template).to.equal('/account/update-password/success');
       });


### PR DESCRIPTION
WATER-2520

Fixes an issue in the shared error plugin where the 404 page title was
being set to the same text as if a server error had occurred.