### PR TITLE
Billing list page issues

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -229,6 +229,11 @@ const badge = {
 
 const getBatchType = (type) => type === 'two_part_tariff' ? 'Two-part tariff' : sentenceCase(type);
 
+const mapBatchLink = batch =>
+  ['processing', 'ready'].includes(batch.status)
+    ? `/billing/batch/${batch.id}/summary`
+    : null;
+
 /**
  * Maps a batch for the batch list view, adding the badge, batch type and
  * bill count
@@ -239,7 +244,8 @@ const mapBatchListRow = batch => ({
   ...batch,
   badge: badge[batch.status],
   batchType: getBatchType(batch.type),
-  billCount: batch.externalId ? batch.totals.invoiceCount + batch.totals.creditNoteCount : null
+  billCount: batch.externalId ? batch.totals.invoiceCount + batch.totals.creditNoteCount : null,
+  link: mapBatchLink(batch)
 });
 
 const getBillingBatchList = async (request, h) => {

--- a/src/internal/modules/billing/pre-handlers.js
+++ b/src/internal/modules/billing/pre-handlers.js
@@ -22,7 +22,7 @@ const redirectToWaitingIfEventNotComplete = async (request, h) => {
 
   return (event.status === 'complete')
     ? h.continue
-    : h.redirect(`/waiting/${event.event_id}`);
+    : h.redirect(`/waiting/${event.event_id}`).takeover();
 };
 
 exports.loadBatch = loadBatch;

--- a/src/internal/views/nunjucks/billing/batch-list.njk
+++ b/src/internal/views/nunjucks/billing/batch-list.njk
@@ -31,8 +31,8 @@
         {% for batch in batches %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            {% if batch.badge.text != 'Sent' %}
-              <a class="govuk-link" href="/billing/batch/{{batch.id}}/summary">
+            {% if batch.link %}
+              <a class="govuk-link" href="{{ batch.link }}">
                 {{ batch.dateCreated | date }}
               </a>
             {% else %}

--- a/test/internal/modules/billing/controller.js
+++ b/test/internal/modules/billing/controller.js
@@ -405,7 +405,7 @@ experiment('internal/modules/billing/controller', () => {
         data: [
           {
             invoices: [],
-            id: '8ae7c31b-3c5a-44b8-baa5-a10b40aef9e2',
+            id: '8ae7c31b-3c5a-44b8-baa5-a10b40aef9e1',
             type: 'supplementary',
             season: 'all year',
             status: 'processing',
@@ -483,10 +483,12 @@ experiment('internal/modules/billing/controller', () => {
       expect(batches[0].region.name).to.equal('Anglian');
       expect(batches[0].status).to.equal('processing');
       expect(batches[0].billCount).to.equal(14);
+      expect(batches[0].link).to.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e1/summary');
       expect(batches[1].type).to.equal('Two-part tariff');
       expect(batches[1].region.name).to.equal('Midlands');
       expect(batches[1].status).to.equal('review');
       expect(batches[1].billCount).to.equal(null);
+      expect(batches[1].link).to.be.null();
     });
 
     test('configures the expected view template', async () => {


### PR DESCRIPTION
- Fixes an issue in the billing pre-handlers where the redirect did not take over the response when redirecting.
- Adjusts logic in billing list page to only show a link when batch status is `processing` or `ready` (these are the only 2 states that currently have working UI)