### PR TITLE
Feat: Use new event shape in billing

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -115,7 +115,7 @@ const postBillingBatchRegion = async (request, h) => {
   try {
     const batch = getBatchDetails(request, billingRegionForm);
     const { data: { event } } = await services.water.billingBatches.createBillingBatch(batch);
-    return h.redirect(`/waiting/${event.event_id}?back=0`);
+    return h.redirect(`/waiting/${event.eventId}?back=0`);
   } catch (err) {
     if (err.statusCode === 409) {
       return h.redirect(`/billing/batch/${err.error.existingBatch.id}/exists`);

--- a/test/internal/modules/billing/controller.js
+++ b/test/internal/modules/billing/controller.js
@@ -178,7 +178,7 @@ experiment('internal/modules/billing/controller', () => {
     test('billingRegionFrom is valid redirects to waiting page', async () => {
       services.water.billingBatches.createBillingBatch.resolves({
         data: {
-          event: { event_id: 'test-event-id' }
+          event: { eventId: 'test-event-id' }
         }
       });
 


### PR DESCRIPTION
WATER-2554

For the new error handling in the batch process the event shape has
changed, so this change uses the new camel cased event id

Depends on https://github.com/DEFRA/water-abstraction-service/pull/815