### PR TITLE
Handle errors approving batches

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -145,6 +145,7 @@ const getBillingBatchExists = async (request, h) => {
  */
 const getBillingBatchSummary = async (request, h) => {
   const { batchId } = request.params;
+  const { error } = request.query;
   const { batch, invoices } = await batchService.getBatchInvoices(batchId);
 
   return h.view('nunjucks/billing/batch-summary', {
@@ -155,6 +156,10 @@ const getBillingBatchSummary = async (request, h) => {
       ...row,
       isCredit: row.netTotal < 0
     })),
+    // This error string comes from the query param, and will allow us
+    // to display a suitable alert to the user e.g. when a batch cannot
+    // be approved
+    error,
     // only show the back link from the list page, so not to offer the link
     // as part of the batch creation flow.
     back: request.query.back && '/billing/batch/list'
@@ -225,12 +230,14 @@ const getBillingBatchConfirm = async (request, h) => {
 
 const postBillingBatchConfirm = async (request, h) => {
   const { batchId } = request.params;
+  const redirectPath = `/billing/batch/${batchId}/summary`;
   try {
     await services.water.billingBatches.approveBatch(batchId);
   } catch (err) {
     logger.info(`Did not successfully approve batch ${batchId}`);
+    return h.redirect(`${redirectPath}?error=confirm`);
   }
-  return h.redirect('/billing/batch/list');
+  return h.redirect(redirectPath);
 };
 
 /**

--- a/src/internal/modules/billing/routes.js
+++ b/src/internal/modules/billing/routes.js
@@ -101,7 +101,8 @@ if (isAcceptanceTestTarget) {
             batchId: Joi.string().uuid()
           },
           query: {
-            back: Joi.number().integer().default(1).optional()
+            back: Joi.number().integer().default(1).optional(),
+            error: Joi.string().valid(['confirm']).optional()
           }
         },
         pre: [

--- a/src/internal/views/nunjucks/billing/batch-summary.njk
+++ b/src/internal/views/nunjucks/billing/batch-summary.njk
@@ -4,6 +4,10 @@
 
 {% block content %}
 
+  {% if error %}
+  {# display error message here if confirm batch failed #}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
       {{ title(pageTitle, batch.billRunDate | date('D MMMM YYYY'), false, true) }}

--- a/test/internal/modules/billing/controller.js
+++ b/test/internal/modules/billing/controller.js
@@ -383,17 +383,17 @@ experiment('internal/modules/billing/controller', () => {
       expect(batchId).to.equal('test-batch-id');
     });
 
-    test('the user is redirected back to the list of batches', async () => {
+    test('the user is redirected back to the batch summary', async () => {
       const [redirectPath] = h.redirect.lastCall.args;
-      expect(redirectPath).to.equal('/billing/batch/list');
+      expect(redirectPath).to.equal('/billing/batch/test-batch-id/summary');
     });
 
-    test('if the approval fails, the user is still redirected back to the list of batches', async () => {
+    test('if the approval fails, the user is redirected to the batch summary, with a query parameter added', async () => {
       services.water.billingBatches.approveBatch.rejects();
       await controller.postBillingBatchConfirm(request, h);
 
       const [redirectPath] = h.redirect.lastCall.args;
-      expect(redirectPath).to.equal('/billing/batch/list');
+      expect(redirectPath).to.equal('/billing/batch/test-batch-id/summary?error=confirm');
     });
   });
 


### PR DESCRIPTION
- Redirect user to batch summary when approved.
- Include query param if water service error so an error message can be displayed.