### PR TITLE
Feat: Persist user errors in bulk upload 

### DIFF
--- a/src/external/modules/returns/lib/upload-summary-helpers.js
+++ b/src/external/modules/returns/lib/upload-summary-helpers.js
@@ -25,7 +25,7 @@ const getReturnQuantitiesPath = (ret, eventId) => {
 const mapReturn = (ret, eventId) => {
   return {
     ...ret,
-    returnRequirement: ret.returnRequirement || getReturnRequirmentFromId(ret.returnId),
+    returnRequirement: getReturnRequirmentFromId(ret.returnId),
     path: getReturnQuantitiesPath(ret, eventId)
   };
 };

--- a/src/external/views/nunjucks/returns/upload-summary.njk
+++ b/src/external/views/nunjucks/returns/upload-summary.njk
@@ -70,7 +70,7 @@
             {% if return.isNil %}
             Nil return
             {% else %}
-            {{ return.totalVolume | number }} {{ return.reading.units | units }}
+            {{ return.totalVolume | number }} cubic meters
             {% endif %}
           </td>
         </tr>

--- a/src/shared/lib/connectors/services/water/ReturnsService.js
+++ b/src/shared/lib/connectors/services/water/ReturnsService.js
@@ -39,9 +39,9 @@ class ReturnsService extends ServiceClient {
     * @param {String} type - the file type, supported is 'xml', 'csv'
     * @return {string} - JSON containing, eventId, filename, location, etc
     */
-  postUpload (fileData, userName, type = 'xml') {
+  postUpload (fileData, userName, companyId, type = 'csv') {
     const url = this.joinUrl('returns/upload', type.toLowerCase());
-    return this.serviceRequest.post(url, { body: { fileData, userName } });
+    return this.serviceRequest.post(url, { body: { fileData, userName, companyId } });
   }
 
   /**
@@ -71,7 +71,7 @@ class ReturnsService extends ServiceClient {
    * @return {Promise} resolves with array of returns
    */
   async getUploadPreview (eventId, qs, returnId) {
-    const uri = this.joinUrl('returns/upload-preview', eventId, returnId || '');
+    const uri = this.joinUrl('returns/upload-preview', eventId, returnId);
     const response = await this.serviceRequest.get(uri, { qs });
     return responseHandler(response);
   }

--- a/test/external/modules/returns/controllers/upload.js
+++ b/test/external/modules/returns/controllers/upload.js
@@ -12,6 +12,7 @@ const services = require('external/lib/connectors/services');
 const controller = require('external/modules/returns/controllers/upload');
 const { logger } = require('external/logger');
 const uploadHelpers = require('external/modules/returns/lib/upload-helpers');
+const uploadSummaryHelpers = require('external/modules/returns/lib/upload-summary-helpers');
 const helpers = require('external/modules/returns/lib/helpers.js');
 const csvTemplates = require('external/modules/returns/lib/csv-templates');
 
@@ -90,9 +91,8 @@ const csvData = {
 
 const zipObject = { zip: true };
 
-experiment('upload controller', () => {
-  let h;
-  let header;
+experiment('external/modules/returns/controllers/upload', () => {
+  let header, h, request;
 
   beforeEach(async () => {
     header = sandbox.stub().returnsThis();
@@ -105,12 +105,16 @@ experiment('upload controller', () => {
       })
     };
 
+    request = createRequest();
+
     sandbox.stub(services.water.events, 'findMany');
     sandbox.stub(forms, 'handleRequest');
     sandbox.stub(uploadHelpers, 'getFile').returns('filepath');
     sandbox.stub(uploadHelpers, 'uploadFile');
     sandbox.stub(uploadHelpers, 'getUploadedFileStatus');
     sandbox.stub(uploadHelpers, 'createDirectory');
+    sandbox.stub(uploadSummaryHelpers, 'mapRequestOptions').returns({ userName, entityId, companyId });
+    sandbox.stub(uploadSummaryHelpers, 'groupReturns');
     sandbox.stub(services.water.returns, 'postUpload').resolves({ data: { eventId } });
     sandbox.stub(files, 'deleteFile');
     sandbox.stub(files, 'readFile').returns('fileData');
@@ -129,9 +133,8 @@ experiment('upload controller', () => {
     sandbox.restore();
   });
 
-  experiment('getBulkUpload', () => {
+  experiment('.getBulkUpload', () => {
     test('it should display the upload xml page', async () => {
-      const request = createRequest();
       await controller.getBulkUpload(request, h);
       const [template, view] = h.view.lastCall.args;
 
@@ -140,10 +143,10 @@ experiment('upload controller', () => {
     });
   });
 
-  experiment('postBulkUpload', () => {
+  experiment('.postBulkUpload', () => {
     test('redirects to spinner page if there are no errors', async () => {
       uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.OK);
-      await controller.postBulkUpload(createRequest(), h);
+      await controller.postBulkUpload(request, h);
 
       const [path] = h.redirect.lastCall.args;
       expect(path).to.equal(`/returns/processing-upload/processing/${eventId}`);
@@ -151,14 +154,14 @@ experiment('upload controller', () => {
 
     test('redirects to same page with virus error message if virus', async () => {
       uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.VIRUS);
-      await controller.postBulkUpload(createRequest(), h);
+      await controller.postBulkUpload(request, h);
       const [path] = h.redirect.lastCall.args;
       expect(path).to.equal('/returns/upload?error=virus');
     });
 
     test('redirects to same page with file type message if unsupported file type', async () => {
       uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.INVALID_TYPE);
-      await controller.postBulkUpload(createRequest(), h);
+      await controller.postBulkUpload(request, h);
       const [path] = h.redirect.lastCall.args;
       expect(path).to.equal('/returns/upload?error=invalid-type');
     });
@@ -166,24 +169,25 @@ experiment('upload controller', () => {
     test('calls the water returns upload API with the correct file type', async () => {
       uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.OK);
       fileCheck.detectFileType.resolves('csv');
-      await controller.postBulkUpload(createRequest(), h);
-      const [data, user, fileType] = services.water.returns.postUpload.lastCall.args;
+      await controller.postBulkUpload(request, h);
+      const [data, user, compId, fileType] = services.water.returns.postUpload.lastCall.args;
       expect(data).to.equal('fileData');
       expect(user).to.equal('user_1');
+      expect(compId).to.equal('company_1');
       expect(fileType).to.equal('csv');
     });
 
     test('logs the journey data if there is an error', async () => {
       uploadHelpers.createDirectory.rejects();
       try {
-        await controller.postBulkUpload(createRequest());
+        await controller.postBulkUpload(request);
       } catch (err) {
         expect(logger.errorWithJourney.called).to.be.true();
       }
     });
   });
 
-  experiment('getSpinnerPage', () => {
+  experiment('.getSpinnerPage', () => {
     test('throws an error if there is an error response from the events API', async () => {
       const response = createErrorResponse();
       services.water.events.findMany.resolves(response);
@@ -192,7 +196,7 @@ experiment('upload controller', () => {
     });
 
     test('it should redirect to the summary page if status is validated', async () => {
-      const response = createResponse('validated');
+      const response = createResponse('ready');
       const request = createSpinnerRequest();
       services.water.events.findMany.resolves(response);
       await controller.getSpinnerPage(request, h);
@@ -234,238 +238,244 @@ experiment('upload controller', () => {
     });
   });
 
-  experiment('XML return upload controller', () => {
-    let request;
-
+  experiment('.getSummary', () => {
     beforeEach(async () => {
-      request = createRequest();
+      const metadata = { validationResults: returns };
+      const response = createResponse('ready', metadata);
+      const returnsWithErrors = [returns[1]];
+      const returnsWithoutErrors = [returns[0]];
+      uploadSummaryHelpers.groupReturns.returns({ returnsWithErrors, returnsWithoutErrors });
+      services.water.events.findMany.resolves(response);
     });
 
-    experiment('getSummary', () => {
-      beforeEach(async () => {
-        sandbox.stub(services.water.returns, 'getUploadPreview').resolves(returns);
-      });
+    test('gets options from uploadSummaryHelpers', async () => {
+      await controller.getSummary(request, h);
+      const [req] = uploadSummaryHelpers.mapRequestOptions.lastCall.args;
+      expect(req).to.equal(request);
+    });
 
-      test('should call water returns API with correct params', async () => {
-        await controller.getSummary(request, h);
-        const { args } = services.water.returns.getUploadPreview.lastCall;
-        expect(args[0]).to.equal(eventId);
-        expect(args[1]).to.equal({
+    test('loads the upload event', async () => {
+      await controller.getSummary(request, h);
+      const [filter] = services.water.events.findMany.lastCall.args;
+      expect(filter).to.equal({
+        event_id: eventId,
+        issuer: userName,
+        type: 'returns-upload'
+      });
+    });
+
+    test('calls groupReturns upload summary helper with expected params', async () => {
+      await controller.getSummary(request, h);
+      const [validationResults, evtId] = uploadSummaryHelpers.groupReturns.lastCall.args;
+      expect(validationResults).to.equal(returns);
+      expect(evtId).to.equal(eventId);
+    });
+
+    test('redirects to error page if no returns data is returns from uploadSummaryHelpers', async () => {
+      uploadSummaryHelpers.groupReturns.returns([]);
+      await controller.getSummary(request, h);
+      expect(h.redirect.calledWith('/returns/upload?error=empty')).to.be.true();
+    });
+
+    test('should use the correct template', async () => {
+      await controller.getSummary(request, h);
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/returns/upload-summary');
+    });
+
+    test('should set the correct view data', async () => {
+      await controller.getSummary(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.pageTitle).to.equal(controller.pageTitles.error);
+      expect(view.back).to.equal('/returns/upload');
+      expect(view.returnsWithErrors).to.be.an.array();
+      expect(view.returnsWithoutErrors).to.be.an.array();
+      expect(view.form).to.be.an.object();
+    });
+
+    test('should have correct page title if there are no errors', async () => {
+      uploadSummaryHelpers.groupReturns.returns({ returnsWithoutErrors: [returns[0]] });
+      await controller.getSummary(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.pageTitle).to.equal(controller.pageTitles.ok);
+    });
+
+    test('should log an error if water returns API error', async () => {
+      services.water.events.findMany.rejects();
+      const func = () => controller.getSummary(request, h);
+      await expect(func()).to.reject();
+
+      const [message, , , params] = logger.errorWithJourney.lastCall.args;
+      expect(message).to.be.a.string();
+      expect(params).to.equal({
+        eventId,
+        options: {
           userName,
           entityId,
           companyId
-        });
-      });
-
-      test('should use the correct template', async () => {
-        await controller.getSummary(request, h);
-        const [template] = h.view.lastCall.args;
-        expect(template).to.equal('nunjucks/returns/upload-summary');
-      });
-
-      test('should set the correct view data', async () => {
-        await controller.getSummary(request, h);
-        const [, view] = h.view.lastCall.args;
-        expect(view.pageTitle).to.equal(controller.pageTitles.error);
-        expect(view.back).to.equal('/returns/upload');
-        expect(view.returnsWithErrors).to.be.an.array();
-        expect(view.returnsWithoutErrors).to.be.an.array();
-        expect(view.form).to.be.an.object();
-      });
-
-      test('should have correct page title if there are no errors', async () => {
-        services.water.returns.getUploadPreview.resolves([returns[0]]);
-        await controller.getSummary(request, h);
-        const [, view] = h.view.lastCall.args;
-        expect(view.pageTitle).to.equal(controller.pageTitles.ok);
-      });
-
-      test('should log an error if water returns API error', async () => {
-        services.water.returns.getUploadPreview.rejects();
-        const func = () => controller.getSummary(request, h);
-        await expect(func()).to.reject();
-
-        const [message, , , params] = logger.errorWithJourney.lastCall.args;
-        expect(message).to.be.a.string();
-        expect(params).to.equal({
-          eventId,
-          options: {
-            userName,
-            entityId,
-            companyId
-          }
-        });
-      });
-
-      test('redirects to upload form if upload contains no data', async () => {
-        services.water.returns.getUploadPreview.resolves([]);
-        await controller.getSummary(request, h);
-        expect(h.redirect.calledWith(`/returns/upload?error=empty`)).to.equal(true);
+        }
       });
     });
 
-    experiment('getSummaryReturn', () => {
-      beforeEach(async () => {
-        sandbox.stub(services.water.returns, 'getUploadPreview').resolves(returns[0]);
-      });
+    // test('redirects to upload form if upload contains no data', async () => {
+    //   services.water.returns.getUploadPreview.resolves([]);
+    //   await controller.getSummary(request, h);
+    //   expect(h.redirect.calledWith(`/returns/upload?error=empty`)).to.equal(true);
+    // });
+  });
 
-      test('should call water returns API with correct params', async () => {
-        await controller.getSummaryReturn(request, h);
-        const { args } = services.water.returns.getUploadPreview.lastCall;
-        expect(args[0]).to.equal(eventId);
-        expect(args[1]).to.equal({
+  experiment('.getSummaryReturn', () => {
+    beforeEach(async () => {
+      sandbox.stub(services.water.returns, 'getUploadPreview').resolves(returns[0]);
+    });
+
+    test('should call water returns API with correct params', async () => {
+      await controller.getSummaryReturn(request, h);
+      const { args } = services.water.returns.getUploadPreview.lastCall;
+      expect(args[0]).to.equal(eventId);
+      expect(args[1]).to.equal({
+        userName,
+        entityId,
+        companyId
+      });
+      expect(args[2]).to.equal(returnId);
+    });
+
+    test('should output correct view data', async () => {
+      await controller.getSummaryReturn(request, h);
+      const [, view] = h.view.lastCall.args;
+      expect(view.back).to.equal(`/returns/upload-summary/${eventId}`);
+      expect(view.return).to.be.an.object();
+      expect(view.pageTitle).to.be.a.string();
+      expect(view.lines).to.be.an.array();
+    });
+
+    test('should log an error if water returns API error', async () => {
+      services.water.returns.getUploadPreview.rejects();
+      const func = () => controller.getSummaryReturn(request, h);
+      await expect(func()).to.reject();
+
+      const [message, , , params] = logger.errorWithJourney.lastCall.args;
+      expect(message).to.be.a.string();
+      expect(params).to.equal({
+        eventId,
+        returnId,
+        options: {
           userName,
           entityId,
           companyId
-        });
-        expect(args[2]).to.equal(returnId);
-      });
-
-      test('should output correct view data', async () => {
-        await controller.getSummaryReturn(request, h);
-        const [, view] = h.view.lastCall.args;
-        expect(view.back).to.equal(`/returns/upload-summary/${eventId}`);
-        expect(view.return).to.be.an.object();
-        expect(view.pageTitle).to.be.a.string();
-        expect(view.lines).to.be.an.array();
-      });
-
-      test('should log an error if water returns API error', async () => {
-        services.water.returns.getUploadPreview.rejects();
-        const func = () => controller.getSummaryReturn(request, h);
-        await expect(func()).to.reject();
-
-        const [message, , , params] = logger.errorWithJourney.lastCall.args;
-        expect(message).to.be.a.string();
-        expect(params).to.equal({
-          eventId,
-          returnId,
-          options: {
-            userName,
-            entityId,
-            companyId
-          }
-        });
-      });
-    });
-
-    experiment('postSubmit', () => {
-      test('should call the water service upload submit API with correct params', async () => {
-        const request = createRequest();
-        await controller.postSubmit(request, h);
-        const { args } = services.water.returns.postUploadSubmit.lastCall;
-        expect(args[0]).to.equal(eventId);
-        expect(args[1]).to.equal({
-          companyId,
-          entityId,
-          userName
-        });
-      });
-
-      test('should redirect to the correct URL if the API call succeeds', async () => {
-        const request = createRequest();
-        await controller.postSubmit(request, h);
-        const [path] = h.redirect.lastCall.args;
-        expect(path).to.equal(`/returns/processing-upload/submitting/${eventId}`);
-      });
-
-      test('should log an error if the submission fails', async () => {
-        services.water.returns.postUploadSubmit.rejects();
-        const func = () => controller.postSubmit(request, h);
-        await expect(func()).to.reject();
-        const [message, err, , params] = logger.errorWithJourney.lastCall.args;
-        expect(message).to.be.a.string();
-        expect(err).to.be.an.error();
-        expect(params).to.equal({
-          eventId,
-          options: {
-            entityId,
-            userName,
-            companyId
-          }
-        });
-      });
-    });
-
-    experiment('getSubmitted', () => {
-      test('should render a success page', async () => {
-        const request = createRequest();
-        await controller.getSubmitted(request, h);
-        const [template] = h.view.lastCall.args;
-        expect(template).to.equal('nunjucks/returns/upload-submitted');
-      });
-
-      test('should log an info message', async () => {
-        const request = createRequest();
-        await controller.getSubmitted(request, h);
-        const [message, params] = logger.info.lastCall.args;
-        expect(message).to.be.a.string();
-        expect(params).to.equal({ eventId });
-      });
-    });
-
-    experiment('getCSVTemplates', () => {
-      experiment('when there are returns', () => {
-        beforeEach(async () => {
-          const request = createRequest();
-          await controller.getCSVTemplates(request, h);
-        });
-
-        test('should get current due returns for the correct company', async () => {
-          expect(services.water.companies.getCurrentDueReturns.calledWith(companyId)).to.equal(true);
-        });
-
-        test('calls csvTemplates.createCSVData with the company returns', async () => {
-          expect(csvTemplates.createCSVData.calledWith(companyReturns)).to.equal(true);
-        });
-
-        test('calls csvTemplates.buildZip with CSV data and company name', async () => {
-          const { args } = csvTemplates.buildZip.lastCall;
-          expect(args[0]).to.equal(csvData);
-          expect(args[1]).to.equal(companyName);
-        });
-
-        test('responds with the zip stream', async () => {
-          expect(h.response.calledWith(zipObject)).to.equal(true);
-        });
-
-        test('sets the correct mime type header in the response', async () => {
-          const [key, value] = header.firstCall.args;
-          expect(key).to.equal('Content-type');
-          expect(value).to.equal('application/zip');
-        });
-
-        test('sets the correct content disposition in the response', async () => {
-          const [key, value] = header.secondCall.args;
-          expect(key).to.equal('Content-disposition');
-          expect(value).to.equal('attachment; filename="test co ltd return templates 2019.zip"');
-        });
-      });
-
-      experiment('when there are no returns', () => {
-        let request;
-
-        beforeEach(async () => {
-          services.water.companies.getCurrentDueReturns.resolves([]);
-          request = createRequest();
-        });
-
-        test('a Boom 404 error is thrown', async () => {
-          try {
-            await controller.getCSVTemplates(request, h);
-            fail();
-          } catch (err) {
-            expect(err.isBoom).to.be.true();
-            expect(err.output.statusCode).to.equal(404);
-          }
-        });
+        }
       });
     });
   });
 
-  experiment('getUploadInstructions', () => {
+  experiment('.postSubmit', () => {
+    test('should call the water service upload submit API with correct params', async () => {
+      await controller.postSubmit(request, h);
+      const { args } = services.water.returns.postUploadSubmit.lastCall;
+      expect(args[0]).to.equal(eventId);
+      expect(args[1]).to.equal({
+        companyId,
+        entityId,
+        userName
+      });
+    });
+
+    test('should redirect to the correct URL if the API call succeeds', async () => {
+      await controller.postSubmit(request, h);
+      const [path] = h.redirect.lastCall.args;
+      expect(path).to.equal(`/returns/processing-upload/submitting/${eventId}`);
+    });
+
+    test('should log an error if the submission fails', async () => {
+      services.water.returns.postUploadSubmit.rejects();
+      const func = () => controller.postSubmit(request, h);
+      await expect(func()).to.reject();
+      const [message, err, , params] = logger.errorWithJourney.lastCall.args;
+      expect(message).to.be.a.string();
+      expect(err).to.be.an.error();
+      expect(params).to.equal({
+        eventId,
+        options: {
+          entityId,
+          userName,
+          companyId
+        }
+      });
+    });
+  });
+
+  experiment('.getSubmitted', () => {
+    test('should render a success page', async () => {
+      await controller.getSubmitted(request, h);
+      const [template] = h.view.lastCall.args;
+      expect(template).to.equal('nunjucks/returns/upload-submitted');
+    });
+
+    test('should log an info message', async () => {
+      await controller.getSubmitted(request, h);
+      const [message, params] = logger.info.lastCall.args;
+      expect(message).to.be.a.string();
+      expect(params).to.equal({ eventId });
+    });
+  });
+
+  experiment('.getCSVTemplates', () => {
+    experiment('when there are returns', () => {
+      beforeEach(async () => {
+        await controller.getCSVTemplates(request, h);
+      });
+
+      test('should get current due returns for the correct company', async () => {
+        expect(services.water.companies.getCurrentDueReturns.calledWith(companyId)).to.equal(true);
+      });
+
+      test('calls csvTemplates.createCSVData with the company returns', async () => {
+        expect(csvTemplates.createCSVData.calledWith(companyReturns)).to.equal(true);
+      });
+
+      test('calls csvTemplates.buildZip with CSV data and company name', async () => {
+        const { args } = csvTemplates.buildZip.lastCall;
+        expect(args[0]).to.equal(csvData);
+        expect(args[1]).to.equal(companyName);
+      });
+
+      test('responds with the zip stream', async () => {
+        expect(h.response.calledWith(zipObject)).to.equal(true);
+      });
+
+      test('sets the correct mime type header in the response', async () => {
+        const [key, value] = header.firstCall.args;
+        expect(key).to.equal('Content-type');
+        expect(value).to.equal('application/zip');
+      });
+
+      test('sets the correct content disposition in the response', async () => {
+        const [key, value] = header.secondCall.args;
+        expect(key).to.equal('Content-disposition');
+        expect(value).to.equal('attachment; filename="test co ltd return templates 2019.zip"');
+      });
+    });
+
+    experiment('when there are no returns', () => {
+      beforeEach(async () => {
+        services.water.companies.getCurrentDueReturns.resolves([]);
+      });
+
+      test('a Boom 404 error is thrown', async () => {
+        try {
+          await controller.getCSVTemplates(request, h);
+          fail();
+        } catch (err) {
+          expect(err.isBoom).to.be.true();
+          expect(err.output.statusCode).to.equal(404);
+        }
+      });
+    });
+  });
+
+  experiment('.getUploadInstructions', () => {
     beforeEach(async () => {
-      const request = createRequest();
       await controller.getUploadInstructions(request, h);
     });
 

--- a/test/external/modules/returns/lib/upload-summary-helpers.js
+++ b/test/external/modules/returns/lib/upload-summary-helpers.js
@@ -70,15 +70,8 @@ experiment('return upload helpers', () => {
       const result = helpers.mapReturn(returns[0], eventId);
       expect(result).to.be.an.object();
     });
-    test('should use return requirement in return if available', async () => {
-      const ret = {
-        ...returns[0],
-        returnRequirement: 'foo'
-      };
-      const result = helpers.mapReturn(ret, eventId);
-      expect(result.returnRequirement).to.equal('foo');
-    });
-    test('should get return requirement from returnId if not set', async () => {
+
+    test('should get return requirement from returnId', async () => {
       const result = helpers.mapReturn(returns[0], eventId);
       expect(result.returnRequirement).to.equal('1234');
     });

--- a/test/shared/lib/connectors/services/water/ReturnsService.js
+++ b/test/shared/lib/connectors/services/water/ReturnsService.js
@@ -90,18 +90,18 @@ experiment('services/water/ReturnsService', () => {
   experiment('.postUpload', () => {
     beforeEach(async () => {
       const service = new ReturnsService('http://127.0.0.1:8001/water/1.0');
-      await service.postUpload('file-data', 'user-name');
+      await service.postUpload('file-data', 'user-name', 'company_1');
     });
 
     test('passes the expected URL to the service request', async () => {
-      const expectedUrl = `http://127.0.0.1:8001/water/1.0/returns/upload/xml`;
+      const expectedUrl = `http://127.0.0.1:8001/water/1.0/returns/upload/csv`;
       const [url] = serviceRequest.post.lastCall.args;
       expect(url).to.equal(expectedUrl);
     });
 
     test('lowercases the file type', async () => {
       const service = new ReturnsService('http://127.0.0.1:8001/water/1.0');
-      await service.postUpload('file-data', 'user-name', 'CSV');
+      await service.postUpload('file-data', 'user-name', 'company_1', 'CSV');
 
       const expectedUrl = `http://127.0.0.1:8001/water/1.0/returns/upload/csv`;
       const [url] = serviceRequest.post.lastCall.args;
@@ -110,7 +110,7 @@ experiment('services/water/ReturnsService', () => {
 
     test('passes the body data to the service request', async () => {
       const expectedOptions = {
-        body: { fileData: 'file-data', userName: 'user-name' }
+        body: { fileData: 'file-data', userName: 'user-name', companyId: 'company_1' }
       };
       const [, options] = serviceRequest.post.lastCall.args;
 
@@ -176,13 +176,13 @@ experiment('services/water/ReturnsService', () => {
     });
 
     test('calls service request with correct url', async () => {
-      await service.getUploadPreview('event-id', { query: 'string' });
+      await service.getUploadPreview('event-id', {}, 'return-id');
       const [uri] = serviceRequest.get.lastCall.args;
-      expect(uri).to.equal('http://127.0.0.1:8001/water/1.0/returns/upload-preview/event-id');
+      expect(uri).to.equal('http://127.0.0.1:8001/water/1.0/returns/upload-preview/event-id/return-id');
     });
 
     test('calls service request with correct options', async () => {
-      await service.getUploadPreview('event-id', { query: 'string' });
+      await service.getUploadPreview('event-id', { query: 'string' }, 'return-id');
       const [, options] = serviceRequest.get.lastCall.args;
       expect(options).to.equal({
         qs: {
@@ -193,19 +193,13 @@ experiment('services/water/ReturnsService', () => {
 
     test('should throw an error if API returns error response', async () => {
       serviceRequest.get.resolves(responses.error);
-      const func = () => service.getUploadPreview('event-id', {});
+      const func = () => service.getUploadPreview('event-id', {}, 'return-id');
       expect(func()).to.reject();
     });
 
     test('resolves with data from API response', async () => {
-      const response = await service.getUploadPreview('event-id', {});
+      const response = await service.getUploadPreview('event-id', {}, 'return-id');
       expect(response).to.equal(responses.multi.data);
-    });
-
-    test('calls service request with correct URL if return ID supplied', async () => {
-      await service.getUploadPreview('event-id', {}, 'return-id');
-      const [uri] = serviceRequest.get.lastCall.args;
-      expect(uri).to.equal('http://127.0.0.1:8001/water/1.0/returns/upload-preview/event-id/return-id');
     });
   });
 });


### PR DESCRIPTION
WATER-2584

 - Remove call to getUploadPreview without returnId.
 - Update GET for bulk upload summary page to get view data from event metadata.