### PR TITLE
Error handling for billing batch approve

### DIFF
--- a/src/internal/modules/billing/controller.js
+++ b/src/internal/modules/billing/controller.js
@@ -149,7 +149,6 @@ const getBillingBatchExists = async (request, h) => {
  */
 const getBillingBatchSummary = async (request, h) => {
   const { batchId } = request.params;
-  const { error } = request.query;
   const { batch, invoices } = await batchService.getBatchInvoices(batchId);
 
   return h.view('nunjucks/billing/batch-summary', {
@@ -160,10 +159,7 @@ const getBillingBatchSummary = async (request, h) => {
       ...row,
       isCredit: row.netTotal < 0
     })),
-    // This error string comes from the query param, and will allow us
-    // to display a suitable alert to the user e.g. when a batch cannot
-    // be approved
-    error,
+    isEditable: batch.status === 'ready',
     // only show the back link from the list page, so not to offer the link
     // as part of the batch creation flow.
     back: request.query.back && '/billing/batch/list'
@@ -233,14 +229,8 @@ const getBillingBatchConfirm = async (request, h) => billingBatchAction(request,
 
 const postBillingBatchConfirm = async (request, h) => {
   const { batchId } = request.params;
-  const redirectPath = `/billing/batch/${batchId}/summary`;
-  try {
-    await services.water.billingBatches.approveBatch(batchId);
-  } catch (err) {
-    logger.info(`Did not successfully approve batch ${batchId}`);
-    return h.redirect(`${redirectPath}?error=confirm`);
-  }
-  return h.redirect(redirectPath);
+  await services.water.billingBatches.approveBatch(batchId);
+  return h.redirect(`/billing/batch/${batchId}/summary`);
 };
 
 /**

--- a/src/internal/modules/billing/routes.js
+++ b/src/internal/modules/billing/routes.js
@@ -101,8 +101,7 @@ if (isAcceptanceTestTarget) {
             batchId: Joi.string().uuid()
           },
           query: {
-            back: Joi.number().integer().default(1).optional(),
-            error: Joi.string().valid(['confirm']).optional()
+            back: Joi.number().integer().default(1).optional()
           }
         },
         pre: [

--- a/src/internal/views/nunjucks/billing/batch-summary.njk
+++ b/src/internal/views/nunjucks/billing/batch-summary.njk
@@ -7,10 +7,6 @@
 
 {% block content %}
 
-  {% if error %}
-  {# display error message here if confirm batch failed #}
-  {% endif %}
-
   {% if not batch.totals %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
@@ -59,6 +55,9 @@
     </h2>
     </div>
   </div>
+
+  {% if isEditable %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <section class="govuk-!-margin-bottom-6">
@@ -81,6 +80,9 @@
       </p>
     </div>
   </div>
+
+  {% endif %}
+    
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-margin-top-6">
       <hr class="govuk-section-break section-break--heavy" />
@@ -98,7 +100,9 @@
               <th scope="col" class="govuk-table__header">Contact</th>
               <th scope="col" class="govuk-table__header">Licence</th>
               <th scope="col" class="govuk-table__header govuk-table__header--numeric">Total</th>
+              {% if isEditable %}
               <th scope="col" class="govuk-table__header govuk-table__header--numeric">Action</th>
+              {% endif %}
             </tr>
           </thead>
           <tbody class="govuk-table__body">
@@ -121,9 +125,11 @@
                     <div>Credit note</div>
                   {% endif %}
                 </td>
+                {% if isEditable %}
                 <td class="govuk-table__cell govuk-table__cell--numeric">
                   <a class="govuk-link" href="/billing/batch/{{batch.id}}/delete-account/{{invoice.id}}">Remove</a>
                 </td>
+                {% endif %}
               </tr>
             {% endfor %}
           </tbody>

--- a/src/internal/views/nunjucks/errors/error.njk
+++ b/src/internal/views/nunjucks/errors/error.njk
@@ -1,13 +1,20 @@
 {% extends "./nunjucks/layout.njk" %}
 
+{% set pageTitle %}There is a problem with this service{% endset %}
+
 {% block content %}
+
   {{ title(pageTitle) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p>Sorry, there was a technical problem.</p>
-      <p>Please refresh your screen to continue using the service.</p>
-      <p>If the problem continues, please try again later. You can also <a href="https://www.gov.uk/government/organisations/environment-agency#org-contacts">contact the Environment Agency</a> for support.</p>
+
+      <p>Sorry, there is a technical problem.</p>
+
+      <p>Please refresh your screen. If the problem continues, try again later.</p>
+
+      <p>If you need help call the IT Service Desk on 0800 014 8255.</p>
+
     </div>
   </div>
 

--- a/test/internal/modules/billing/controller.js
+++ b/test/internal/modules/billing/controller.js
@@ -584,12 +584,10 @@ experiment('internal/modules/billing/controller', () => {
       expect(redirectPath).to.equal('/billing/batch/test-batch-id/summary');
     });
 
-    test('if the approval fails, the user is redirected to the batch summary, with a query parameter added', async () => {
+    test('if the approval fails, the user is redirected to the batch summary, an error is thrown', async () => {
       services.water.billingBatches.approveBatch.rejects();
-      await controller.postBillingBatchConfirm(request, h);
-
-      const [redirectPath] = h.redirect.lastCall.args;
-      expect(redirectPath).to.equal('/billing/batch/test-batch-id/summary?error=confirm');
+      const func = () => controller.postBillingBatchConfirm(request, h);
+      expect(func()).to.reject();
     });
   });
 


### PR DESCRIPTION
- Implements new content for internal error page
- On service error sending batch, displays error page instead of redirect 
- Bonus: hides confirm/send/actions on a batch not in `ready` status