### PR TITLE
Feat: Use maxAnnualQuantity when setting billable quantity

### DIFF
--- a/src/internal/modules/billing/forms/two-part-tariff-quantity-confirm.js
+++ b/src/internal/modules/billing/forms/two-part-tariff-quantity-confirm.js
@@ -1,8 +1,9 @@
 'use strict';
-const confirmForm = require('./confirm-form');
 
-const { fields } = require('shared/lib/forms/');
 const Joi = require('@hapi/joi');
+
+const confirmForm = require('./confirm-form');
+const { fields } = require('shared/lib/forms/');
 
 const twoPartTariffQuantityConfirmForm = (request, quantity) => {
   const { batchId, invoiceLicenceId, transactionId } = request.params;
@@ -13,7 +14,7 @@ const twoPartTariffQuantityConfirmForm = (request, quantity) => {
 };
 
 const twoPartTariffQuantityConfirmSchema = transaction => {
-  const maxQuantity = parseFloat(transaction.chargeElement.authorisedAnnualQuantity);
+  const maxQuantity = parseFloat(transaction.chargeElement.maxAnnualQuantity);
   return {
     csrf_token: Joi.string().uuid().required(),
     quantity: Joi.number().required().min(0).max(maxQuantity)

--- a/src/internal/modules/billing/forms/two-part-tariff-quantity.js
+++ b/src/internal/modules/billing/forms/two-part-tariff-quantity.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { formFactory, fields } = require('shared/lib/forms/');
 const Joi = require('@hapi/joi');
+const { formFactory, fields } = require('shared/lib/forms/');
 
 /**
  * Gets an array of form choices for the billable quantity
@@ -67,11 +67,14 @@ const twoPartTariffQuantityForm = (request, transaction) => {
 };
 
 const twoPartTariffQuantitySchema = transaction => {
-  const maxQuantity = parseFloat(transaction.chargeElement.authorisedAnnualQuantity);
+  const maxQuantity = parseFloat(transaction.chargeElement.maxAnnualQuantity);
   return {
     csrf_token: Joi.string().uuid().required(),
     quantity: Joi.string().valid(['authorised', 'custom']).required(),
-    customQuantity: Joi.when('quantity', { is: 'custom', then: Joi.number().required().min(0).max(maxQuantity) })
+    customQuantity: Joi.when('quantity', {
+      is: 'custom',
+      then: Joi.number().required().min(0).max(maxQuantity)
+    })
   };
 };
 

--- a/src/internal/views/nunjucks/billing/two-part-tariff-quantities.njk
+++ b/src/internal/views/nunjucks/billing/two-part-tariff-quantities.njk
@@ -42,10 +42,10 @@
  <dl class="meta">
   {% for condition in aggregateConditions %}
     {{ metaRow('Aggregate condition', condition.title) }}
-    {{ metaRow(condition.parameter1Label, condition.parameter1) }} 
-    {{ metaRow(condition.parameter2Label, condition.parameter2, not condition.text) }} 
+    {{ metaRow(condition.parameter1Label, condition.parameter1) }}
+    {{ metaRow(condition.parameter2Label, condition.parameter2, not condition.text) }}
     {% if condition.text %}
-    {{ metaRow('Other information', condition.text, true) }} 
+    {{ metaRow('Other information', condition.text, true) }}
     {% endif %}
   {% endfor %}
 
@@ -59,9 +59,9 @@
 
   {% if transaction.chargeElement.timeLimitedPeriod %}
     {% set timeLimitedPeriod %}
-      {{ transaction.chargeElement.timeLimitedPeriod.startDate | date }} 
+      {{ transaction.chargeElement.timeLimitedPeriod.startDate | date }}
       to {{ transaction.chargeElement.timeLimitedPeriod.endDate | date }}
-    {% endset %} 
+    {% endset %}
   {{ metaRow('Time limited', timeLimitedPeriod) }}
   {% endif %}
 </dl>
@@ -115,7 +115,7 @@
     {{ formRender(form) }}
   </div>
 </div>
-        
+
 
 
 

--- a/test/internal/modules/billing/controllers/two-part-tariff.js
+++ b/test/internal/modules/billing/controllers/two-part-tariff.js
@@ -103,7 +103,8 @@ const getTransactionReviewRequest = payload => (
             },
             chargeElement: {
               description: 'Test description',
-              authorisedAnnualQuantity: 25.3
+              authorisedAnnualQuantity: 25.3,
+              maxAnnualQuantity: 25.3
             }
           }
         ]

--- a/test/internal/modules/billing/forms/two-part-tariff-quantity-confirm.js
+++ b/test/internal/modules/billing/forms/two-part-tariff-quantity-confirm.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+
+const uuid = require('uuid/v4');
+const { expect } = require('@hapi/code');
+const Joi = require('@hapi/joi');
+
+const { schema } = require('../../../../../src/internal/modules/billing/forms/two-part-tariff-quantity-confirm');
+
+experiment('internal/modules/billing/forms/two-part-tariff-quantity-confirm', () => {
+  experiment('schema', () => {
+    let transaction;
+    let tptSchema;
+
+    beforeEach(async () => {
+      transaction = {
+        chargeElement: {
+          authorisedAnnualQuantity: 1,
+          billableAnnualQuantity: 2,
+          maxAnnualQuantity: 3
+        }
+      };
+
+      tptSchema = schema(transaction);
+    });
+
+    experiment('csrf_token', () => {
+      test('can be a uuid', async () => {
+        const result = tptSchema.csrf_token.validate(uuid());
+        expect(result.error).to.equal(null);
+      });
+
+      test('cannot be a non uuid', async () => {
+        const result = tptSchema.csrf_token.validate('hello');
+        expect(result.error).to.exist();
+      });
+
+      test('is required', async () => {
+        const result = tptSchema.csrf_token.validate();
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('quantity', () => {
+      const getData = ({ quantity }) => ({
+        csrf_token: uuid(),
+        quantity
+      });
+
+      test('is required', async () => {
+        const data = getData({});
+        const result = Joi.validate(data, tptSchema);
+        expect(result.error).to.exist();
+      });
+
+      test('the quantity cannot be less than 0', async () => {
+        const data = getData({ quantity: -1 });
+        const result = Joi.validate(data, tptSchema);
+        expect(result.error).to.exist();
+      });
+
+      test('the quantity cannot be greater than the maxAnnualQuantity', async () => {
+        const data = getData({ quantity: 4 });
+        const result = Joi.validate(data, tptSchema);
+        expect(result.error).to.exist();
+      });
+
+      test('the quantity can equal the maxAnnualQuantity', async () => {
+        const data = getData({ quantity: 3 });
+        const result = Joi.validate(data, tptSchema);
+        expect(result.error).to.equal(null);
+      });
+
+      test('the quantity can be greater than zero and less that the maxAnnualQuantity', async () => {
+        const data = getData({ quantity: 2 });
+        const result = Joi.validate(data, tptSchema);
+        expect(result.error).to.equal(null);
+      });
+    });
+  });
+});

--- a/test/internal/modules/billing/forms/two-part-tariff-quantity.js
+++ b/test/internal/modules/billing/forms/two-part-tariff-quantity.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const {
+  experiment,
+  test,
+  beforeEach
+} = exports.lab = require('@hapi/lab').script();
+
+const uuid = require('uuid/v4');
+const { expect } = require('@hapi/code');
+const Joi = require('@hapi/joi');
+
+const { schema } = require('../../../../../src/internal/modules/billing/forms/two-part-tariff-quantity');
+
+experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
+  experiment('schema', () => {
+    let transaction;
+    let tptSchema;
+
+    beforeEach(async () => {
+      transaction = {
+        chargeElement: {
+          authorisedAnnualQuantity: 1,
+          billableAnnualQuantity: 2,
+          maxAnnualQuantity: 3
+        }
+      };
+
+      tptSchema = schema(transaction);
+    });
+
+    experiment('csrf_token', () => {
+      test('can be a uuid', async () => {
+        const result = tptSchema.csrf_token.validate(uuid());
+        expect(result.error).to.equal(null);
+      });
+
+      test('cannot be a non uuid', async () => {
+        const result = tptSchema.csrf_token.validate('hello');
+        expect(result.error).to.exist();
+      });
+
+      test('is required', async () => {
+        const result = tptSchema.csrf_token.validate();
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('quantity', () => {
+      test('can be "authorised"', async () => {
+        const result = tptSchema.quantity.validate('authorised');
+        expect(result.error).to.equal(null);
+      });
+
+      test('can be "custom', async () => {
+        const result = tptSchema.quantity.validate('custom');
+        expect(result.error).to.equal(null);
+      });
+
+      test('cannot be another value', async () => {
+        const result = tptSchema.quantity.validate('hello');
+        expect(result.error).to.exist();
+      });
+
+      test('is required', async () => {
+        const result = tptSchema.quantity.validate();
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('customQuantity', () => {
+      const getData = ({ customQuantity }) => ({
+        csrf_token: uuid(),
+        quantity: 'custom',
+        customQuantity
+      });
+
+      experiment('when the quantity is of type "custom', () => {
+        test('the customQuantity cannot be less than 0', async () => {
+          const data = getData({ customQuantity: -1 });
+          const result = Joi.validate(data, tptSchema);
+          expect(result.error).to.exist();
+        });
+
+        test('the customQuantity cannot be greater than the maxAnnualQuantity', async () => {
+          const data = getData({ customQuantity: 4 });
+          const result = Joi.validate(data, tptSchema);
+          expect(result.error).to.exist();
+        });
+
+        test('the customQuantity can equal the maxAnnualQuantity', async () => {
+          const data = getData({ customQuantity: 3 });
+          const result = Joi.validate(data, tptSchema);
+          expect(result.error).to.equal(null);
+        });
+
+        test('the customQuantity can be greater than zero and less that the maxAnnualQuantity', async () => {
+          const data = getData({ customQuantity: 2 });
+          const result = Joi.validate(data, tptSchema);
+          expect(result.error).to.equal(null);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
WATER-2772

When setting a transactions billable quantity use the maxAnnualQuantity
calculated in the water service when validating the user input.

Depends on https://github.com/DEFRA/water-abstraction-service/pull/1079