### PR TITLE
Feat: Non chargeable licence flow

### DIFF
--- a/src/internal/modules/charge-information/forms/index.js
+++ b/src/internal/modules/charge-information/forms/index.js
@@ -1,4 +1,7 @@
+'use strict';
+
 exports.billingAccount = require('./billing-account');
+exports.nonChargeableReason = require('./non-chargeable-reason');
 exports.reason = require('./reason');
 exports.startDate = require('./start-date');
 exports.useAbstractionData = require('./use-abstraction-data');

--- a/src/internal/modules/charge-information/forms/non-chargeable-reason.js
+++ b/src/internal/modules/charge-information/forms/non-chargeable-reason.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { get } = require('lodash');
+const Joi = require('@hapi/joi');
+
+const { formFactory, fields } = require('shared/lib/forms/');
+const routing = require('../lib/routing');
+
+const mapChoice = changeReason => ({
+  value: changeReason.changeReasonId,
+  label: changeReason.description
+});
+
+/**
+ * Select reason for new charge version
+ */
+const selectReasonForm = request => {
+  const { csrfToken } = request.view;
+  const { changeReasons, licence, draftChargeInformation } = request.pre;
+
+  const changeReasonId = get(draftChargeInformation, 'changeReason.changeReasonId');
+
+  const action = routing.getNonChargeableReason(licence);
+
+  const f = formFactory(action, 'POST');
+
+  f.fields.push(fields.radio('reason', {
+    errors: {
+      'any.required': {
+        message: 'Select a reason'
+      }
+    },
+    choices: changeReasons.map(mapChoice)
+  }, changeReasonId));
+
+  f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
+  f.fields.push(fields.button(null, { label: 'Continue' }));
+
+  return f;
+};
+
+const selectReasonSchema = request => {
+  const { changeReasons } = request.pre;
+
+  return {
+    csrf_token: Joi.string().uuid().required(),
+    reason: Joi.string().required().valid(
+      changeReasons.map(changeReason => changeReason.changeReasonId)
+    )
+  };
+};
+
+exports.form = selectReasonForm;
+exports.schema = selectReasonSchema;

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -50,25 +50,46 @@ const minErrors = {
   [MIN_6_YEARS]: "Date must be today or up to six years' in the past"
 };
 
-const getCustomDateField = (dates, value) => fields.date('customDate', {
-  label: 'Start date',
-  errors: {
-    'any.required': {
-      message: 'Enter the charge information start date'
-    },
-    'date.base': {
-      message: 'Enter a real date for the charge information start date'
-    },
-    'date.min': {
-      message: minErrors[dates.minType]
-    },
-    'date.max': {
-      message: 'You must enter a date before the licence end date'
-    }
+const getCommomCustomDateErrors = dates => ({
+  'date.min': {
+    message: minErrors[dates.minType]
+  },
+  'date.max': {
+    message: 'You must enter a date before the licence end date'
   }
+});
+
+const getStartDateCustomDataErrors = dates => ({
+  'any.required': {
+    message: 'Enter the charge information start date'
+  },
+  'date.base': {
+    message: 'Enter a real date for the charge information start date'
+  },
+  ...getCommomCustomDateErrors(dates)
+});
+
+const getEffectiveDateCustomDataErrors = dates => ({
+  'any.required': {
+    message: 'Enter the effective date'
+  },
+  'date.base': {
+    message: 'Enter a real date for the effective date'
+  },
+  ...getCommomCustomDateErrors(dates)
+});
+
+const getCustomStartDateField = (dates, value) => fields.date('customDate', {
+  label: 'Start date',
+  errors: getStartDateCustomDataErrors(dates)
 }, value);
 
-const getChoices = (dates, values, refDate) => {
+const getCustomEffectiveDateField = (dates, value) => fields.date('customDate', {
+  label: 'Effective date',
+  errors: getEffectiveDateCustomDataErrors(dates)
+}, value);
+
+const getChoices = (dates, values, refDate, isChargeable) => {
   const allChoices = [{
     value: 'today',
     label: 'Today',
@@ -85,7 +106,9 @@ const getChoices = (dates, values, refDate) => {
     value: 'customDate',
     label: 'Another date',
     fields: [
-      getCustomDateField(dates, values.customDate)
+      isChargeable
+        ? getCustomStartDateField(dates, values.customDate)
+        : getCustomEffectiveDateField(dates, values.customDate)
     ]
   }];
 
@@ -99,9 +122,16 @@ const getChoices = (dates, values, refDate) => {
  */
 const selectStartDateForm = (request, refDate) => {
   const { csrfToken } = request.view;
-  const { licence } = request.pre;
+  const { licence, isChargeable } = request.pre;
 
-  const action = routing.getStartDate(licence);
+  const action = isChargeable
+    ? routing.getStartDate(licence)
+    : routing.getEffectiveDate(licence);
+
+  const errorMessage = isChargeable
+    ? 'Select charge information start date'
+    : 'Select effective date';
+
   const values = getValues(request, licence, refDate);
   const dates = getDates(licence);
 
@@ -110,10 +140,10 @@ const selectStartDateForm = (request, refDate) => {
   f.fields.push(fields.radio('startDate', {
     errors: {
       'any.required': {
-        message: 'Select charge information start date'
+        message: errorMessage
       }
     },
-    choices: getChoices(dates, values, refDate)
+    choices: getChoices(dates, values, refDate, isChargeable)
   }, values.startDate));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
   f.fields.push(fields.button(null, { label: 'Continue' }));

--- a/src/internal/modules/charge-information/lib/routing.js
+++ b/src/internal/modules/charge-information/lib/routing.js
@@ -1,7 +1,22 @@
-exports.getCheckData = licence => `/licences/${licence.id}/charge-information/check`;
-exports.getCreateBillingAccount = licence => `/licences/${licence.id}/charge-information/billing-account/create`;
-exports.getNonChargeableReason = licence => `/licences/${licence.id}/charge-information/non-chargeable-reason`;
-exports.getReason = licence => `/licences/${licence.id}/charge-information/create`;
-exports.getStartDate = licence => `/licences/${licence.id}/charge-information/start-date`;
-exports.getSelectBillingAccount = licence => `/licences/${licence.id}/charge-information/billing-account`;
-exports.getUseAbstractionData = licence => `/licences/${licence.id}/charge-information/use-abstraction-data`;
+'use strict';
+
+const querystring = require('querystring');
+
+const createUrl = urlTail => licence => {
+  return `/licences/${licence.id}/charge-information/${urlTail}`;
+};
+
+exports.getCheckData = createUrl('check');
+
+exports.getConfirm = (licence, isChargeable) => {
+  const qs = querystring.stringify({ chargeable: isChargeable });
+  return `/licences/${licence.id}/charge-information/confirm?${qs}`;
+};
+
+exports.getCreateBillingAccount = createUrl('billing-account/create');
+exports.getEffectiveDate = createUrl('effective-date');
+exports.getNonChargeableReason = createUrl('non-chargeable-reason');
+exports.getReason = createUrl('create');
+exports.getStartDate = createUrl('start-date');
+exports.getSelectBillingAccount = createUrl('billing-account');
+exports.getUseAbstractionData = createUrl('use-abstraction-data');

--- a/src/internal/modules/charge-information/pre-handlers.js
+++ b/src/internal/modules/charge-information/pre-handlers.js
@@ -39,20 +39,28 @@ const loadDraftChargeInformation = async request => {
   }
 };
 
-/**
- * Loads list of change reasons
- * or a Boom 404 error if not found
- * @param {String} request.params.licenceId - licence ID from water.licences.licence_id
- * @param {Promise<Object>}
- */
-const loadChargeableChangeReasons = async request => {
+const getFilteredChangeReasons = async type => {
   try {
     const response = await services.water.changeReasons.getChangeReasons();
-    return response.data.filter(reason => reason.type === 'new_chargeable_charge_version');
+    return response.data.filter(reason => reason.type === type);
   } catch (err) {
     return errorHandler(err, `Change reasons not found`);
   }
 };
+
+/**
+ * Loads list of chargeable change reasons or a Boom 404 error if not found
+ *
+ * @param {Promise<Object>}
+ */
+const loadChargeableChangeReasons = () => getFilteredChangeReasons('new_chargeable_charge_version');
+
+/**
+ * Loads list of non chargeable change reasons or a Boom 404 error if not found
+ *
+ * @param {Promise<Object>}
+ */
+const loadNonChargeableChangeReasons = () => getFilteredChangeReasons('new_non_chargeable_charge_version');
 
 const loadDefaultCharges = async request => {
   const { licenceId } = request.params;
@@ -82,8 +90,15 @@ const loadBillingAccounts = async request => {
   }
 };
 
+const loadIsChargeable = async request => {
+  const { changeReason } = request.pre.draftChargeInformation;
+  return changeReason.type === 'new_chargeable_charge_version';
+};
+
 exports.loadBillingAccounts = loadBillingAccounts;
 exports.loadChargeableChangeReasons = loadChargeableChangeReasons;
 exports.loadDefaultCharges = loadDefaultCharges;
 exports.loadDraftChargeInformation = loadDraftChargeInformation;
+exports.loadIsChargeable = loadIsChargeable;
 exports.loadLicence = loadLicence;
+exports.loadNonChargeableChangeReasons = loadNonChargeableChangeReasons;

--- a/src/internal/modules/charge-information/routes.js
+++ b/src/internal/modules/charge-information/routes.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const Joi = require('joi');
+
 const controller = require('./controller');
 const preHandlers = require('./pre-handlers');
 const { VALID_GUID } = require('shared/lib/validators');
@@ -87,7 +91,8 @@ module.exports = {
       },
       pre: [
         { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
-        { method: preHandlers.loadLicence, assign: 'licence' }
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' }
       ]
     }
   },
@@ -250,7 +255,8 @@ module.exports = {
       },
       pre: [
         { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
-        { method: preHandlers.loadLicence, assign: 'licence' }
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' }
       ]
     }
   },
@@ -278,6 +284,152 @@ module.exports = {
       },
       pre: [
         { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' }
+      ]
+    }
+  },
+
+  getNonChargeableReason: {
+    method: 'GET',
+    path: '/licences/{licenceId}/charge-information/non-chargeable-reason',
+    handler: controller.getNonChargeableReason,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      description: 'Select a non chargeable reason',
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: {
+          licenceId: VALID_GUID
+        },
+        query: {
+          form: VALID_GUID.optional(),
+          start: Joi.boolean().optional()
+        }
+      },
+      pre: [
+        { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadNonChargeableChangeReasons, assign: 'changeReasons' }
+      ]
+    }
+  },
+
+  postNonChargeableReason: {
+    method: 'POST',
+    path: '/licences/{licenceId}/charge-information/non-chargeable-reason',
+    handler: controller.postNonChargeableReason,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: {
+          licenceId: VALID_GUID
+        },
+        query: {
+          form: VALID_GUID.optional()
+        }
+      },
+      pre: [
+        { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadNonChargeableChangeReasons, assign: 'changeReasons' }
+      ]
+    }
+  },
+
+  getEffectiveDate: {
+    method: 'GET',
+    path: '/licences/{licenceId}/charge-information/effective-date',
+    handler: controller.getEffectiveDate,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      description: 'Select effective date for a non chargeable licence',
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: {
+          licenceId: VALID_GUID
+        },
+        query: {
+          form: VALID_GUID.optional()
+        }
+      },
+      pre: [
+        { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' }
+
+      ]
+    }
+  },
+
+  postEffectiveDate: {
+    method: 'POST',
+    path: '/licences/{licenceId}/charge-information/effective-date',
+    handler: controller.postEffectiveDate,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      description: 'Select effective date for a non chargeable licence',
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: {
+          licenceId: VALID_GUID
+        }
+      },
+      pre: [
+        { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
+        { method: preHandlers.loadLicence, assign: 'licence' }
+      ]
+    }
+  },
+
+  getConfirm: {
+    method: 'GET',
+    path: '/licences/{licenceId}/charge-information/confirm',
+    handler: controller.getConfirm,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      description: 'Confirmation page for the end of the charge information flow',
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: {
+          licenceId: VALID_GUID
+        },
+        query: {
+          chargeable: Joi.boolean().default(false).optional()
+        }
+      },
+      pre: [
         { method: preHandlers.loadLicence, assign: 'licence' }
       ]
     }

--- a/src/internal/views/nunjucks/charge-information/check.njk
+++ b/src/internal/views/nunjucks/charge-information/check.njk
@@ -3,10 +3,21 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "crm/address.njk" import address %}
 
-{% macro summaryListRow(key, value) %}
+{% macro actions(licence, page, rowKey) %}
+  <dd class="govuk-summary-list__actions">
+    <a class="govuk-link" href="/licences/{{ licence.id }}/charge-information/{{ page}}">
+      Change<span class="govuk-visually-hidden"> {{ rowKey | lower }}</span>
+    </a>
+  </dd>
+{% endmacro %}
+
+{% macro summaryListRow(key, value, licence, page) %}
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">{{ key }}</dt>
     <dd class="govuk-summary-list__value">{{ value }}</dd>
+    {% if licence %}
+      {{actions(licence, page, key) }}
+    {% endif %}
   </div>
 {% endmacro %}
 
@@ -14,62 +25,92 @@
   {{ period.startDate | date }} to {{ period.endDate | date }}
 {% endmacro %}
 
+{% macro chargeableData(drafChargeInformation, invoiceAccountAddress) %}
+  <section class="govuk-!-margin-bottom-7">
+    <dl class="govuk-summary-list">
+      {{ summaryListRow('Reason', draftChargeInformation.changeReason.description)}}
+      {{ summaryListRow('Start date', draftChargeInformation.startDate | date )}}
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Billing account</dt>
+        <dd class="govuk-summary-list__value">
+          {{ draftChargeInformation.billingAccount.billingAccount.accountNumber }}
+          <br>
+          {{ address(invoiceAccountAddress.address) }}
+        </dd>
+      </div>
+
+      {{ summaryListRow('Licence holder', draftChargeInformation.billingAccount.billingAccount.company.name) }}
+    </dl>
+  </section>
+
+  {% for chargeElement in draftChargeInformation.abstractionData %}
+    <section class="govuk-!-margin-bottom-7">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Element {{loop.index}}</h2>
+      <dl class="govuk-summary-list">
+        {{ summaryListRow('Purpose', chargeElement.purposeUse.name) }}
+        {{ summaryListRow('Description', chargeElement.description) }}
+        {{ summaryListRow('Abstraction period', chargeElement.abstractionPeriod | abstractionPeriod) }}
+        {{ summaryListRow('Authorised quantity', chargeElement.authorisedAnnualQuantity + ' megalitres per year') }}
+
+        {% set billableQuantity = 'Not set' %}
+        {% if chargeElement.billableAnnualQuantity %}
+          {% set billableQuantity = chargeElement.billableAnnualQuantity %}
+        {% endif %}
+        {{ summaryListRow('Billable quantity', billableQuantity) }}
+
+        {% set timeLimited = 'No' %}
+        {% if chargeElement.timeLimitedPeriod %}
+          {% set timeLimited %}
+            {{ timeLimitedPeriod(chargeElement.timeLimitedPeriod) }}
+          {% endset %}
+        {% endif %}
+        {{ summaryListRow('Time limit', timeLimited) }}
+
+        {{ summaryListRow('Source', chargeElement.source | title) }}
+        {{ summaryListRow('Season', chargeElement.season | title) }}
+        {{ summaryListRow('Loss', chargeElement.loss | title) }}
+        {{ summaryListRow('Environmental Improvement Unit Charge', chargeElement.eiucSource | title) }}
+      </dl>
+    </section>
+  {% endfor %}
+{% endmacro %}
+
+{% macro nonChargeableData(drafChargeInformation, licence) %}
+  <section class="govuk-!-margin-bottom-7">
+    <dl class="govuk-summary-list">
+      {{ summaryListRow(
+        'Reason licence is not chargeable',
+        draftChargeInformation.changeReason.description,
+        licence,
+        'non-chargeable-reason')
+      }}
+      {{ summaryListRow(
+        'Effective date',
+        draftChargeInformation.startDate | date,
+        licence,
+        'effective-date')
+      }}
+    </dl>
+  </section>
+{% endmacro %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ title(pageTitle, caption, null, true) }}
     </div>
-    <div class="govuk-grid-column-full">
-      <section class="govuk-!-margin-bottom-7">
+
+    {% if isChargeable %}
+      <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Charge information</h2>
-        <dl class="govuk-summary-list">
-          {{ summaryListRow('Reason', draftChargeInformation.changeReason.description)}}
-          {{ summaryListRow('Start date', draftChargeInformation.startDate | date )}}
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Billing account</dt>
-            <dd class="govuk-summary-list__value">
-              {{ draftChargeInformation.billingAccount.billingAccount.accountNumber }}
-              <br>
-              {{ address(invoiceAccountAddress.address) }}
-            </dd>
-          </div>
-
-          {{ summaryListRow('Licence holder', draftChargeInformation.billingAccount.billingAccount.company.name) }}
-        </dl>
-      </section>
-
-      {% for chargeElement in draftChargeInformation.abstractionData %}
-        <section class="govuk-!-margin-bottom-7">
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Element {{loop.index}}</h2>
-          <dl class="govuk-summary-list">
-            {{ summaryListRow('Purpose', chargeElement.purposeUse.name) }}
-            {{ summaryListRow('Description', chargeElement.description) }}
-            {{ summaryListRow('Abstraction period', chargeElement.abstractionPeriod | abstractionPeriod) }}
-            {{ summaryListRow('Authorised quantity', chargeElement.authorisedAnnualQuantity + ' megalitres per year') }}
-
-            {% set billableQuantity = 'Not set' %}
-            {% if chargeElement.billableAnnualQuantity %}
-              {% set billableQuantity = chargeElement.billableAnnualQuantity %}
-            {% endif %}
-            {{ summaryListRow('Billable quantity', billableQuantity) }}
-
-            {% set timeLimited = 'No' %}
-            {% if chargeElement.timeLimitedPeriod %}
-              {% set timeLimited %}
-                {{ timeLimitedPeriod(chargeElement.timeLimitedPeriod) }}
-              {% endset %}
-            {% endif %}
-            {{ summaryListRow('Time limit', timeLimited) }}
-
-            {{ summaryListRow('Source', chargeElement.source | title) }}
-            {{ summaryListRow('Season', chargeElement.season | title) }}
-            {{ summaryListRow('Loss', chargeElement.loss | title) }}
-            {{ summaryListRow('Environmental Improvement Unit Charge', chargeElement.eiucSource | title) }}
-          </dl>
-        </section>
-      {% endfor %}
-    </div>
+        {{ chargeableData(draftChargeInformation, invoiceAccountAddress)}}
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds">
+        {{ nonChargeableData(draftChargeInformation, licence)}}
+      </div>
+    {% endif %}
   </div>
 
   <div class="govuk-grid-row">

--- a/src/internal/views/nunjucks/charge-information/confirm.njk
+++ b/src/internal/views/nunjucks/charge-information/confirm.njk
@@ -1,0 +1,54 @@
+{% extends "./nunjucks/layout.njk" %}
+{% from "title.njk" import title %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "crm/address.njk" import address %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <span class="govuk-caption-l">{{ caption }}</span>
+      {{ govukPanel({ titleText: "Charge information complete" }) }}
+
+      <section class="govuk-!-margin-bottom-9">
+        <h2 class="govuk-heading-l">What happens next</h2>
+        <p class="govuk-body">
+          The Billing and Data team will review the charge information.
+        </p>
+
+        <h3 class="govuk-heading-m">If Billing and Data need you to make changes</h3>
+        <p class="govuk-body">
+          The status will be ‘Draft’. Select 'Review' to see details of the
+          changes you need to make.
+        </p>
+
+        <h3 class="govuk-heading-m">If Billing and Data approve the licence for billing</h3>
+        <p class="govuk-body">
+          The charge information will be listed in the
+          licence's charge information tab and the status will be ‘Active’.
+        </p>
+        <p class="govuk-body">
+          <a href="{{ licenceUrl }}" class="govuk-link">View charge information</a>
+        </p>
+      </section>
+
+      {% if isChargeable %}
+        <section>
+          <h3 class="govuk-heading-m">Licence agreements</h3>
+          <p class="govuk-body">
+            If this licence has an agreement you can set this up now.
+          </p>
+          {{ govukButton({
+            text: "Set up new agreement",
+            classes: "govuk-button--secondary",
+            href: "/licences/" + licence.id + "/agreements/create"
+          }) }}
+        </section>
+      {% endif %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -75,7 +75,7 @@
     </tbody>
   </table>
 
-  {# <a href="/licences/{{ licenceId }}/charge-versions/create"
+  <a href="/licences/{{ licenceId }}/charge-information/create"
     role="button"
     draggable="false"
     class="govuk-button govuk-!-margin-right-3"
@@ -83,13 +83,13 @@
     Setup a new charge
   </a>
 
-  <a href="/licences/{{ licenceId }}/make-non-chargeable"
+  <a href="/licences/{{ licenceId }}/charge-information/non-chargeable-reason?start=true"
     role="button"
     draggable="false"
     class="govuk-button govuk-button--secondary"
     data-module="govuk-button">
     Make licence non-chargeable
-  </a> #}
+  </a>
 {% else %}
   <p>No charge information for this licence.</p>
 {% endif %}

--- a/test/internal/modules/charge-information/forms/non-chargeable-reason.js
+++ b/test/internal/modules/charge-information/forms/non-chargeable-reason.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { expect } = require('@hapi/code');
+const { experiment, test } = exports.lab = require('@hapi/lab').script();
+
+const { form, schema } = require('internal/modules/charge-information/forms/non-chargeable-reason');
+const { findField, findButton } = require('../../../../lib/form-test');
+
+const createRequest = () => ({
+  view: {
+    csrfToken: 'token'
+  },
+  pre: {
+    licence: {
+      id: 'test-licence-id'
+    },
+    changeReasons: [
+      { changeReasonId: 'test-id-1', description: 'test-desc-1' },
+      { changeReasonId: 'test-id-2', description: 'test-desc-2' }
+    ],
+    draftChargeInformation: {}
+  }
+});
+
+experiment('internal/modules/charge-information/forms/non-chargeable-reason', () => {
+  experiment('form', () => {
+    test('sets the form method to POST', async () => {
+      const nonChargeableForm = form(createRequest());
+      expect(nonChargeableForm.method).to.equal('POST');
+    });
+
+    test('has CSRF token field', async () => {
+      const nonChargeableForm = form(createRequest());
+      const csrf = findField(nonChargeableForm, 'csrf_token');
+      expect(csrf.value).to.equal('token');
+    });
+
+    test('has a submit button', async () => {
+      const nonChargeableForm = form(createRequest());
+      const button = findButton(nonChargeableForm);
+      expect(button.options.label).to.equal('Continue');
+    });
+
+    test('has a choices for the non chargeable reasons', async () => {
+      const nonChargeableForm = form(createRequest());
+      const radio = findField(nonChargeableForm, 'reason');
+
+      expect(radio.options.choices[0].value).to.equal('test-id-1');
+      expect(radio.options.choices[0].label).to.equal('test-desc-1');
+      expect(radio.options.choices[1].value).to.equal('test-id-2');
+      expect(radio.options.choices[1].label).to.equal('test-desc-2');
+    });
+  });
+
+  experiment('schema', () => {
+    experiment('csrf token', () => {
+      test('validates for a uuid', async () => {
+        const result = schema(createRequest()).csrf_token.validate('c5afe238-fb77-4131-be80-384aaf245842');
+        expect(result.error).to.be.null();
+      });
+
+      test('fails for a string that is not a uuid', async () => {
+        const result = schema(createRequest()).csrf_token.validate('pizza');
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('reason', () => {
+      test('can be an id from the pre handler charge reasons', async () => {
+        const result = schema(createRequest()).reason.validate('test-id-1');
+        expect(result.error).to.not.exist();
+      });
+
+      test('cannot be a unexpected string be true', async () => {
+        const result = schema(createRequest()).reason.validate('pizza');
+        expect(result.error).to.exist();
+      });
+    });
+  });
+});

--- a/test/internal/modules/charge-information/forms/start-date.js
+++ b/test/internal/modules/charge-information/forms/start-date.js
@@ -1,0 +1,230 @@
+'use strict';
+
+const { expect } = require('@hapi/code');
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const uuid = require('uuid/v4');
+const Joi = require('joi');
+
+const { form, schema } = require('internal/modules/charge-information/forms/start-date');
+const { findField, findButton } = require('../../../../lib/form-test');
+
+const createRequest = isChargeable => ({
+  view: {
+    csrfToken: 'token'
+  },
+  pre: {
+    licence: {
+      id: 'test-licence-id',
+      startDate: '2020-02-02',
+      endDate: '2020-12-02'
+    },
+    isChargeable,
+    draftChargeInformation: {}
+  }
+});
+
+experiment('internal/modules/charge-information/forms/start-date', () => {
+  experiment('form', () => {
+    experiment('when the licence is set to be chargeable', () => {
+      let dateForm;
+
+      beforeEach(async () => {
+        dateForm = form(createRequest(true));
+      });
+
+      test('sets the form method to POST', async () => {
+        expect(dateForm.method).to.equal('POST');
+      });
+
+      test('the action submits back to the expected url', async () => {
+        expect(dateForm.action).to.equal('/licences/test-licence-id/charge-information/start-date');
+      });
+
+      test('has CSRF token field', async () => {
+        const csrf = findField(dateForm, 'csrf_token');
+        expect(csrf.value).to.equal('token');
+      });
+
+      test('has a submit button', async () => {
+        const button = findButton(dateForm);
+        expect(button.options.label).to.equal('Continue');
+      });
+
+      experiment('date choices', () => {
+        test('has option for today', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[0].label).to.equal('Today');
+        });
+
+        test('has option for licence start date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[1].label).to.equal('Licence start date');
+          expect(radio.options.choices[1].hint).to.equal('2 February 2020');
+        });
+
+        test('has option for custom date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[3].label).to.equal('Another date');
+        });
+
+        test('has start date based errors for the custom date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          const errors = radio.options.choices[3].fields[0].options.errors;
+
+          expect(errors['any.required'].message).to.equal('Enter the charge information start date');
+          expect(errors['date.base'].message).to.equal('Enter a real date for the charge information start date');
+          expect(errors['date.min'].message).to.equal('You must enter a date after the licence start date');
+          expect(errors['date.max'].message).to.equal('You must enter a date before the licence end date');
+        });
+      });
+    });
+
+    experiment('when the licence is set to be non-chargeable', () => {
+      let dateForm;
+
+      beforeEach(async () => {
+        dateForm = form(createRequest(false));
+      });
+
+      test('sets the form method to POST', async () => {
+        expect(dateForm.method).to.equal('POST');
+      });
+
+      test('the action submits back to the expected url', async () => {
+        expect(dateForm.action).to.equal('/licences/test-licence-id/charge-information/effective-date');
+      });
+
+      test('has CSRF token field', async () => {
+        const csrf = findField(dateForm, 'csrf_token');
+        expect(csrf.value).to.equal('token');
+      });
+
+      test('has a submit button', async () => {
+        const button = findButton(dateForm);
+        expect(button.options.label).to.equal('Continue');
+      });
+
+      experiment('date choices', () => {
+        test('has option for today', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[0].label).to.equal('Today');
+        });
+
+        test('has option for licence start date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[1].label).to.equal('Licence start date');
+          expect(radio.options.choices[1].hint).to.equal('2 February 2020');
+        });
+
+        test('has option for custom date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          expect(radio.options.choices[3].label).to.equal('Another date');
+        });
+
+        test('has start date based errors for the custom date', async () => {
+          const radio = findField(dateForm, 'startDate');
+          const errors = radio.options.choices[3].fields[0].options.errors;
+
+          expect(errors['any.required'].message).to.equal('Enter the effective date');
+          expect(errors['date.base'].message).to.equal('Enter a real date for the effective date');
+          expect(errors['date.min'].message).to.equal('You must enter a date after the licence start date');
+          expect(errors['date.max'].message).to.equal('You must enter a date before the licence end date');
+        });
+      });
+    });
+  });
+
+  experiment('schema', () => {
+    let dateSchema;
+
+    beforeEach(async () => {
+      dateSchema = schema(createRequest(true));
+    });
+
+    experiment('csrf token', () => {
+      test('validates for a uuid', async () => {
+        const result = dateSchema.csrf_token.validate('c5afe238-fb77-4131-be80-384aaf245842');
+        expect(result.error).to.be.null();
+      });
+
+      test('fails for a string that is not a uuid', async () => {
+        const result = dateSchema.csrf_token.validate('pizza');
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('startDate', () => {
+      test('can be an today', async () => {
+        const result = dateSchema.startDate.validate('today');
+        expect(result.error).to.not.exist();
+      });
+
+      test('can be an licenceStartDate', async () => {
+        const result = dateSchema.startDate.validate('licenceStartDate');
+        expect(result.error).to.not.exist();
+      });
+
+      test('can be an customDate', async () => {
+        const result = dateSchema.startDate.validate('customDate');
+        expect(result.error).to.not.exist();
+      });
+
+      test('cannot be an unexpected value', async () => {
+        const result = dateSchema.startDate.validate('pizza');
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('customDate', () => {
+      test('can be the start date', async () => {
+        const data = {
+          csrf_token: uuid(),
+          startDate: 'customDate',
+          customDate: '2020-02-02'
+        };
+        const result = Joi.validate(data, dateSchema);
+        expect(result.error).to.not.exist();
+      });
+
+      test('can be the end date', async () => {
+        const data = {
+          csrf_token: uuid(),
+          startDate: 'customDate',
+          customDate: '2020-12-02'
+        };
+        const result = Joi.validate(data, dateSchema);
+        expect(result.error).to.not.exist();
+      });
+
+      test('can be between the start and end date', async () => {
+        const data = {
+          csrf_token: uuid(),
+          startDate: 'customDate',
+          customDate: '2020-11-02'
+        };
+        const result = Joi.validate(data, dateSchema);
+        expect(result.error).to.not.exist();
+      });
+
+      test('cannot be before the licence start date', async () => {
+        const data = {
+          csrf_token: uuid(),
+          startDate: 'customDate',
+          customDate: '2010-11-02'
+        };
+        const result = Joi.validate(data, dateSchema);
+        expect(result.error).to.exist();
+      });
+
+      test('cannot be after the licence end date', async () => {
+        const data = {
+          csrf_token: uuid(),
+          startDate: 'customDate',
+          customDate: '2030-11-02'
+        };
+        const result = Joi.validate(data, dateSchema);
+        expect(result.error).to.exist();
+      });
+    });
+  });
+});

--- a/test/internal/modules/charge-information/lib/routing.js
+++ b/test/internal/modules/charge-information/lib/routing.js
@@ -25,10 +25,29 @@ experiment('internal/modules/charge-information/lib/routing', () => {
     });
   });
 
+  experiment('.getConfirm', () => {
+    test('returns the correct url for when chargeable', async () => {
+      const url = routing.getConfirm(licence, true);
+      expect(url).to.equal('/licences/test-licence-id/charge-information/confirm?chargeable=true');
+    });
+
+    test('returns the correct url for when non-chargeable', async () => {
+      const url = routing.getConfirm(licence, false);
+      expect(url).to.equal('/licences/test-licence-id/charge-information/confirm?chargeable=false');
+    });
+  });
+
   experiment('.getCreateBillingAccount', () => {
     test('returns the corrent url', async () => {
       const url = routing.getCreateBillingAccount(licence);
       expect(url).to.equal('/licences/test-licence-id/charge-information/billing-account/create');
+    });
+  });
+
+  experiment('.getEffectiveDate', () => {
+    test('returns the correct url', async () => {
+      const url = routing.getEffectiveDate(licence);
+      expect(url).to.equal('/licences/test-licence-id/charge-information/effective-date');
     });
   });
 

--- a/test/internal/modules/charge-information/pre-handlers.js
+++ b/test/internal/modules/charge-information/pre-handlers.js
@@ -38,6 +38,10 @@ experiment('internal/modules/charge-information/pre-handlers', () => {
         {
           changeReasonId: 'test-change-reason-id-2',
           type: 'new_non_chargeable_charge_version'
+        },
+        {
+          changeReasonId: 'test-change-reason-id-3',
+          type: 'new_non_chargeable_charge_version'
         }
       ]
     });
@@ -211,6 +215,54 @@ experiment('internal/modules/charge-information/pre-handlers', () => {
     });
   });
 
+  experiment('loadNonChargeableChangeReasons', () => {
+    experiment('when data is found', () => {
+      beforeEach(async () => {
+        result = await preHandlers.loadNonChargeableChangeReasons(request);
+      });
+
+      test('the service method is called', async () => {
+        expect(
+          services.water.changeReasons.getChangeReasons.called
+        ).to.be.true();
+      });
+
+      test('resolves with reasons data', async () => {
+        expect(result).to.be.an.array().length(2);
+        expect(result[0].changeReasonId).to.equal('test-change-reason-id-2');
+        expect(result[1].changeReasonId).to.equal('test-change-reason-id-3');
+      });
+    });
+
+    experiment('when the data is not found', () => {
+      beforeEach(async () => {
+        const err = new Error();
+        err.statusCode = 404;
+        services.water.changeReasons.getChangeReasons.rejects(err);
+        result = await preHandlers.loadNonChargeableChangeReasons(request);
+      });
+
+      test('resolves with a Boom 404 error', async () => {
+        expect(result.isBoom).to.be.true();
+        expect(result.output.statusCode).to.equal(404);
+        expect(result.message).to.equal('Change reasons not found');
+      });
+    });
+
+    experiment('for other errors', () => {
+      beforeEach(async () => {
+        const err = new Error('Oh no!');
+        services.water.changeReasons.getChangeReasons.rejects(err);
+      });
+
+      test('rejects with the error', async () => {
+        const func = () => preHandlers.loadNonChargeableChangeReasons(request);
+        const err = await expect(func()).to.reject();
+        expect(err.message).to.equal('Oh no!');
+      });
+    });
+  });
+
   experiment('loadDefaultCharges', () => {
     experiment('when data is found', () => {
       beforeEach(async () => {
@@ -308,6 +360,36 @@ experiment('internal/modules/charge-information/pre-handlers', () => {
         const err = await expect(func()).to.reject();
         expect(err.message).to.equal('Oh no!');
       });
+    });
+  });
+
+  experiment('loadIsChargeable', () => {
+    test('returns true if the change reason is new_chargeable_charge_version', async () => {
+      request.pre = {
+        draftChargeInformation: {
+          changeReason: {
+            type: 'new_chargeable_charge_version'
+          }
+        }
+      };
+
+      result = await preHandlers.loadIsChargeable(request);
+
+      expect(result).to.equal(true);
+    });
+
+    test('returns true if the change reason is new_non_chargeable_charge_version', async () => {
+      request.pre = {
+        draftChargeInformation: {
+          changeReason: {
+            type: 'new_non_chargeable_charge_version'
+          }
+        }
+      };
+
+      result = await preHandlers.loadIsChargeable(request);
+
+      expect(result).to.equal(false);
     });
   });
 });

--- a/test/internal/modules/charge-information/routes.js
+++ b/test/internal/modules/charge-information/routes.js
@@ -42,6 +42,7 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.getReason.options.pre.length).to.equal(3);
       expect(routes.getReason.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getReason.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getReason.options.pre[1].method).to.equal(preHandlers.loadLicence);
@@ -78,12 +79,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
-      expect(routes.getReason.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
-      expect(routes.getReason.options.pre[0].assign).to.equal('draftChargeInformation');
-      expect(routes.getReason.options.pre[1].method).to.equal(preHandlers.loadLicence);
-      expect(routes.getReason.options.pre[1].assign).to.equal('licence');
-      expect(routes.getReason.options.pre[2].method).to.equal(preHandlers.loadChargeableChangeReasons);
-      expect(routes.getReason.options.pre[2].assign).to.equal('changeReasons');
+      expect(routes.postReason.options.pre.length).to.equal(3);
+      expect(routes.postReason.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
+      expect(routes.postReason.options.pre[0].assign).to.equal('draftChargeInformation');
+      expect(routes.postReason.options.pre[1].method).to.equal(preHandlers.loadLicence);
+      expect(routes.postReason.options.pre[1].assign).to.equal('licence');
+      expect(routes.postReason.options.pre[2].method).to.equal(preHandlers.loadChargeableChangeReasons);
+      expect(routes.postReason.options.pre[2].assign).to.equal('changeReasons');
     });
   });
 
@@ -112,10 +114,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.getStartDate.options.pre.length).to.equal(3);
       expect(routes.getStartDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getStartDate.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getStartDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.getStartDate.options.pre[1].assign).to.equal('licence');
+      expect(routes.getStartDate.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
+      expect(routes.getStartDate.options.pre[2].assign).to.equal('isChargeable');
     });
   });
 
@@ -146,6 +151,7 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.postStartDate.options.pre.length).to.equal(2);
       expect(routes.postStartDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.postStartDate.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.postStartDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
@@ -178,10 +184,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.getSelectBillingAccount.options.pre.length).to.equal(3);
       expect(routes.getSelectBillingAccount.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getSelectBillingAccount.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getSelectBillingAccount.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.getSelectBillingAccount.options.pre[1].assign).to.equal('licence');
+      expect(routes.getSelectBillingAccount.options.pre[2].method).to.equal(preHandlers.loadBillingAccounts);
+      expect(routes.getSelectBillingAccount.options.pre[2].assign).to.equal('billingAccounts');
     });
   });
 
@@ -212,10 +221,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.postSelectBillingAccount.options.pre.length).to.equal(3);
       expect(routes.postSelectBillingAccount.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.postSelectBillingAccount.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.postSelectBillingAccount.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.postSelectBillingAccount.options.pre[1].assign).to.equal('licence');
+      expect(routes.postSelectBillingAccount.options.pre[2].method).to.equal(preHandlers.loadBillingAccounts);
+      expect(routes.postSelectBillingAccount.options.pre[2].assign).to.equal('billingAccounts');
     });
   });
 
@@ -244,6 +256,7 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.getUseAbstractionData.options.pre.length).to.equal(2);
       expect(routes.getUseAbstractionData.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getUseAbstractionData.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getUseAbstractionData.options.pre[1].method).to.equal(preHandlers.loadLicence);
@@ -278,10 +291,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.postUseAbstractionData.options.pre.length).to.equal(3);
       expect(routes.postUseAbstractionData.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.postUseAbstractionData.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.postUseAbstractionData.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.postUseAbstractionData.options.pre[1].assign).to.equal('licence');
+      expect(routes.postUseAbstractionData.options.pre[2].method).to.equal(preHandlers.loadDefaultCharges);
+      expect(routes.postUseAbstractionData.options.pre[2].assign).to.equal('defaultCharges');
     });
   });
 
@@ -310,10 +326,13 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.getCheckData.options.pre.length).to.equal(3);
       expect(routes.getCheckData.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getCheckData.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getCheckData.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.getCheckData.options.pre[1].assign).to.equal('licence');
+      expect(routes.getCheckData.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
+      expect(routes.getCheckData.options.pre[2].assign).to.equal('isChargeable');
     });
   });
 
@@ -344,10 +363,204 @@ experiment('internal/modules/charge-information/routes', () => {
     });
 
     test('has the expected pre handlers', async () => {
+      expect(routes.postCheckData.options.pre.length).to.equal(3);
       expect(routes.postCheckData.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.postCheckData.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.postCheckData.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.postCheckData.options.pre[1].assign).to.equal('licence');
+      expect(routes.postCheckData.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
+      expect(routes.postCheckData.options.pre[2].assign).to.equal('isChargeable');
+    });
+  });
+
+  experiment('getNonChargeableReason', () => {
+    beforeEach(async () => {
+      licenceId = uuid();
+      server = testHelpers.getTestServer(routes.getNonChargeableReason);
+    });
+
+    test('allows a uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/non-chargeable-reason`
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('does not allow a non uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/test-non-uuid-licence-id/charge-information/non-chargeable-reason`
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('allows an optional start query param which is boolean', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/non-chargeable-reason?start=true`
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('has the expected pre handlers', async () => {
+      expect(routes.getNonChargeableReason.options.pre.length).to.equal(3);
+      expect(routes.getNonChargeableReason.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
+      expect(routes.getNonChargeableReason.options.pre[0].assign).to.equal('draftChargeInformation');
+      expect(routes.getNonChargeableReason.options.pre[1].method).to.equal(preHandlers.loadLicence);
+      expect(routes.getNonChargeableReason.options.pre[1].assign).to.equal('licence');
+      expect(routes.getNonChargeableReason.options.pre[2].method).to.equal(preHandlers.loadNonChargeableChangeReasons);
+      expect(routes.getNonChargeableReason.options.pre[2].assign).to.equal('changeReasons');
+    });
+  });
+
+  experiment('postNonChargeableReason', () => {
+    beforeEach(async () => {
+      licenceId = uuid();
+      server = testHelpers.getTestServer(routes.postNonChargeableReason);
+    });
+
+    test('allows a uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/non-chargeable-reason`,
+        method: 'POST'
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('does not allow a non uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/test-non-uuid-licence-id/charge-information/non-chargeable-reason`,
+        method: 'POST'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('has the expected pre handlers', async () => {
+      expect(routes.postNonChargeableReason.options.pre.length).to.equal(3);
+      expect(routes.postNonChargeableReason.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
+      expect(routes.postNonChargeableReason.options.pre[0].assign).to.equal('draftChargeInformation');
+      expect(routes.postNonChargeableReason.options.pre[1].method).to.equal(preHandlers.loadLicence);
+      expect(routes.postNonChargeableReason.options.pre[1].assign).to.equal('licence');
+      expect(routes.postNonChargeableReason.options.pre[2].method).to.equal(preHandlers.loadNonChargeableChangeReasons);
+      expect(routes.postNonChargeableReason.options.pre[2].assign).to.equal('changeReasons');
+    });
+  });
+
+  experiment('getEffectiveDate', () => {
+    beforeEach(async () => {
+      licenceId = uuid();
+      server = testHelpers.getTestServer(routes.getEffectiveDate);
+    });
+
+    test('allows a uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/effective-date`
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('does not allow a non uuid for the licence id', async () => {
+      const request = {
+        url: '/licences/test-non-uuid-licence-id/charge-information/effective-date'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('has the expected pre handlers', async () => {
+      expect(routes.getEffectiveDate.options.pre.length).to.equal(3);
+      expect(routes.getEffectiveDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
+      expect(routes.getEffectiveDate.options.pre[0].assign).to.equal('draftChargeInformation');
+      expect(routes.getEffectiveDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
+      expect(routes.getEffectiveDate.options.pre[1].assign).to.equal('licence');
+      expect(routes.getEffectiveDate.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
+      expect(routes.getEffectiveDate.options.pre[2].assign).to.equal('isChargeable');
+    });
+  });
+
+  experiment('postEffectiveDate', () => {
+    beforeEach(async () => {
+      licenceId = uuid();
+      server = testHelpers.getTestServer(routes.postEffectiveDate);
+    });
+
+    test('allows a uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/effective-date`,
+        method: 'POST'
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('does not allow a non uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/test-non-uuid-licence-id/charge-information/effective-date`,
+        method: 'POST'
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('has the expected pre handlers', async () => {
+      expect(routes.postEffectiveDate.options.pre.length).to.equal(2);
+      expect(routes.postEffectiveDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
+      expect(routes.postEffectiveDate.options.pre[0].assign).to.equal('draftChargeInformation');
+      expect(routes.postEffectiveDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
+      expect(routes.postEffectiveDate.options.pre[1].assign).to.equal('licence');
+    });
+  });
+
+  experiment('getConfirm', () => {
+    beforeEach(async () => {
+      licenceId = uuid();
+      server = testHelpers.getTestServer(routes.getConfirm);
+    });
+
+    test('allows a uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/confirm`
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('does not allow a non uuid for the licence id', async () => {
+      const request = {
+        url: `/licences/test-non-uuid-licence-id/charge-information/confirm`
+      };
+
+      const response = await server.inject(request);
+      expect(response.statusCode).to.equal(400);
+    });
+
+    test('allows an optional chargeable query param which is boolean', async () => {
+      const request = {
+        url: `/licences/${licenceId}/charge-information/confirm?chargeable=true`
+      };
+
+      const response = await server.inject(request);
+      expect(response.payload).to.equal('Test handler');
+    });
+
+    test('has the expected pre handlers', async () => {
+      expect(routes.getConfirm.options.pre.length).to.equal(1);
+      expect(routes.getConfirm.options.pre[0].method).to.equal(preHandlers.loadLicence);
+      expect(routes.getConfirm.options.pre[0].assign).to.equal('licence');
     });
   });
 });


### PR DESCRIPTION
WATER-2689

Updates the UI to enable the non chargeable licence flow from the charge
information tab.

Makes the start-date form dual purpose, now capturing either the start
date of a new charge version, or the effective date for a non chargeable
charge version.

Depends on https://github.com/DEFRA/water-abstraction-service/pull/1144