### PR TITLE
Bigfix - Non charge flow - start date is required with custom start date selected

### DIFF
--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -161,7 +161,7 @@ const selectStartDateSchema = (request) => {
     startDate: Joi.string().valid('today', 'licenceStartDate', 'customDate').required(),
     customDate: Joi.when('startDate', {
       is: 'customDate',
-      then: Joi.date().min(dates.minDate).max(dates.maxDate)
+      then: Joi.date().min(dates.minDate).max(dates.maxDate).required()
     })
   };
 };


### PR DESCRIPTION
bugfix/non-charge-flow
-- added Joi.required() to the start date form when custom date selected