### PR TITLE
Reg pack/internal password reset fork

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -185,6 +185,11 @@ jobs:
         with:
           redis-version: 6
 
+      - name: Sleep for 15 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '15s'
+          
       - name: Start pm2
         run: |
           cd water-abstraction-permit-repository && pm2 start ecosystem.config.json && cd ..
@@ -193,7 +198,12 @@ jobs:
           cd water-abstraction-tactical-idm && pm2 start ecosystem.config.json && cd ..
           cd water-abstraction-returns && pm2 start ecosystem.config.json && cd ..
           cd water-abstraction-import && pm2 start ecosystem.config.json && cd ..
-          pm2 start ecosystem.config.json
+          pm2 start ecosystem.config.json --env production
+
+      - name: Sleep for 15 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '15s'
 
       - name: Run regression tests
         run: |

--- a/test/regression/external/helpers/loginAsUser.js
+++ b/test/regression/external/helpers/loginAsUser.js
@@ -2,7 +2,7 @@ const { baseUrl } = require('../config');
 /* eslint-disable no-undef */
 
 const loginAsUser = async () => {
-  await browser.url(`${baseUrl}/signin`);
+  await browser.url(`http://127.0.0.1:8000/signin`);
 
   let emailField = await $('#email');
   await emailField.setValue('acceptance-test.external@example.com');

--- a/test/regression/external/helpers/loginAsUser.js
+++ b/test/regression/external/helpers/loginAsUser.js
@@ -2,7 +2,7 @@ const { baseUrl } = require('../config');
 /* eslint-disable no-undef */
 
 const loginAsUser = async () => {
-  await browser.url(`http://127.0.0.1:8000/signin`);
+  await browser.url(`${baseUrl}/signin`);
 
   let emailField = await $('#email');
   await emailField.setValue('acceptance-test.external@example.com');

--- a/test/regression/external/reset-password.spec.js
+++ b/test/regression/external/reset-password.spec.js
@@ -9,7 +9,7 @@ const EMAIL_ADDRESS = 'acceptance-test.external@example.com';
 /* eslint-disable no-undef */
 describe('external user resetting their password:', function () {
   before(async () => {
-    await browser.url(baseUrl);
+    await browser.url(`${baseUrl}/signin`);
   });
 
   it('navigate to the reset your password page', async () => {
@@ -29,20 +29,24 @@ describe('external user resetting their password:', function () {
   it('shows a validation message if the email field is empty', async () => {
     const email = await $('#email');
     const continueButton = await getButton('Continue');
-    const validationMessage = await getValidationSummaryMessage();
 
     email.setValue('');
-    continueButton.click();
-    expect(validationMessage).toHaveText('Enter an email address in the right format');
+    await continueButton.click();
+    browser.pause(1000);
+
+    const validationMessage = await getValidationSummaryMessage();
+    expect(validationMessage).toHaveText('Enter an email address');
   });
 
   it('shows a validation message if the email field is invalid', async () => {
     const email = await $('input#email');
     const continueButton = await getButton('Continue');
-    const validationMessage = await getValidationSummaryMessage();
 
     email.setValue('not-an-email-address');
-    continueButton.click();
+    await continueButton.click();
+    browser.pause(1000);
+
+    const validationMessage = await getValidationSummaryMessage();
     expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 

--- a/test/regression/external/reset-password.spec.js
+++ b/test/regression/external/reset-password.spec.js
@@ -12,7 +12,7 @@ describe('external user resetting their password:', function () {
   before(async () => {
     // registerUser(EMAIL_ADDRESS);
     await setUp();
-    browser.url(`${config.baseUrl}/signin`);
+    browser.url(`http://127.0.0.1:8000/signin`);
   });
 
   it('navigate to the reset your password page', () => {

--- a/test/regression/external/reset-password.spec.js
+++ b/test/regression/external/reset-password.spec.js
@@ -2,68 +2,97 @@
 
 const { getButton, getPageTitle, getValidationSummaryMessage } = require('../shared/helpers/page');
 const { getPersonalisation } = require('../shared/helpers/notifications');
-const config = require('./config');
+const { baseUrl } = require('./config');
 
 const EMAIL_ADDRESS = 'acceptance-test.external@example.com';
 
 /* eslint-disable no-undef */
 describe('external user resetting their password:', function () {
-  it('navigate to the reset your password page', () => {
-    $('#main-content > p > a').click();
+  before(async () => {
+    await browser.url(baseUrl);
+  });
+
+  it('navigate to the reset your password page', async () => {
+    const passwordResetLink = await $('#main-content > p > a');
+    passwordResetLink.click();
     expect(browser).toHaveUrlContaining('/reset_password');
     expect(getPageTitle()).toHaveText('Reset your password');
   });
 
-  it('shows the email address field', () => {
-    expect($('label[for="email"]')).toHaveText('Email address');
-    expect($('input#email')).toBeVisible();
+  it('shows the email address field', async () => {
+    const emailFieldLabel = await $('label[for="email"]');
+    const emailFieldInput = await $('input#email');
+    expect(emailFieldLabel).toHaveText('Email address');
+    expect(emailFieldInput).toBeVisible();
   });
 
-  it('shows a validation message if the email field is empty', () => {
-    $('input#email').setValue('');
-    getButton('Continue').click();
+  it('shows a validation message if the email field is empty', async () => {
+    const email = await $('#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
 
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address');
+    email.setValue('');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('shows a validation message if the email field is invalid', () => {
-    $('input#email').setValue('not-an-email-address');
-    getButton('Continue').click();
+  it('shows a validation message if the email field is invalid', async () => {
+    const email = await $('input#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
 
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address in the correct format');
+    email.setValue('not-an-email-address');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('navigates to success page if the email address is valid', () => {
-    $('input#email').setValue(EMAIL_ADDRESS);
-    getButton('Continue').click();
+  it('navigates to success page if the email address is valid', async () => {
+    const emailFieldInput = await $('input#email');
+    const continueButton = await getButton('Continue');
+    const pageTitle = await getPageTitle();
+
+    emailFieldInput.setValue(EMAIL_ADDRESS);
+    continueButton.click();
 
     expect(browser).toHaveUrlContaining('/reset_password_check_email');
-    expect(getPageTitle()).toHaveText('Check your email');
+    expect(pageTitle).toHaveText('Check your email');
   });
 
-  it('shows a link to resend the reset password email', () => {
-    expect($('a[href="/reset_password_resend_email"]')).toHaveText('Has the email not arrived?');
+  it('shows a link to resend the reset password email', async () => {
+    const linkToResendEmail = await $('a[href="/reset_password_resend_email"]');
+    expect(linkToResendEmail).toHaveText('Has the email not arrived?');
   });
 
-  it('clicks the link in the confirmation email', () => {
-    const resetUrl = getPersonalisation(config.baseUrl, EMAIL_ADDRESS, 'reset_url');
+  it('clicks the link in the confirmation email', async () => {
+    const resetUrl = await getPersonalisation(baseUrl, EMAIL_ADDRESS, 'reset_url');
+    const pageTitle = await getPageTitle();
+
     browser.url(resetUrl);
     expect(browser).toHaveUrlContaining('/reset_password_change_password?');
-    expect(getPageTitle()).toHaveText('Change your password');
+    expect(pageTitle).toHaveText('Change your password');
   });
 
-  it('shows the change password fields', () => {
-    expect($('label[for="password"]')).toHaveText('Enter a new password');
-    expect($('input#password')).toBeVisible();
-    expect($('label[for="confirm-password"]')).toHaveText('Confirm your password');
-    expect($('input#confirm-password')).toBeVisible();
+  it('shows the change password fields', async () => {
+    const passwordFieldLabel = await $('label[for="password"]');
+    const passwordFieldInput = await $('input#password');
+    const confirmPasswordFieldLabel = await $('label[for="confirm-password"]');
+    const confirmPasswordFieldInput = await $('input#confirm-password');
+
+    expect(passwordFieldLabel).toHaveText('Enter a new password');
+    expect(passwordFieldInput).toBeVisible();
+    expect(confirmPasswordFieldLabel).toHaveText('Confirm your password');
+    expect(confirmPasswordFieldInput).toBeVisible();
   });
 
-  it('changes the password and signs in', () => {
-    $('#password').setValue('P@55word');
-    $('#confirm-password').setValue('P@55word');
+  it('changes the password and signs in', async () => {
+    const passwordFieldInput = await $('input#password');
+    const confirmPasswordFieldInput = await $('input#confirm-password');
+    const changePasswordButton = await getButton('Change password');
 
-    getButton('Change password').click();
+    passwordFieldInput.setValue('P@55word');
+    confirmPasswordFieldInput.setValue('P@55word');
+
+    changePasswordButton.click();
   });
 
   it('is redirected to the add licences page', async () => {

--- a/test/regression/external/reset-password.spec.js
+++ b/test/regression/external/reset-password.spec.js
@@ -2,19 +2,12 @@
 
 const { getButton, getPageTitle, getValidationSummaryMessage } = require('../shared/helpers/page');
 const { getPersonalisation } = require('../shared/helpers/notifications');
-const { setUp } = require('../shared/helpers/setup');
 const config = require('./config');
 
 const EMAIL_ADDRESS = 'acceptance-test.external@example.com';
 
 /* eslint-disable no-undef */
 describe('external user resetting their password:', function () {
-  before(async () => {
-    // registerUser(EMAIL_ADDRESS);
-    await setUp();
-    browser.url(`http://127.0.0.1:8000/signin`);
-  });
-
   it('navigate to the reset your password page', () => {
     $('#main-content > p > a').click();
     expect(browser).toHaveUrlContaining('/reset_password');

--- a/test/regression/external/user-registration.spec.js
+++ b/test/regression/external/user-registration.spec.js
@@ -49,83 +49,131 @@ describe('external user registration', () => {
     expect(getPageTitle()).toHaveText('Create an account');
   });
 
-  it('shows a validation message if the email field is empty', () => {
-    $('#email').setValue('');
-    getButton('Continue').click();
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address in the right format');
+  it('shows a validation message if the email field is empty', async () => {
+    const email = await $('#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
+
+    email.setValue('');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('shows a validation message if the email field is invalid', () => {
-    $('#email').setValue('not-an-email-address');
-    getButton('Continue').click();
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address in the right format');
+  it('shows a validation message if the email field is invalid', async () => {
+    const email = await $('input#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
+
+    email.setValue('not-an-email-address');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('navigates to the success page if the email address is valid', () => {
-    $('#email').setValue(EMAIL_ADDRESS);
-    getButton('Continue').click();
+  it('navigates to the success page if the email address is valid', async () => {
+    const email = await $('input#email');
+    const continueButton = await getButton('Continue');
+    const pageTitle = await getPageTitle();
+
+    email.setValue(EMAIL_ADDRESS);
+    continueButton.click();
     const uri = `/success?${qs.encode({ email: EMAIL_ADDRESS })}`;
     expect(browser).toHaveUrlContaining(uri);
-    expect(getPageTitle()).toHaveText('Confirm your email address');
+    expect(pageTitle).toHaveText('Confirm your email address');
   });
 
-  it('shows confirmation text including the email address', () => {
-    expect(getByTestId('success-text')).toHaveText(`We have sent a link to ${EMAIL_ADDRESS}`);
+  it('shows confirmation text including the email address', async () => {
+    const confirmationText = await getByTestId('success-text');
+    expect(confirmationText).toHaveText(`We have sent a link to ${EMAIL_ADDRESS}`);
   });
 
-  it('clicks the link in the confirmation email', () => {
-    const link = getPersonalisation(baseUrl, EMAIL_ADDRESS, 'link');
+  it('clicks the link in the confirmation email', async () => {
+    const link = await getPersonalisation(baseUrl, EMAIL_ADDRESS, 'link');
+    const pageTitle = await getPageTitle();
+
     browser.url(link);
     expect(browser).toHaveUrlContaining('/create-password?');
-    expect(getPageTitle()).toHaveText('Create a password');
+    expect(pageTitle).toHaveText('Create a password');
   });
 
-  it('shows a validation error message if no passwords are entered', () => {
-    $('#password').setValue('');
-    $('#confirm-password').setValue('');
-    getButton('Change password').click();
+  it('shows a validation error message if no passwords are entered', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('');
+    confirmPasswordField.setValue('');
+
+    changePasswordButton.click();
     expectPasswordValidationToBe(false, false, false);
   });
 
-  it('shows a validation error message if passwords are too short', () => {
-    $('#password').setValue('short');
-    $('#confirm-password').setValue('short');
-    getButton('Change password').click();
+  it('shows a validation error message if passwords are too short', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('short');
+    confirmPasswordField.setValue('short');
+    changePasswordButton.click();
+
     expectPasswordValidationToBe(false, false, false);
   });
 
-  it('shows a validation error message if passwords have correct length only', () => {
-    $('#password').setValue('12345678');
-    $('#confirm-password').setValue('12345678');
-    getButton('Change password').click();
+  it('shows a validation error message if passwords have correct length only', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('12345678');
+    confirmPasswordField.setValue('12345678');
+    changePasswordButton.click();
     expectPasswordValidationToBe(true, false, false);
   });
 
-  it('shows a validation error message if passwords have symbol only', () => {
-    $('#password').setValue('123$');
-    $('#confirm-password').setValue('123$');
-    getButton('Change password').click();
+  it('shows a validation error message if passwords have symbol only', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('123$');
+    confirmPasswordField.setValue('123$');
+    changePasswordButton.click();
+
     expectPasswordValidationToBe(false, true, false);
   });
 
-  it('shows a validation error message if passwords have capital only', () => {
-    $('#password').setValue('123A');
-    $('#confirm-password').setValue('123A');
-    getButton('Change password').click();
+  it('shows a validation error message if passwords have capital only', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('123A');
+    confirmPasswordField.setValue('123A');
+    changePasswordButton.click();
+
     expectPasswordValidationToBe(false, false, true);
   });
 
-  it('shows a validation error message if passwords do not match', () => {
-    $('#password').setValue('A12345678$');
-    $('#confirm-password').setValue('B12345678$');
-    getButton('Change password').click();
+  it('shows a validation error message if passwords do not match', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('A12345678$');
+    confirmPasswordField.setValue('B12345678$');
+    changePasswordButton.click();
     expect(getValidationSummaryMessage()).toHaveText('Re-enter your new password');
   });
 
-  it('sets the passwords and signs in if valid and matching', () => {
-    $('#password').setValue('A12345678$');
-    $('#confirm-password').setValue('A12345678$');
-    getButton('Change password').click();
+  it('sets the passwords and signs in if valid and matching', async () => {
+    const passwordField = await $('#password');
+    const confirmPasswordField = await $('#confirm-password');
+    const changePasswordButton = await getButton('Change password');
+
+    passwordField.setValue('A12345678$');
+    confirmPasswordField.setValue('A12345678$');
+    changePasswordButton.click();
+
     expect(browser).toHaveUrlContaining('/add-licences');
     expect(getPageTitle()).toHaveText('Add your licences to the service');
   });

--- a/test/regression/external/user-registration.spec.js
+++ b/test/regression/external/user-registration.spec.js
@@ -2,7 +2,7 @@
 
 const { getButton, getPageTitle, getValidationSummaryMessage, getByTestId } = require('../shared/helpers/page');
 const { getPersonalisation } = require('../shared/helpers/notifications');
-const config = require('./config');
+const { baseUrl } = require('./config');
 
 const uuid = require('uuid/v4');
 const qs = require('querystring');
@@ -29,7 +29,7 @@ describe('external user registration', () => {
   };
 
   before(() => {
-    browser.url('http://127.0.0.1:8000');
+    browser.url(baseUrl);
   });
 
   it('redirects to the welcome page', () => {
@@ -74,7 +74,7 @@ describe('external user registration', () => {
   });
 
   it('clicks the link in the confirmation email', () => {
-    const link = getPersonalisation('http://127.0.0.1:8000', EMAIL_ADDRESS, 'link');
+    const link = getPersonalisation(baseUrl, EMAIL_ADDRESS, 'link');
     browser.url(link);
     expect(browser).toHaveUrlContaining('/create-password?');
     expect(getPageTitle()).toHaveText('Create a password');

--- a/test/regression/external/user-registration.spec.js
+++ b/test/regression/external/user-registration.spec.js
@@ -74,7 +74,7 @@ describe('external user registration', () => {
   });
 
   it('clicks the link in the confirmation email', () => {
-    const link = getPersonalisation(config.baseUrl, EMAIL_ADDRESS, 'link');
+    const link = getPersonalisation('http://127.0.0.1:8000', EMAIL_ADDRESS, 'link');
     browser.url(link);
     expect(browser).toHaveUrlContaining('/create-password?');
     expect(getPageTitle()).toHaveText('Create a password');

--- a/test/regression/external/user-registration.spec.js
+++ b/test/regression/external/user-registration.spec.js
@@ -62,10 +62,12 @@ describe('external user registration', () => {
   it('shows a validation message if the email field is invalid', async () => {
     const email = await $('input#email');
     const continueButton = await getButton('Continue');
-    const validationMessage = await getValidationSummaryMessage();
 
     email.setValue('not-an-email-address');
-    continueButton.click();
+    await continueButton.click();
+    browser.pause(1000);
+
+    const validationMessage = await getValidationSummaryMessage();
     expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 

--- a/test/regression/external/user-registration.spec.js
+++ b/test/regression/external/user-registration.spec.js
@@ -29,7 +29,7 @@ describe('external user registration', () => {
   };
 
   before(() => {
-    browser.url(config.baseUrl);
+    browser.url('http://127.0.0.1:8000');
   });
 
   it('redirects to the welcome page', () => {

--- a/test/regression/internal/helpers/loginAsSuper.js
+++ b/test/regression/internal/helpers/loginAsSuper.js
@@ -3,7 +3,7 @@ const config = require('../config');
 
 const loginAsSuperUser = async () => {
   try {
-    await browser.url(`${config.baseUrl}/signin`);
+    await browser.url(`http://127.0.0.1:8008/signin`);
 
     let emailField = await $('#email');
     await emailField.setValue('acceptance-test.internal.super@defra.gov.uk');

--- a/test/regression/internal/helpers/loginAsSuper.js
+++ b/test/regression/internal/helpers/loginAsSuper.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-undef */
-const config = require('../config');
+const { baseUrl } = require('../config');
 
 const loginAsSuperUser = async () => {
   try {
-    await browser.url(`http://127.0.0.1:8008/signin`);
+    await browser.url(`${baseUrl}/signin`);
 
     let emailField = await $('#email');
     await emailField.setValue('acceptance-test.internal.super@defra.gov.uk');

--- a/test/regression/internal/reset-password.spec.js
+++ b/test/regression/internal/reset-password.spec.js
@@ -25,20 +25,24 @@ describe('internal user resetting their password:', function () {
   it('shows a validation message if the email field is empty', async () => {
     const email = await $('#email');
     const continueButton = await getButton('Continue');
-    const validationMessage = await getValidationSummaryMessage();
 
     email.setValue('');
-    continueButton.click();
-    expect(validationMessage).toHaveText('Enter an email address in the right format');
+    await continueButton.click();
+    browser.pause(1000);
+
+    const validationMessage = await getValidationSummaryMessage();
+    expect(validationMessage).toHaveText('Enter an email address');
   });
 
   it('shows a validation message if the email field is invalid', async () => {
     const email = await $('#email');
     const continueButton = await getButton('Continue');
-    const validationMessage = await getValidationSummaryMessage();
 
     email.setValue('not-an-email-address');
-    continueButton.click();
+    await continueButton.click();
+    browser.pause(1000);
+
+    const validationMessage = await getValidationSummaryMessage();
     expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 

--- a/test/regression/internal/reset-password.spec.js
+++ b/test/regression/internal/reset-password.spec.js
@@ -1,16 +1,14 @@
 'use strict';
 const { getButton, getPageTitle, getPageCaption, getValidationSummaryMessage } = require('../shared/helpers/page');
 const { getPersonalisation } = require('../shared/helpers/notifications');
-const { setUp } = require('../shared/helpers/setup');
-const config = require('./config');
+const { baseUrl } = require('./config');
 
 const EMAIL_ADDRESS = 'acceptance-test.internal.wirs@defra.gov.uk';
 
 /* eslint-disable no-undef */
 describe('internal user resetting their password:', function () {
   before(async () => {
-    await setUp();
-    browser.url(`http://127.0.0.1:8008/signin`);
+    browser.url(`${baseUrl}/signin`);
   });
 
   it('navigate to the reset your password page', () => {
@@ -51,7 +49,7 @@ describe('internal user resetting their password:', function () {
   });
 
   it('clicks the link in the confirmation email', () => {
-    const resetUrl = getPersonalisation('http://127.0.0.1:8008', EMAIL_ADDRESS, 'reset_url');
+    const resetUrl = getPersonalisation(baseUrl, EMAIL_ADDRESS, 'reset_url');
     browser.url(resetUrl);
     expect(browser).toHaveUrlContaining('/reset_password_change_password?');
     expect(getPageTitle()).toHaveText('Change your password');

--- a/test/regression/internal/reset-password.spec.js
+++ b/test/regression/internal/reset-password.spec.js
@@ -22,51 +22,73 @@ describe('internal user resetting their password:', function () {
     expect($('input#email')).toBeVisible();
   });
 
-  it('shows a validation message if the email field is empty', () => {
-    $('input#email').setValue('');
-    getButton('Continue').click();
+  it('shows a validation message if the email field is empty', async () => {
+    const email = await $('#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
 
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address');
+    email.setValue('');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('shows a validation message if the email field is invalid', () => {
-    $('input#email').setValue('not-an-email-address');
-    getButton('Continue').click();
+  it('shows a validation message if the email field is invalid', async () => {
+    const email = await $('#email');
+    const continueButton = await getButton('Continue');
+    const validationMessage = await getValidationSummaryMessage();
 
-    expect(getValidationSummaryMessage()).toHaveText('Enter an email address in the correct format');
+    email.setValue('not-an-email-address');
+    continueButton.click();
+    expect(validationMessage).toHaveText('Enter an email address in the right format');
   });
 
-  it('navigates to success page if the email address is valid', () => {
-    $('input#email').setValue(EMAIL_ADDRESS);
-    getButton('Continue').click();
+  it('navigates to success page if the email address is valid', async () => {
+    const email = await $('input#email');
+    const continueButton = await getButton('Continue');
+    const pageTitle = await getPageTitle();
+
+    email.setValue(EMAIL_ADDRESS);
+    continueButton.click();
 
     expect(browser).toHaveUrlContaining('/reset_password_check_email');
-    expect(getPageTitle()).toHaveText('Check your email');
+    expect(pageTitle).toHaveText('Check your email');
   });
 
-  it('shows a link to resend the reset password email', () => {
-    expect($('a[href="/reset_password_resend_email"]')).toHaveText('Has the email not arrived?');
+  it('shows a link to resend the reset password email', async () => {
+    const resetPasswordLink = await $('a[href="/reset_password_resend_email"]');
+    expect(resetPasswordLink).toHaveText('Has the email not arrived?');
   });
 
-  it('clicks the link in the confirmation email', () => {
-    const resetUrl = getPersonalisation(baseUrl, EMAIL_ADDRESS, 'reset_url');
+  it('clicks the link in the confirmation email', async () => {
+    const resetUrl = await getPersonalisation(baseUrl, EMAIL_ADDRESS, 'reset_url');
+    const pageTitle = await getPageTitle();
+
     browser.url(resetUrl);
     expect(browser).toHaveUrlContaining('/reset_password_change_password?');
-    expect(getPageTitle()).toHaveText('Change your password');
+    expect(pageTitle).toHaveText('Change your password');
   });
 
-  it('shows the change password fields', () => {
-    expect($('label[for="password"]')).toHaveText('Enter a new password');
-    expect($('input#password')).toBeVisible();
-    expect($('label[for="confirm-password"]')).toHaveText('Confirm your password');
-    expect($('input#confirm-password')).toBeVisible();
+  it('shows the change password fields', async () => {
+    const passwordFieldLabel = await $('label[for="password"]');
+    const passwordFieldInput = await $('input#password');
+    const confirmPasswordFieldLabel = await $('label[for="confirm-password"]');
+    const confirmPasswordFieldInput = await $('input#confirm-password');
+
+    expect(passwordFieldLabel).toHaveText('Enter a new password');
+    expect(passwordFieldInput).toBeVisible();
+    expect(confirmPasswordFieldLabel).toHaveText('Confirm your password');
+    expect(confirmPasswordFieldInput).toBeVisible();
   });
 
-  it('changes the password and signs in', () => {
-    $('#password').setValue('P@55word');
-    $('#confirm-password').setValue('P@55word');
+  it('changes the password and signs in', async () => {
+    const passwordFieldInput = await $('input#password');
+    const confirmPasswordFieldInput = await $('input#confirm-password');
+    const changePasswordButton = await getButton('Change password');
 
-    getButton('Change password').click();
+    passwordFieldInput.setValue('P@55word');
+    confirmPasswordFieldInput.setValue('P@55word');
+
+    changePasswordButton.click();
   });
 
   it('is redirected to the search page', async () => {

--- a/test/regression/internal/reset-password.spec.js
+++ b/test/regression/internal/reset-password.spec.js
@@ -10,7 +10,7 @@ const EMAIL_ADDRESS = 'acceptance-test.internal.wirs@defra.gov.uk';
 describe('internal user resetting their password:', function () {
   before(async () => {
     await setUp();
-    browser.url(`${config.baseUrl}/signin`);
+    browser.url(`http://127.0.0.1:8008/signin`);
   });
 
   it('navigate to the reset your password page', () => {
@@ -51,7 +51,7 @@ describe('internal user resetting their password:', function () {
   });
 
   it('clicks the link in the confirmation email', () => {
-    const resetUrl = getPersonalisation(config.baseUrl, EMAIL_ADDRESS, 'reset_url');
+    const resetUrl = getPersonalisation('http://127.0.0.1:8008', EMAIL_ADDRESS, 'reset_url');
     browser.url(resetUrl);
     expect(browser).toHaveUrlContaining('/reset_password_change_password?');
     expect(getPageTitle()).toHaveText('Change your password');

--- a/test/regression/shared/helpers/notifications.js
+++ b/test/regression/shared/helpers/notifications.js
@@ -3,20 +3,21 @@
 /* eslint-disable no-undef */
 const { get } = require('lodash');
 const querystring = require('querystring');
+const request = require('request');
 
 /**
  * Gets the data for the last notification sent to the supplied email address
  * @param {String} email
  * @return {Object}
  */
-const getLastNotifications = (baseUrl, email) => {
-  // Go to the last notification page
+const getLastNotifications = (baseUrl, email, callback) => {
   const url = `${baseUrl}/notifications/last?${querystring.encode({ email })}`;
-  browser.url(url);
-
-  // Get the content body and parse JSON
-  const content = $('pre').getText(false);
-  return JSON.parse(content);
+  request.get(url, function (err, resp, body) {
+    if (err) {
+      return callback(err, null);
+    }
+    callback(null, JSON.parse(body));
+  });
 };
 
 /**
@@ -26,8 +27,12 @@ const getLastNotifications = (baseUrl, email) => {
  * @return {Mixed}
  */
 const getPersonalisation = (baseUrl, email, param) => {
-  const data = getLastNotifications(baseUrl, email);
-  return get(data, `data[0].personalisation.${param}`);
+  getLastNotifications(baseUrl, email, function (err, body) {
+    if (err) {
+      throw err;
+    }
+    return get(body, `data[0].personalisation.${param}`);
+  });
 };
 
 exports.getPersonalisation = getPersonalisation;

--- a/test/regression/shared/helpers/page.js
+++ b/test/regression/shared/helpers/page.js
@@ -25,8 +25,9 @@ const getPageCaption = () => $('.govuk-caption-l');
  * the message with the supplied index
  * @param {Number} [index] - index of validation summary error message
  */
-const getValidationSummaryMessage = (index = 0) =>
-  $('ul.govuk-error-summary__list').$$('li')[index];
+const getValidationSummaryMessage = (index = 0) => {
+  $('ul.govuk-error-summary__list') ? $('ul.govuk-error-summary__list').$$ ? $('ul.govuk-error-summary__list').$$('li')[index] : null : null;
+};
 
 /**
  * Gets the element with specified data-test-id id

--- a/test/regression/shared/helpers/page.js
+++ b/test/regression/shared/helpers/page.js
@@ -1,5 +1,4 @@
 'use strict';
-
 /* eslint-disable no-undef */
 
 /**
@@ -25,9 +24,7 @@ const getPageCaption = () => $('.govuk-caption-l');
  * the message with the supplied index
  * @param {Number} [index] - index of validation summary error message
  */
-const getValidationSummaryMessage = (index = 0) => {
-  $('ul.govuk-error-summary__list') ? $('ul.govuk-error-summary__list').$$ ? $('ul.govuk-error-summary__list').$$('li')[index] : null : null;
-};
+const getValidationSummaryMessage = (index = 0) => $('ul.govuk-error-summary__list') ? $('ul.govuk-error-summary__list').$$ ? $('ul.govuk-error-summary__list').$$('li')[index] : null : null;
 
 /**
  * Gets the element with specified data-test-id id

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -237,7 +237,7 @@ exports.config = {
      * Hook that gets executed after the suite has ended
      * @param {Object} suite suite details
      */
-  afterSuite: () => setup.tearDown()
+  // afterSuite: () => setup.tearDown()
   /**
      * Runs after a WebdriverIO command gets executed
      * @param {String} commandName hook command name
@@ -262,8 +262,7 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that ran
      */
-  // afterSession: function (config, capabilities, specs) {
-  // },
+  afterSession: () => setup.tearDown()
   /**
      * Gets executed after all workers got shut down and the process is about to exit. An error
      * thrown in the onComplete hook will result in the test run failing.

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -51,6 +51,7 @@ exports.config = {
   // Sauce Labs platform configurator - a great tool to configure your capabilities:
   // https://docs.saucelabs.com/reference/platforms-configurator
   //
+  port: '4444',
   capabilities: [{
 
     // maxInstances can get overwritten per capability. So if you have an in-house Selenium


### PR DESCRIPTION
This PR is a fork of the current regression packs, modified in such a way that they can now pass when run through a GitHub worker run. 

Last successful run can be found here: https://github.com/DEFRA/water-abstraction-ui/runs/1644886748?check_suite_focus=true

I recommend that `reg-pack/internal-password-reset-fork` is merged into `reg-pack/internal-password-reset`,

... And then `reg-pack/internal-password-reset` can be merged into `develop`.