### PR TITLE
Initial work on change billing account address

### DIFF
--- a/src/internal/lib/connectors/services/water/InvoiceAccountService.js
+++ b/src/internal/lib/connectors/services/water/InvoiceAccountService.js
@@ -20,7 +20,7 @@ class InvoiceAccountService extends ServiceClient {
    */
   createInvoiceAccountAddress (invoiceAccountId, data) {
     const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'addresses');
-    return this.serviceRequest.post(uri, data);
+    return this.serviceRequest.post(uri, { body: data });
   }
 }
 

--- a/src/internal/lib/connectors/services/water/InvoiceAccountService.js
+++ b/src/internal/lib/connectors/services/water/InvoiceAccountService.js
@@ -22,6 +22,16 @@ class InvoiceAccountService extends ServiceClient {
     const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'addresses');
     return this.serviceRequest.post(uri, { body: data });
   }
+
+  /**
+   * Gets licences currently linked to the supplied invoice account
+   * via charge versions
+   * @param {String} invoiceAccountId
+   */
+  getLicences (invoiceAccountId) {
+    const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'licences');
+    return this.serviceRequest.get(uri);
+  }
 }
 
 module.exports = InvoiceAccountService;

--- a/src/internal/lib/connectors/services/water/InvoiceAccountService.js
+++ b/src/internal/lib/connectors/services/water/InvoiceAccountService.js
@@ -9,6 +9,19 @@ class InvoiceAccountService extends ServiceClient {
     const uri = this.joinUrl('invoice-accounts', invoiceAccountId);
     return this.serviceRequest.get(uri);
   }
+
+  /**
+   * Creates a new invoice account address record
+   * @param {String} invoiceAccountId
+   * @param {Object} data
+   * @param {Object|Null} data.agent - company record for agent
+   * @param {Object|Null} data.contact - FAO
+   * @param {Object} data.address
+   */
+  createInvoiceAccountAddress (invoiceAccountId, data) {
+    const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'addresses');
+    return this.serviceRequest.post(uri, data);
+  }
 }
 
 module.exports = InvoiceAccountService;

--- a/src/internal/lib/connectors/services/water/InvoiceAccountService.js
+++ b/src/internal/lib/connectors/services/water/InvoiceAccountService.js
@@ -1,12 +1,14 @@
 const ServiceClient = require('shared/lib/connectors/services/ServiceClient');
 
+const pathPrefix = 'invoice-accounts';
+
 class InvoiceAccountService extends ServiceClient {
   /**
    * Get invoice account by ID
    * @param {String} invoiceAccountId
    */
   getInvoiceAccount (invoiceAccountId) {
-    const uri = this.joinUrl('invoice-accounts', invoiceAccountId);
+    const uri = this.joinUrl(pathPrefix, invoiceAccountId);
     return this.serviceRequest.get(uri);
   }
 
@@ -19,7 +21,7 @@ class InvoiceAccountService extends ServiceClient {
    * @param {Object} data.address
    */
   createInvoiceAccountAddress (invoiceAccountId, data) {
-    const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'addresses');
+    const uri = this.joinUrl(pathPrefix, invoiceAccountId, 'addresses');
     return this.serviceRequest.post(uri, { body: data });
   }
 
@@ -29,7 +31,7 @@ class InvoiceAccountService extends ServiceClient {
    * @param {String} invoiceAccountId
    */
   getLicences (invoiceAccountId) {
-    const uri = this.joinUrl('invoice-accounts', invoiceAccountId, 'licences');
+    const uri = this.joinUrl(pathPrefix, invoiceAccountId, 'licences');
     return this.serviceRequest.get(uri);
   }
 }

--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -17,7 +17,7 @@ const getBillingAccountRedirectLink = request => {
     caption: `Billing account ${billingAccount.accountNumber}`,
     key: `change-address-${billingAccountId}`,
     back: `/billing-accounts/${billingAccountId}`,
-    redirectPath: `/billing-accounts/${billingAccountId}/change-address-complete`,
+    redirectPath: `/billing-accounts/${billingAccountId}`,
     isUpdate: true,
     data: billingAccount
   };

--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -9,16 +9,33 @@ const getCurrentAddress = billingAccount =>
   billingAccount.invoiceAccountAddresses.find(accountAddress =>
     accountAddress.dateRange.endDate === null);
 
+const getBillingAccountRedirectLink = request => {
+  const { billingAccountId } = request.params;
+  const { billingAccount } = request.pre;
+
+  const data = {
+    caption: `Billing account ${billingAccount.accountNumber}`,
+    key: `change-address-${billingAccountId}`,
+    back: `/billing-accounts/${billingAccountId}`,
+    redirectPath: `/billing-accounts/${billingAccountId}/change-address-complete`,
+    isUpdate: true,
+    data: billingAccount
+  };
+  return request.billingAccountEntryRedirect(data);
+};
+
 const getBillingAccount = (request, h) => {
   const { billingAccount } = request.pre;
   const { back } = request.query;
+
   return h.view('nunjucks/billing-accounts/view', {
     ...request.view,
     caption: getBillingAccountCaption(billingAccount),
     pageTitle: `Billing account for ${titleCase(billingAccount.company.name)}`,
     back,
     currentAddress: getCurrentAddress(billingAccount),
-    billingAccount
+    billingAccount,
+    changeAddressLink: getBillingAccountRedirectLink(request)
   });
 };
 

--- a/src/internal/modules/billing-accounts/controllers/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/controllers/select-billing-account.js
@@ -221,6 +221,7 @@ const getHandleContactEntry = async (request, h) => {
  */
 const getCheckAnswers = (request, h) => {
   const { key } = request.params;
+  const { licences } = request.pre;
   return h.view('nunjucks/billing-accounts/check-answers', {
     ...getDefaultView(request),
     pageTitle: 'Check billing account details',
@@ -231,7 +232,8 @@ const getCheckAnswers = (request, h) => {
       address: getAddressRedirectPath(request, { checkAnswers: true }),
       fao: routing.getFAORequired(key)
     },
-    form: confirmForm.form(request, 'Continue')
+    licences,
+    form: confirmForm.form(request, 'Confirm')
   });
 };
 

--- a/src/internal/modules/billing-accounts/lib/mapper.js
+++ b/src/internal/modules/billing-accounts/lib/mapper.js
@@ -48,8 +48,7 @@ const mapContactToWaterApi = contact =>
 
 const mapSessionDataToCreateInvoiceAccount = state => pick(state, ['regionId', 'startDate']);
 
-const mapSessionDataToCreateInvoiceAccountAddress = ({ startDate, data }) => ({
-  startDate,
+const mapSessionDataToCreateInvoiceAccountAddress = ({ data }) => ({
   agentCompany: mapCompanyToWaterApi(data.agentCompany),
   contact: mapContactToWaterApi(data.contact),
   address: mapAddressToWaterApi(data.address)

--- a/src/internal/modules/billing-accounts/lib/mapper.js
+++ b/src/internal/modules/billing-accounts/lib/mapper.js
@@ -2,13 +2,9 @@
 
 const { pick } = require('lodash');
 
-/**
- * @note the water company API currently accepts addressId rather than id
- * as it should
- */
 const mapAddressToWaterApi = address => ({
-  ...address.id && { addressId: address.id },
   ...pick(address, [
+    'id',
     'addressLine1',
     'addressLine2',
     'addressLine3',
@@ -22,14 +18,10 @@ const mapAddressToWaterApi = address => ({
   ])
 });
 
-/**
- * @note the water company API currently accepts companyId rather than id
- * as it should
- */
 const mapCompanyToWaterApi = company =>
   company === null ? null : {
-    ...company.id && { companyId: company.id },
     ...pick(company, [
+      'id',
       'type',
       'name',
       'companyNumber',
@@ -39,8 +31,8 @@ const mapCompanyToWaterApi = company =>
 
 const mapContactToWaterApi = contact =>
   contact === null ? null : {
-    ...contact.id && { contactId: contact.id },
     ...pick(contact, [
+      'id',
       'type',
       'title',
       'firstName',
@@ -54,12 +46,14 @@ const mapContactToWaterApi = contact =>
     ])
   };
 
-const mapSessionDataToWaterApi = ({ regionId, startDate, data }) => ({
-  regionId,
+const mapSessionDataToCreateInvoiceAccount = state => pick(state, ['regionId', 'startDate']);
+
+const mapSessionDataToCreateInvoiceAccountAddress = ({ startDate, data }) => ({
   startDate,
-  agent: mapCompanyToWaterApi(data.agentCompany),
+  agentCompany: mapCompanyToWaterApi(data.agentCompany),
   contact: mapContactToWaterApi(data.contact),
   address: mapAddressToWaterApi(data.address)
 });
 
-exports.mapSessionDataToWaterApi = mapSessionDataToWaterApi;
+exports.mapSessionDataToCreateInvoiceAccount = mapSessionDataToCreateInvoiceAccount;
+exports.mapSessionDataToCreateInvoiceAccountAddress = mapSessionDataToCreateInvoiceAccountAddress;

--- a/src/internal/modules/billing-accounts/plugin.js
+++ b/src/internal/modules/billing-accounts/plugin.js
@@ -11,7 +11,19 @@ const OPTIONS_SCHEMA = Joi.object({
   redirectPath: Joi.string().required(),
   key: Joi.string().required(),
   caption: Joi.string().optional(),
-  data: Joi.object().optional().default({}),
+  data: Joi.when(
+    'isUpdate', {
+      is: true,
+      then: Joi.object({
+        id: Joi.string().guid(),
+        company: Joi.object(),
+        address: Joi.object(),
+        agentCompany: Joi.object().allow(null),
+        contact: Joi.object().allow(null)
+      }),
+      otherwise: Joi.object().optional().default({})
+    }
+  ),
   isUpdate: Joi.boolean().optional().default(false).notes('True if updating an existing billing account'),
   startDate: Joi.when(
     'isUpdate', {

--- a/src/internal/modules/billing-accounts/plugin.js
+++ b/src/internal/modules/billing-accounts/plugin.js
@@ -9,13 +9,42 @@ const routing = require('./lib/routing');
 const OPTIONS_SCHEMA = Joi.object({
   back: Joi.string().required(),
   redirectPath: Joi.string().required(),
-  companyId: Joi.string().guid().required(),
-  regionId: Joi.string().guid().required(),
   key: Joi.string().required(),
   caption: Joi.string().optional(),
   data: Joi.object().optional().default({}),
-  startDate: Joi.string().isoDate().required()
+  isUpdate: Joi.boolean().optional().default(false).notes('True if updating an existing billing account'),
+  startDate: Joi.when(
+    'isUpdate', {
+      is: true,
+      then: Joi.forbidden(),
+      otherwise: Joi.string().isoDate().required()
+    }
+  ),
+  companyId: Joi.when(
+    'isUpdate', {
+      is: true,
+      then: Joi.forbidden(),
+      otherwise: Joi.string().guid().required()
+    }
+  ),
+  regionId: Joi.when(
+    'isUpdate', {
+      is: true,
+      then: Joi.forbidden(),
+      otherwise: Joi.string().guid().required()
+    }
+  )
 });
+
+const mapOptions = options => {
+  if (!options.isUpdate) {
+    return options;
+  }
+  return {
+    ...options,
+    companyId: options.data.company.id
+  };
+};
 
 /**
  * This function stores data in the session and returns
@@ -28,12 +57,14 @@ function billingAccountEntryRedirect (options) {
   Joi.assert(options, OPTIONS_SCHEMA);
 
   // Store in session
-  session.set(this, options.key, options);
+  session.set(this, options.key, mapOptions(options));
 
   const { key } = options;
 
   // Return redirect path to enter flow
-  return routing.getSelectExistingBillingAccount(key);
+  return options.isUpdate
+    ? routing.getSelectAccount(key)
+    : routing.getSelectExistingBillingAccount(key);
 }
 
 /**

--- a/src/internal/modules/billing-accounts/pre-handlers.js
+++ b/src/internal/modules/billing-accounts/pre-handlers.js
@@ -62,6 +62,7 @@ const getBillingAccountLicences = async request => {
     const { data } = await water.invoiceAccounts.getLicences(id);
     return data;
   }
+  return [];
 };
 
 exports.loadBillingAccount = loadBillingAccount;

--- a/src/internal/modules/billing-accounts/pre-handlers.js
+++ b/src/internal/modules/billing-accounts/pre-handlers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
+const { get } = require('lodash');
 const { water } = require('../../lib/connectors/services');
 
 const session = require('./lib/session');
@@ -45,7 +46,6 @@ const getBillingAccounts = async request => {
 
 /**
  * Gets the "company" account
- * @param {*} request
  */
 const getAccount = async request => {
   const { key } = request.params;
@@ -53,7 +53,19 @@ const getAccount = async request => {
   return water.companies.getCompany(companyId);
 };
 
+/**
+ * Get licences currently linked to the billing account
+ */
+const getBillingAccountLicences = async request => {
+  const { id } = get(request, 'pre.sessionData.data');
+  if (id) {
+    const { data } = await water.invoiceAccounts.getLicences(id);
+    return data;
+  }
+};
+
 exports.loadBillingAccount = loadBillingAccount;
 exports.getSessionData = getSessionData;
 exports.getBillingAccounts = getBillingAccounts;
 exports.getAccount = getAccount;
+exports.getBillingAccountLicences = getBillingAccountLicences;

--- a/src/internal/modules/billing-accounts/routes/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/routes/select-billing-account.js
@@ -152,6 +152,8 @@ module.exports = {
       },
       pre: [{
         method: preHandlers.getSessionData, assign: 'sessionData'
+      }, {
+        method: preHandlers.getBillingAccountLicences, assign: 'licences'
       }]
     }
   })

--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -15,9 +15,11 @@ const formatDateForPageTitle = startDate =>
   moment(startDate).format('D MMMM YYYY');
 
 const getViewChargeInformation = async (request, h) => {
-  const { chargeVersion, licence } = request.pre;
+  const { chargeVersion, licence, billingAccount } = request.pre;
   const { chargeVersionWorkflowId } = request.params;
   const backLink = await getLicencePageUrl(licence);
+
+  const billingAccountAddress = getCurrentBillingAccountAddress(billingAccount);
 
   return h.view('nunjucks/charge-information/view', {
     ...getDefaultView(request, backLink),
@@ -25,6 +27,8 @@ const getViewChargeInformation = async (request, h) => {
     chargeVersion,
     isEditable: false,
     chargeVersionWorkflowId,
+    billingAccount,
+    billingAccountAddress,
     // @TODO: use request.pre.isChargeable to determine this
     // after the chargeVersion import ticket has been completed
     isChargeable: true

--- a/src/internal/modules/charge-information/pre-handlers.js
+++ b/src/internal/modules/charge-information/pre-handlers.js
@@ -163,14 +163,20 @@ const loadLicenceHolderRole = async request => {
   }
 };
 
+const getBillingAccount = invoiceAccountId => invoiceAccountId
+  ? services.water.invoiceAccounts.getInvoiceAccount(invoiceAccountId)
+  : null;
+
 const loadBillingAccount = async request => {
   const { licenceId } = request.params;
   const state = request.getDraftChargeInformation(licenceId);
   const invoiceAccountId = get(state, 'invoiceAccount.id');
-  if (invoiceAccountId) {
-    return services.water.invoiceAccounts.getInvoiceAccount(invoiceAccountId);
-  }
-  return null;
+  return getBillingAccount(invoiceAccountId);
+};
+
+const loadBillingAccountByChargeVersion = async request => {
+  const invoiceAccountId = get(request, 'pre.chargeVersion.invoiceAccount.id');
+  return getBillingAccount(invoiceAccountId);
 };
 
 exports.loadChargeableChangeReasons = loadChargeableChangeReasons;
@@ -186,3 +192,4 @@ exports.loadLicencesWithoutChargeVersions = loadLicencesWithoutChargeVersions;
 exports.loadLicencesWithWorkflowsInProgress = loadLicencesWithWorkflowsInProgress;
 exports.loadLicenceHolderRole = loadLicenceHolderRole;
 exports.loadBillingAccount = loadBillingAccount;
+exports.loadBillingAccountByChargeVersion = loadBillingAccountByChargeVersion;

--- a/src/internal/modules/charge-information/routes/view-charge-information.js
+++ b/src/internal/modules/charge-information/routes/view-charge-information.js
@@ -29,7 +29,7 @@ module.exports = {
       pre: [
         { method: preHandlers.loadLicence, assign: 'licence' },
         { method: preHandlers.loadChargeVersion, assign: 'chargeVersion' },
-        { method: preHandlers.loadBillingAccount, assign: 'billingAccount' }
+        { method: preHandlers.loadBillingAccountByChargeVersion, assign: 'billingAccount' }
       ]
     }
   },

--- a/src/internal/modules/charge-information/routes/view-charge-information.js
+++ b/src/internal/modules/charge-information/routes/view-charge-information.js
@@ -28,7 +28,8 @@ module.exports = {
       },
       pre: [
         { method: preHandlers.loadLicence, assign: 'licence' },
-        { method: preHandlers.loadChargeVersion, assign: 'chargeVersion' }
+        { method: preHandlers.loadChargeVersion, assign: 'chargeVersion' },
+        { method: preHandlers.loadBillingAccount, assign: 'billingAccount' }
       ]
     }
   },

--- a/src/internal/views/nunjucks/billing-accounts/check-answers.njk
+++ b/src/internal/views/nunjucks/billing-accounts/check-answers.njk
@@ -1,4 +1,5 @@
 {% extends "./nunjucks/layout.njk" %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "crm/company.njk" import company as crmCompany %}
 {% from "crm/address.njk" import address as crmAddress %}
 {% from "crm/contact.njk" import contact as crmContact %}
@@ -65,6 +66,24 @@ formErrorSummary %}
           </section>
         </div>
       </div>
+
+      {% if licences.length %}
+        <h2 class="govuk-heading-m">You are about to update the billing address for
+          {{ 'this licence' if licences.length === 1 else 'these licences' }}
+        </h2>
+
+        {% set html %}
+        <ul class="govuk-list">
+          {% for licences in licences %}
+            <li>{{ licences.licenceNumber}}</li>
+          {% endfor %}
+        </ul>
+        {% endset %}
+
+        {{ govukInsetText({ html : html }) }}
+
+      {% endif %}
+
       {{ formRender(form) }}
     </div>
   </div>

--- a/src/internal/views/nunjucks/billing-accounts/view.njk
+++ b/src/internal/views/nunjucks/billing-accounts/view.njk
@@ -1,21 +1,27 @@
 {% extends "./nunjucks/layout.njk" %}
 {% from "title.njk" import title %}
 {% from "crm/invoice-address.njk" import invoiceAddress %}
-
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
   {{ title(pageTitle, caption) }}
-  
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-m">
-      Billing address
-    </h2>
+      <h2 class="govuk-heading-m">
+        Billing address
+      </h2>
 
-    <p class="govuk-body">
-      {{ invoiceAddress(currentAddress, billingAccount.company) }}
-    </p>
+      <p class="govuk-body">
+        {{ invoiceAddress(currentAddress, billingAccount.company) }}
+      </p>
+
+      {{ govukButton({ 
+        text : 'Change address', 
+        classes: 'govuk-button--secondary', 
+        href: changeAddressLink 
+      }) }}
 
     </div>
   </div>

--- a/src/internal/views/nunjucks/charge-information/view.njk
+++ b/src/internal/views/nunjucks/charge-information/view.njk
@@ -81,7 +81,9 @@ formErrorSummary %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Billing account</dt>
             <dd class="govuk-summary-list__value">
-              {{ billingAccount.accountNumber }}
+              <a href="/billing-accounts/{{ billingAccount.id }}">
+                {{ billingAccount.accountNumber }}
+              </a>
               <br>
               {% if billingAccountAddress.contact %}
                 FAO
@@ -189,7 +191,8 @@ formErrorSummary %}
   <section class="govuk-!-margin-bottom-7">
     <dl class="govuk-summary-list">
       {% if not chargeVersionWorkflowId %}
-        This licence was made non-chargeable on {{ chargeVersion.dateRange.startDate | date }}.
+        This licence was made non-chargeable on
+        {{ chargeVersion.dateRange.startDate | date }}.
       {% endif %}
       {{ summaryListRow(
         'Reason licence is not chargeable',

--- a/test/internal/lib/connectors/services/water/InvoiceAccountService.js
+++ b/test/internal/lib/connectors/services/water/InvoiceAccountService.js
@@ -15,9 +15,11 @@ const { serviceRequest } = require('@envage/water-abstraction-helpers');
 
 experiment('services/water/InvoiceAccountService', () => {
   let service;
+  const invoiceAccountId = uuid();
 
   beforeEach(async () => {
     sandbox.stub(serviceRequest, 'get');
+    sandbox.stub(serviceRequest, 'post');
 
     service = new InvoiceAccountService('https://example.com/water/1.0');
   });
@@ -28,10 +30,38 @@ experiment('services/water/InvoiceAccountService', () => {
 
   experiment('.getInvoiceAccount', () => {
     test('passes the expected URL to the service request', async () => {
-      const invoiceAccountId = uuid();
       await service.getInvoiceAccount(invoiceAccountId);
       const [url] = serviceRequest.get.lastCall.args;
       expect(url).to.equal(`https://example.com/water/1.0/invoice-accounts/${invoiceAccountId}`);
+    });
+  });
+
+  experiment('.createInvoiceAccountAddress', () => {
+    const data = { address: {}, agentCompany: null, contact: null };
+
+    beforeEach(async () => {
+      await service.createInvoiceAccountAddress(invoiceAccountId, data);
+    });
+
+    test('passes the expected URL to the service request', async () => {
+      const [url] = serviceRequest.post.lastCall.args;
+      expect(url).to.equal(`https://example.com/water/1.0/invoice-accounts/${invoiceAccountId}/addresses`);
+    });
+
+    test('passes the expected payload to the service request', async () => {
+      const [, { body }] = serviceRequest.post.lastCall.args;
+      expect(body).to.equal(data);
+    });
+  });
+
+  experiment('.getLicences', () => {
+    beforeEach(async () => {
+      await service.getLicences(invoiceAccountId);
+    });
+
+    test('passes the expected URL to the service request', async () => {
+      const [url] = serviceRequest.get.lastCall.args;
+      expect(url).to.equal(`https://example.com/water/1.0/invoice-accounts/${invoiceAccountId}/licences`);
     });
   });
 });

--- a/test/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/test/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -11,6 +11,8 @@ const sandbox = require('sinon').createSandbox();
 
 const controller = require('internal/modules/billing-accounts/controllers/billing-accounts');
 
+const addressChangeLink = '/test/link';
+
 const createRequest = query => ({
   view: {
     csrf_token: 'csrf-token'
@@ -52,7 +54,8 @@ const createRequest = query => ({
       }
     }
   },
-  query: query || {}
+  query: query || {},
+  billingAccountEntryRedirect: sandbox.stub().returns(addressChangeLink)
 });
 
 const h = {
@@ -93,6 +96,21 @@ experiment('internal/modules/billing-accounts/controllers/billing-accounts', () 
     test('contains the billing account', () => {
       const [, view] = h.view.lastCall.args;
       expect(view.billingAccount).to.equal(request.pre.billingAccount);
+    });
+
+    test('calls request.billingAccountEntryRedirect() with the correct params', () => {
+      const [data] = request.billingAccountEntryRedirect.lastCall.args;
+      expect(data.caption).to.equal(`Billing account ${request.pre.billingAccount.accountNumber}`);
+      expect(data.key).to.equal(`change-address-${request.pre.billingAccount.id}`);
+      expect(data.back).to.equal(`/billing-accounts/${request.pre.billingAccount.id}`);
+      expect(data.redirectPath).to.equal(`/billing-accounts/${request.pre.billingAccount.id}`);
+      expect(data.isUpdate).to.equal(true);
+      expect(data.data).to.equal(request.pre.billingAccount);
+    });
+
+    test('has a change address link', () => {
+      const [, { changeAddressLink }] = h.view.lastCall.args;
+      expect(changeAddressLink).to.equal(addressChangeLink);
     });
 
     experiment('back link', () => {

--- a/test/internal/modules/billing-accounts/plugin.js
+++ b/test/internal/modules/billing-accounts/plugin.js
@@ -8,6 +8,7 @@ const {
   afterEach
 } = exports.lab = require('@hapi/lab').script();
 const sandbox = require('sinon').createSandbox();
+const { omit } = require('lodash');
 const uuid = require('uuid/v4');
 
 const plugin = require('internal/modules/billing-accounts/plugin');
@@ -22,6 +23,16 @@ const createOptions = () => ({
   caption: 'Caption',
   startDate: '2020-01-01',
   data: {}
+});
+
+const createUpdateOptions = () => ({
+  isUpdate: true,
+  ...omit(createOptions(), 'companyId', 'regionId', 'startDate'),
+  data: {
+    company: {
+      id: uuid()
+    }
+  }
 });
 
 experiment('internal/modules/billing-accounts/plugin', () => {
@@ -73,70 +84,143 @@ experiment('internal/modules/billing-accounts/plugin', () => {
   experiment('.billingAccountEntryRedirect request method', () => {
     let options;
 
-    beforeEach(async () => {
-      options = createOptions();
+    experiment('for the billing account creation flow', () => {
+      beforeEach(async () => {
+        options = createOptions();
+      });
+
+      test('throws an error if the "back" option is omitted', async () => {
+        delete options.back;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('throws an error if the "redirectPath" option is omitted', async () => {
+        delete options.redirectPath;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('throws an error if the "companyId" option is omitted', async () => {
+        delete options.companyId;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('throws an error if the "regionId" option is omitted', async () => {
+        delete options.regionId;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('throws an error if the "key" option is omitted', async () => {
+        delete options.key;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('"caption" option is optional', async () => {
+        delete options.caption;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.not.throw();
+      });
+
+      test('throws an error if the "startDate" option is omitted', async () => {
+        delete options.startDate;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
+
+      test('"data" option is optional', async () => {
+        delete options.data;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.not.throw();
+      });
+
+      test('saves the supplied options to the session', async () => {
+        const request = {};
+        plugin._billingAccountEntryRedirect.call(request, options);
+        expect(session.set.calledWith(
+          request, options.key, options
+        )).to.be.true();
+      });
+
+      test('returns a redirect path', async () => {
+        const request = {};
+        const path = plugin._billingAccountEntryRedirect.call(request, options);
+        expect(path).to.equal(`/billing-account-entry/${options.key}`);
+      });
     });
 
-    test('throws an error if the "back" option is omitted', async () => {
-      delete options.back;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+    experiment('for the update address flow', () => {
+      beforeEach(async () => {
+        options = createUpdateOptions();
+      });
 
-    test('throws an error if the "redirectPath" option is omitted', async () => {
-      delete options.redirectPath;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+      test('throws an error if the "back" option is omitted', async () => {
+        delete options.back;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('throws an error if the "companyId" option is omitted', async () => {
-      delete options.companyId;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+      test('throws an error if the "redirectPath" option is omitted', async () => {
+        delete options.redirectPath;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('throws an error if the "regionId" option is omitted', async () => {
-      delete options.regionId;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+      test('throws an error if the "companyId" option is supplied', async () => {
+        options.companyId = uuid();
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('throws an error if the "key" option is omitted', async () => {
-      delete options.key;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+      test('throws an error if the "regionId" option is supplied', async () => {
+        options.regionId = uuid();
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('"caption" option is optional', async () => {
-      delete options.caption;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.not.throw();
-    });
+      test('throws an error if the "key" option is omitted', async () => {
+        delete options.key;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('throws an error if the "startDate" option is omitted', async () => {
-      delete options.startDate;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.throw();
-    });
+      test('"caption" option is optional', async () => {
+        delete options.caption;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.not.throw();
+      });
 
-    test('"data" option is optional', async () => {
-      delete options.data;
-      const func = () => plugin._billingAccountEntryRedirect(options);
-      expect(func).to.not.throw();
-    });
+      test('throws an error if the "startDate" option is supplied', async () => {
+        options.startDate = '2021-01-01';
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('saves the supplied options to the session', async () => {
-      const request = {};
-      plugin._billingAccountEntryRedirect.call(request, options);
-      expect(session.set.calledWith(
-        request, options.key, options
-      )).to.be.true();
-    });
+      test('throws an error if the "data" option is omitted', async () => {
+        delete options.data;
+        const func = () => plugin._billingAccountEntryRedirect(options);
+        expect(func).to.throw();
+      });
 
-    test('returns a redirect path', async () => {
-      const request = {};
-      const path = plugin._billingAccountEntryRedirect.call(request, options);
-      expect(path).to.equal(`/billing-account-entry/${options.key}`);
+      test('saves the supplied options to the session', async () => {
+        const request = {};
+        plugin._billingAccountEntryRedirect.call(request, options);
+        expect(session.set.calledWith(
+          request, options.key, {
+            ...options,
+            companyId: options.data.company.id
+          }
+        )).to.be.true();
+      });
+
+      test('returns a redirect path', async () => {
+        const request = {};
+        const path = plugin._billingAccountEntryRedirect.call(request, options);
+        expect(path).to.equal(`/billing-account-entry/${options.key}/select-account`);
+      });
     });
   });
 

--- a/test/internal/modules/charge-information/routes/view-charge-information.js
+++ b/test/internal/modules/charge-information/routes/view-charge-information.js
@@ -56,11 +56,13 @@ experiment('internal/modules/charge-information/routes/view-charge-information',
     });
 
     test('has the expected pre handlers', async () => {
-      expect(routes.getViewChargeInformation.options.pre.length).to.equal(2);
+      expect(routes.getViewChargeInformation.options.pre.length).to.equal(3);
       expect(routes.getViewChargeInformation.options.pre[0].method).to.equal(preHandlers.loadLicence);
       expect(routes.getViewChargeInformation.options.pre[0].assign).to.equal('licence');
       expect(routes.getViewChargeInformation.options.pre[1].method).to.equal(preHandlers.loadChargeVersion);
       expect(routes.getViewChargeInformation.options.pre[1].assign).to.equal('chargeVersion');
+      expect(routes.getViewChargeInformation.options.pre[2].method).to.equal(preHandlers.loadBillingAccountByChargeVersion);
+      expect(routes.getViewChargeInformation.options.pre[2].assign).to.equal('billingAccount');
     });
   });
 


### PR DESCRIPTION
`WATER-2915`

Modifies billing account CRM plugin to:
* Include a flow for "update address"
* Post to the 2 new endpoints in the water service, 1 for 'create invoice account' and the other to 'create invoice account address'

Also:
* Links new flow in to billing account page
* Links charge information page to billing account page
* Bug fixes