### PR TITLE
Update view-charge-information.js

### DIFF
--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -3,6 +3,7 @@ const {
   getLicencePageUrl,
   getCurrentBillingAccountAddress
 } = require('../lib/helpers');
+const { get } = require('lodash');
 const forms = require('shared/lib/forms');
 const services = require('../../../lib/connectors/services');
 const chargeInformationValidator = require('../lib/charge-information-validator');
@@ -28,7 +29,7 @@ const getViewChargeInformation = async (request, h) => {
     // @TODO: use request.pre.isChargeable to determine this
     // after the chargeVersion import ticket has been completed
     // In the meantime, it will use chargeVersion.changeReason.type === 'new_non_chargeable_charge_version'
-    isChargeable: chargeVersion.changeReason.type !== 'new_non_chargeable_charge_version'
+    isChargeable: get(chargeVersion, 'changeReason.type') !== 'new_non_chargeable_charge_version'
   });
 };
 


### PR DESCRIPTION
Tweak following an issue that James identified, whereby NALD doesn't always populate the changeReason on a charge version.