### PR TITLE
Alternative regex

### DIFF
--- a/src/internal/modules/charge-information/forms/charge-element/quantities.js
+++ b/src/internal/modules/charge-information/forms/charge-element/quantities.js
@@ -58,7 +58,7 @@ const form = request => {
 };
 
 const schema = (request) => {
-  const nonZeroNumberWithWSixDpRegex = /^[1-9]\d*\.?\d{0,6}$/;
+  const nonZeroNumberWithWSixDpRegex = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
   return {
     csrf_token: Joi.string().uuid().required(),
     authorisedAnnualQuantity: Joi.string().regex(nonZeroNumberWithWSixDpRegex).required(),

--- a/test/internal/modules/charge-information/forms/charge-elements/quantities.js
+++ b/test/internal/modules/charge-information/forms/charge-elements/quantities.js
@@ -123,6 +123,16 @@ experiment('internal/modules/charge-information/forms/charge-element/quantities'
         expect(result.error).to.not.exist();
       });
 
+      test('cannot be a string describing -0.x', async () => {
+        const result = schema().billableAnnualQuantity.validate('-0.123');
+        expect(result.error).to.exist();
+      });
+
+      test('validates for a string describing 0.x', async () => {
+        const result = schema().billableAnnualQuantity.validate('0.123');
+        expect(result.error).to.not.exist();
+      });
+
       test('can be empty', async () => {
         const result = schema().billableAnnualQuantity.validate('');
         expect(result.error).not.to.exist();


### PR DESCRIPTION
Modifies the regex to allow for values starting with zero, as long as they're neither negative nor zero. E.g. 0.123 or 0.6

Relates to https://eaflood.atlassian.net/browse/WATER-3014 