### PR TITLE
Force use of return lines frequency/dates when editing returns

### DIFF
--- a/src/shared/modules/returns/models/Lines.js
+++ b/src/shared/modules/returns/models/Lines.js
@@ -28,11 +28,24 @@ const getDateKey = line => `${line.startDate}_${line.endDate}`;
 const getDateKeys = lines => lines.map(getDateKey);
 
 const getInitialLines = (lines = [], options) => {
-  if (lines.length) {
-    return lines;
-  }
   const { startDate, endDate, frequency, isFinal } = options;
-  return getRequiredLines(startDate, endDate, frequency, isFinal);
+
+  // Create the required lines defined by the return header data
+  const requiredLines = getRequiredLines(startDate, endDate, frequency, isFinal);
+
+  // Index supplied lines by date range
+  const map = lines.reduce((acc, line) =>
+    acc.set(getDateKey(line), line)
+  , new Map());
+
+  // Use existing lines if correct date range
+  return requiredLines.reduce((acc, requiredLine) => {
+    const key = getDateKey(requiredLine);
+    return [
+      ...acc,
+      map.has(key) ? map.get(key) : requiredLine
+    ];
+  }, []);
 };
 
 class Lines {

--- a/test/external/modules/returns/controllers/view.js
+++ b/test/external/modules/returns/controllers/view.js
@@ -31,12 +31,18 @@ const testData = isCurrent => {
     licenceNumber: '123-abc',
     isCurrent,
     lines: [{
-      startDate: '2012-01-01'
+      startDate: '2020-11-01',
+      endDate: '2020-11-30',
+      timePeriod: 'month'
     }],
     meters: [{}],
     metadata: {
       isCurrent
-    } };
+    },
+    startDate: '2020-11-01',
+    endDate: '2021-10-31',
+    frequency: 'month'
+  };
 };
 
 experiment('external view controller', async () => {
@@ -104,7 +110,8 @@ experiment('external view controller', async () => {
       expect(template).to.equal('nunjucks/returns/return');
       expect(view.data.isCurrent).to.equal(returnData.isCurrent);
       expect(view.data.licenceNumber).to.equal(returnData.licenceNumber);
-      expect(view.data.lines).to.equal(returnData.lines);
+      expect(view.data.lines).to.be.an.array().length(12);
+      expect(view.data.lines[0]).to.equal(returnData.lines[0]);
       expect(view.data.metadata).to.equal(returnData.metadata);
     });
 

--- a/test/shared/modules/returns/models/Lines.js
+++ b/test/shared/modules/returns/models/Lines.js
@@ -73,13 +73,29 @@ experiment('Lines model', () => {
       expect(lines.lines.length).to.equal(12);
     });
 
-    test('initialises with supplied lines', async () => {
+    test('initialises with supplied lines if they match the line dates', async () => {
       const lines = new Lines([{
         startDate: '2019-01-01',
         endDate: '2019-01-31',
         quantity: 5
       }], createOptions());
-      expect(lines.lines.length).to.equal(1);
+      expect(lines.lines.length).to.equal(12);
+      expect(lines.lines[0].quantity).to.be.undefined();
+      expect(lines.lines[1].quantity).to.be.undefined();
+      expect(lines.lines[2].quantity).to.equal(5);
+      expect(lines.lines[3].quantity).to.be.undefined();
+    });
+
+    test('ignores  supplied lines if they do not match the required line dates', async () => {
+      const lines = new Lines([{
+        startDate: '2019-01-01',
+        endDate: '2019-01-15',
+        quantity: 5
+      }], createOptions());
+      expect(lines.lines.length).to.equal(12);
+
+      const quantities = lines.lines.map(line => line.quantity);
+      expect(quantities).to.only.include(undefined);
     });
 
     test('throws an error if invalid argument for options', async () => {


### PR DESCRIPTION
WATER-3018

Fix issue where when editing already submitted returns, the return frequency/dates are not respected if there are errors in the lines data.