### PR TITLE
Show credit/debit block on invoice view only for WRLS supplementary 

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -67,7 +67,8 @@ const getBillingBatchInvoice = async (request, h) => {
     invoiceLicences: mappers.mapInvoiceLicences(invoice, documentIds),
     isCredit: get(invoice, 'totals.netTotal', 0) < 0,
     caption: `Billing account ${invoice.invoiceAccount.accountNumber}`,
-    errors: mappers.mapInvoiceLevelErrors(invoice)
+    errors: mappers.mapInvoiceLevelErrors(invoice),
+    isCreditDebitBlockVisible: mappers.isCreditDebitBlockVisible(batch)
   });
 };
 

--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -143,6 +143,9 @@ const mapBatchLevelErrors = (batch, invoices) => invoices
     ...pick(invoice, 'accountNumber', 'financialYearEnding')
   }));
 
+const isCreditDebitBlockVisible = batch =>
+  batch.source === 'wrls' && batch.type === 'supplementary';
+
 exports.mapBatchListRow = mapBatchListRow;
 exports.mapInvoiceLicences = mapInvoiceLicences;
 exports.mapBatchType = mapBatchType;
@@ -150,3 +153,4 @@ exports.mapConditions = mapConditions;
 exports.mapInvoices = mapInvoices;
 exports.mapInvoiceLevelErrors = mapInvoiceLevelErrors;
 exports.mapBatchLevelErrors = mapBatchLevelErrors;
+exports.isCreditDebitBlockVisible = isCreditDebitBlockVisible;

--- a/src/internal/views/nunjucks/billing/batch-invoice.njk
+++ b/src/internal/views/nunjucks/billing/batch-invoice.njk
@@ -88,18 +88,20 @@ invoiceDebitsTotal %}
     </div>
   </div>
 
-  <div class="govuk-grid-row govuk-!-margin-bottom-6">
-    <div class="govuk-grid-column-one-half">
-      <h2>
-        {{ invoiceCreditsTotal(invoice.creditNoteValue) }}
-      </h2>
+  {% if isCreditDebitBlockVisible %}
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-one-half">
+        <h2>
+          {{ invoiceCreditsTotal(invoice.creditNoteValue) }}
+        </h2>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <h2>
+          {{ invoiceDebitsTotal(invoice.invoiceValue) }}
+        </h2>
+      </div>
     </div>
-    <div class="govuk-grid-column-one-half">
-      <h2>
-        {{ invoiceDebitsTotal(invoice.invoiceValue) }}
-      </h2>
-    </div>
-  </div>
+  {% endif %}
 
   <div class="govuk-grid-row govuk-!-margin-bottom-0">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
`WATER-3005`

Hides credit and debit blocks on invoice view except for WRLS supplementary batches