### PR TITLE
Grab Deminimis flag from invoice level instead of transaction level

### DIFF
--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -31,7 +31,6 @@ const getChargeElementData = trans => {
 };
 
 const getTransactionData = trans => ({
-  isDeMinimis: trans.isDeMinimis ? 'Y' : 'N',
   description: trans.description,
   'Compensation charge': trans.isCompensationCharge ? 'Y' : 'N',
   ...getChargeElementData(trans),
@@ -97,8 +96,9 @@ const createCSV = async (invoices, chargeVersions) => {
   const sortedInvoices = sortBy(invoices, 'invoiceAccount.accountNumber', 'invoiceLicences[0].licences.licenceNumber');
   return sortedInvoices.reduce((dataForCSV, invoice) => {
     invoice.invoiceLicences.forEach(invLic => {
+      const { isDeMinimis } = invoice;
       invLic.transactions.forEach(trans => {
-        const { isDeMinimis, description, ...transactionData } = getTransactionData(trans);
+        const { description, ...transactionData } = getTransactionData(trans);
         const csvLine = {
           ...getInvoiceAccountData(invoice.invoiceAccount),
           'Licence number': invLic.licence.licenceNumber,
@@ -106,7 +106,7 @@ const createCSV = async (invoices, chargeVersions) => {
           ...getTransactionAmounts(trans),
           'Charge information reason': getChangeReason(chargeVersions, trans),
           'Region': invLic.licence.region.displayName,
-          'De minimis rule': isDeMinimis,
+          'De minimis rule': isDeMinimis ? 'Y' : 'N',
           'Description': description,
           'Water company': invLic.licence.isWaterUndertaker ? 'Y' : 'N',
           'Historical area': invLic.licence.historicalArea.code,

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -19,6 +19,7 @@ const batch = {
 const invoice =
   {
     id: '0817794f-b5b4-47e8-8172-3411bd6165bd',
+    isDeMinimis: false,
     invoiceLicences: [
       {
         id: 'e93c4697-f288-491e-b9fe-6cab333bbef5',
@@ -64,8 +65,7 @@ const invoice =
             billingVolume: {
               calculatedVolume: 10.3,
               volume: 9.1
-            },
-            isDeMinimis: false
+            }
           },
           {
             value: 4006,
@@ -176,10 +176,6 @@ experiment('internal/modules/billing/services/transactions-csv', async () => {
       transactionData = transactionsCSV._getTransactionData(transaction);
     });
 
-    test('isDeMinimis flag as Y/N', () => {
-      expect(transactionData.isDeMinimis).to.equal('N');
-    });
-
     test('description as is', () => {
       expect(transactionData.description).to.equal(transaction.description);
     });
@@ -252,7 +248,6 @@ experiment('internal/modules/billing/services/transactions-csv', async () => {
          'Minimum Charge Calculation - raised under Schedule 23 of the Environment Act 1995',
         isCompensationCharge: false,
         isMinimumCharge: true,
-        isDeMinimis: false,
         isNewLicence: true,
         chargePeriod: {
           startDate: '2019-04-01',
@@ -260,7 +255,6 @@ experiment('internal/modules/billing/services/transactions-csv', async () => {
       };
 
       const transactionData = transactionsCSV._getTransactionData(minChargeTransaction);
-      expect(transactionData.isDeMinimis).to.equal('N');
       expect(transactionData.description).to.equal(minChargeTransaction.description);
       expect(transactionData['Compensation charge']).to.equal('N');
       expect(transactionData['Agreement code']).to.equal('');

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -386,6 +386,10 @@ experiment('internal/modules/billing/services/transactions-csv', async () => {
       expect(csvData[0]['Water company']).to.equal('N');
     });
 
+    test('DeMinimis is mapped to user friendly heading', async () => {
+      expect(csvData[0]['De minimis rule']).to.equal('N');
+    });
+
     test('historical area is mapped to user friendly heading', async () => {
       expect(csvData[0]['Historical area']).to.equal('AREA');
     });


### PR DESCRIPTION
Fixes an issue whereby deminimis was not showing correctly in the CSV following CM v2 switch.