### PR TITLE
Hide the view link until the report is generated

### DIFF
--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -94,9 +94,11 @@
 
 {% macro actionsCell(batch, invoice) %}
   <td class="govuk-table__cell govuk-table__cell--numeric">
-    <a class="govuk-link" href="/billing/batch/{{batch.id}}/invoice/{{invoice.id}}">View<span class="govuk-visually-hidden">
-        invoice for
-        {{ invoice.accountNumber }}</span></a>
+    {% if invoice.netTotal %}
+      <a class="govuk-link" href="/billing/batch/{{batch.id}}/invoice/{{invoice.id}}">View<span class="govuk-visually-hidden">
+          invoice for
+          {{ invoice.accountNumber }}</span></a>
+    {% endif %}
   </td>
 {% endmacro %}
 


### PR DESCRIPTION
When a large report is generated it takes some time to completely build. Clicking the 'view' link before a report section is built will cause an error, so we hide the view link until the data is ready.