### PR TITLE
Fix issues with charge version workflow in "to_setup" status

### DIFF
--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -3,7 +3,12 @@
 <h2 class="govuk-heading-l">Charge information</h2>
 
 {% macro chargeVersionLink(chargeVersion) %}
-  {% if chargeVersion.status == 'review' or chargeVersion.status == 'changes_requested' %}
+
+  {% if chargeVersion.status == 'to_setup' %}
+    <a class="govuk-link" href="/licences/{{ licenceId }}/charge-information/create?chargeVersionWorkflowId={{ chargeVersion.id }}">Set up</a> 
+    | 
+    <a class="govuk-link" href="/charge-information-workflow/{{ chargeVersion.id }}/remove">Remove</a> 
+  {% elif chargeVersion.status == 'review' or chargeVersion.status == 'changes_requested' %}
     <a class="govuk-link" href="/licences/{{ licenceId }}/charge-information/{{ chargeVersion.id }}/review">Review</a>
   {% else %}
     <a class="govuk-link" href="/licences/{{ licenceId }}/charge-information/{{ chargeVersion.id }}/view">View</a>
@@ -58,10 +63,10 @@
 {% macro chargeVersionRow(chargeVersion) %}
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">
-      {{ chargeVersion.dateRange.startDate | date }}
+      {{ chargeVersion.dateRange.startDate | date | default('-') }}
     </td>
     <td class="govuk-table__cell">
-      {{ chargeVersion.dateRange.endDate | date }}
+      {{ chargeVersion.dateRange.endDate | date | default('-') }}
     </td>
     <td class="govuk-table__cell">
       {{ chargeVersion.changeReason.description }}

--- a/src/shared/view/nunjucks/filters/charge-version-badge.js
+++ b/src/shared/view/nunjucks/filters/charge-version-badge.js
@@ -9,7 +9,8 @@ const styles = {
   superseded: 'inactive',
   invalid: 'error',
   review: 'warning',
-  'change request': 'todo'
+  'change request': 'todo',
+  to_setup: 'todo'
 };
 
 //  Map the backend statuses to the desired front-end labels from acceptance criteria.
@@ -22,7 +23,8 @@ const displayedTextTransformer = {
   superseded: 'replaced',
   invalid: 'invalid',
   review: 'review',
-  changes_requested: 'change request'
+  changes_requested: 'change request',
+  to_setup: 'to set up'
 };
 
 /**

--- a/src/shared/view/nunjucks/filters/date.js
+++ b/src/shared/view/nunjucks/filters/date.js
@@ -1,14 +1,20 @@
+'use strict';
+
+const { isNil } = require('lodash');
 const moment = require('moment');
 
 /**
  * Format a timestamp
- * @param  {String} value        - Timestamp / date (parsed by moment)
+ * @param  {String|Number} value        - Timestamp / date (parsed by moment)
  * @param  {String} [format='DDD MMM YYYY'] - Format (see moment docs)
  * @return {String}              formatted date
  */
 const date = (value, format = 'D MMMM YYYY') => {
+  if (isNil(value)) {
+    return undefined;
+  }
   const m = moment(value);
-  return m.isValid() ? m.format(format) : null;
+  return m.isValid() ? m.format(format) : undefined;
 };
 
 exports.date = date;

--- a/test/shared/view/nunjucks/filters/date.js
+++ b/test/shared/view/nunjucks/filters/date.js
@@ -31,8 +31,13 @@ experiment('date Nunjucks filter', () => {
     expect(result).to.equal(undefined);
   });
 
-  test('It should return undefined if an empty value is supplied', async () => {
+  test('It should return undefined if an empty string is supplied', async () => {
     const result = date('');
+    expect(result).to.equal(undefined);
+  });
+
+  test('It should return undefined if null is supplied', async () => {
+    const result = date(null);
     expect(result).to.equal(undefined);
   });
 });

--- a/test/shared/view/nunjucks/filters/date.js
+++ b/test/shared/view/nunjucks/filters/date.js
@@ -21,8 +21,18 @@ experiment('date Nunjucks filter', () => {
     expect(result).to.equal('14 December 2018');
   });
 
-  test('It should return null if an invalid date is supplied', async () => {
+  test('It should return undefined if an invalid date is supplied', async () => {
     const result = date('Some nonsense in here');
-    expect(result).to.equal(null);
+    expect(result).to.equal(undefined);
+  });
+
+  test('It should return undefined if an invalid date is supplied', async () => {
+    const result = date('2020-13-01');
+    expect(result).to.equal(undefined);
+  });
+
+  test('It should return undefined if an empty value is supplied', async () => {
+    const result = date('');
+    expect(result).to.equal(undefined);
   });
 });


### PR DESCRIPTION
Fixes issues with charge version workflows which are in "to_setup" status in the Charge Information tab

* Links work
* Badge displays correctly
* Dates default to hyphens since they are not yet set