### PR TITLE
WATER-2569: Throw an error if the user does not select a file to upload

### DIFF
--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -71,7 +71,7 @@ const getRedirectPath = (status, eventId) => {
 async function postBulkUpload (request, h) {
   let eventId, redirectPath;
 
-  if (request.payload.file.hapi && (!request.payload.file.hapi.filename || request.payload.file.hapi.filename === '')) {
+  if (request.payload.file.hapi && !request.payload.file.hapi.filename) {
     return h.redirect(getRedirectPath(uploadHelpers.fileStatuses.NO_FILE));
   }
 

--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -57,6 +57,7 @@ const getRedirectPath = (status, eventId) => {
   const paths = {
     [uploadHelpers.fileStatuses.VIRUS]: '/returns/upload?error=virus',
     [uploadHelpers.fileStatuses.INVALID_TYPE]: '/returns/upload?error=invalid-type',
+    [uploadHelpers.fileStatuses.NO_FILE]: '/returns/upload?error=no-file',
     [uploadHelpers.fileStatuses.OK]: `/returns/processing-upload/processing/${eventId}`
   };
   return paths[status];
@@ -69,6 +70,11 @@ const getRedirectPath = (status, eventId) => {
  */
 async function postBulkUpload (request, h) {
   let eventId, redirectPath;
+
+  if (request.payload.file.hapi && (!request.payload.file.hapi.filename || request.payload.file.hapi.filename === '')) {
+    return h.redirect(getRedirectPath(uploadHelpers.fileStatuses.NO_FILE));
+  }
+
   const localPath = uploadHelpers.getFile();
 
   try {

--- a/src/external/modules/returns/lib/upload-helpers.js
+++ b/src/external/modules/returns/lib/upload-helpers.js
@@ -21,7 +21,7 @@ const getErrorMessage = key => {
     'invalid-xml': 'The selected file must use the template',
     'invalid-csv': 'The selected file must use the template',
     'invalid-type': 'The selected file must be a CSV or XML file',
-    'no-file': 'Please select a CSV or XML file',
+    'no-file': 'Select a CSV or XML file',
     virus: 'The selected file contains a virus',
     empty: 'The selected file has no returns data in it',
     'invalid-date-format': 'The date format must only include DD/MM/YYYY'

--- a/src/external/modules/returns/lib/upload-helpers.js
+++ b/src/external/modules/returns/lib/upload-helpers.js
@@ -21,6 +21,7 @@ const getErrorMessage = key => {
     'invalid-xml': 'The selected file must use the template',
     'invalid-csv': 'The selected file must use the template',
     'invalid-type': 'The selected file must be a CSV or XML file',
+    'no-file': 'Please select a CSV or XML file',
     virus: 'The selected file contains a virus',
     empty: 'The selected file has no returns data in it',
     'invalid-date-format': 'The date format must only include DD/MM/YYYY'
@@ -68,7 +69,8 @@ const createDirectory = file => mkdirp(path.dirname(file));
 const fileStatuses = {
   OK: 'ok',
   VIRUS: 'virus',
-  INVALID_TYPE: 'invalid-type'
+  INVALID_TYPE: 'invalid-type',
+  NO_FILE: 'no-file'
 };
 
 /**

--- a/test/external/modules/returns/controllers/upload.js
+++ b/test/external/modules/returns/controllers/upload.js
@@ -166,6 +166,22 @@ experiment('external/modules/returns/controllers/upload', () => {
       expect(path).to.equal('/returns/upload?error=invalid-type');
     });
 
+    test('redirects to same page with no file message if no filename is provided', async () => {
+      uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.NO_FILE);
+      await controller.postBulkUpload({
+        ...request,
+        payload: {
+          file: {
+            hapi: {
+              filename: ''
+            }
+          }
+        }
+      }, h);
+      const [path] = h.redirect.lastCall.args;
+      expect(path).to.equal('/returns/upload?error=no-file');
+    });
+
     test('calls the water returns upload API with the correct file type', async () => {
       uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.OK);
       fileCheck.detectFileType.resolves('csv');

--- a/test/external/modules/returns/controllers/upload.js
+++ b/test/external/modules/returns/controllers/upload.js
@@ -167,7 +167,6 @@ experiment('external/modules/returns/controllers/upload', () => {
     });
 
     test('redirects to same page with no file message if no filename is provided', async () => {
-      uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.NO_FILE);
       await controller.postBulkUpload({
         ...request,
         payload: {
@@ -180,6 +179,22 @@ experiment('external/modules/returns/controllers/upload', () => {
       }, h);
       const [path] = h.redirect.lastCall.args;
       expect(path).to.equal('/returns/upload?error=no-file');
+    });
+
+    test('does not redirect a no file page if the filename is set', async () => {
+      uploadHelpers.getUploadedFileStatus.resolves(uploadHelpers.fileStatuses.INVALID_TYPE);
+      await controller.postBulkUpload({
+        ...request,
+        payload: {
+          file: {
+            hapi: {
+              filename: 'test.csv'
+            }
+          }
+        }
+      }, h);
+      const [path] = h.redirect.lastCall.args;
+      expect(path).to.equal('/returns/upload?error=invalid-type');
     });
 
     test('calls the water returns upload API with the correct file type', async () => {

--- a/test/external/modules/returns/lib/upload-helpers.js
+++ b/test/external/modules/returns/lib/upload-helpers.js
@@ -89,6 +89,18 @@ experiment('upload Helpers', () => {
       const output = await uploadHelpers.applyFormError(form, error, errorMessages);
       expect(output).to.equal(updated);
     });
+    test('Form is returned with no-file error message', async () => {
+      const error = 'no-file';
+      const updated = {
+        ...form,
+        errors: [{
+          message: 'Please select a CSV or XML file',
+          name: 'file'
+        }]
+      };
+      const output = await uploadHelpers.applyFormError(form, error, errorMessages);
+      expect(output).to.equal(updated);
+    });
   });
   experiment('uploadFile', () => {
     test('read pipes to write', async () => {

--- a/test/external/modules/returns/lib/upload-helpers.js
+++ b/test/external/modules/returns/lib/upload-helpers.js
@@ -94,7 +94,7 @@ experiment('upload Helpers', () => {
       const updated = {
         ...form,
         errors: [{
-          message: 'Please select a CSV or XML file',
+          message: 'Select a CSV or XML file',
           name: 'file'
         }]
       };


### PR DESCRIPTION
In bulk returns file upload page, uploading no file will cause the API to get through the full file process (creating an empty file, virus scanning, etc) and then return an invalid file message.

This change checks the user has actually uploaded a file first, and then returns the appropriate error if they haven't, without running through the whole file upload function.