### PR TITLE
Include charge period in TPT review screens

### DIFF
--- a/src/internal/modules/billing/controllers/two-part-tariff.js
+++ b/src/internal/modules/billing/controllers/two-part-tariff.js
@@ -107,8 +107,7 @@ const getBillingVolumeReview = async (request, h, form) => {
     ...licenceData,
     billingVolume,
     form: form || twoPartTariffQuantityForm.form(request, billingVolume),
-    back: `/billing/batch/${batch.id}/two-part-tariff/licence/${licence.id}`,
-    returnCycle: mappers.mapReturnCycle(billingVolume)
+    back: `/billing/batch/${batch.id}/two-part-tariff/licence/${licence.id}`
   });
 };
 
@@ -163,7 +162,7 @@ const getConfirmQuantity = async (request, h) => {
     pageTitle: `You're about to set the billable quantity to ${quantity}ML`,
     caption: `Licence ${licence.licenceNumber}`,
     back: `/billing/batch/${batch.id}/two-part-tariff/licence/${licence.id}/billing-volume/${billingVolume.id}`,
-    returnCycle: mappers.mapReturnCycle(billingVolume)
+    billingVolume
   });
 };
 

--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -146,16 +146,6 @@ const mapBatchLevelErrors = (batch, invoices) => invoices
 const isCreditDebitBlockVisible = batch =>
   batch.source === 'wrls' && batch.type === 'supplementary';
 
-/**
- * Maps a billing volume model to a string for the return cycle
- * @param {Object} billingVolume
- * @returns {String}
- */
-const mapReturnCycle = billingVolume => {
-  const prefix = billingVolume.isSummer ? 'Summer' : 'Winter and all year';
-  return `${prefix} ${billingVolume.financialYear.yearEnding}`;
-};
-
 exports.mapBatchListRow = mapBatchListRow;
 exports.mapInvoiceLicences = mapInvoiceLicences;
 exports.mapBatchType = mapBatchType;
@@ -164,4 +154,3 @@ exports.mapInvoices = mapInvoices;
 exports.mapInvoiceLevelErrors = mapInvoiceLevelErrors;
 exports.mapBatchLevelErrors = mapBatchLevelErrors;
 exports.isCreditDebitBlockVisible = isCreditDebitBlockVisible;
-exports.mapReturnCycle = mapReturnCycle;

--- a/src/internal/views/nunjucks/billing/two-part-tariff-quantities-confirm.njk
+++ b/src/internal/views/nunjucks/billing/two-part-tariff-quantities-confirm.njk
@@ -16,13 +16,13 @@
     <table class="govuk-table govuk-!-margin-bottom-9">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Returns cycle</th>
+          <th scope="col" class="govuk-table__header">Charge period</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric">Billable quantity</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ returnCycle }}</td>
+          <td class="govuk-table__cell">{{ billingVolume.chargePeriod.startDate | date }} to {{ billingVolume.chargePeriod.endDate | date}}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ quantity }}ML</td>
         </tr>
       </tbody>

--- a/src/internal/views/nunjucks/billing/two-part-tariff-quantities.njk
+++ b/src/internal/views/nunjucks/billing/two-part-tariff-quantities.njk
@@ -85,7 +85,7 @@
       <table class="govuk-table govuk-!-margin-bottom-9">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Returns cycle</th>
+            <th scope="col" class="govuk-table__header">Charge period</th>
             <th scope="col" class="govuk-table__header">Element quantity</th>
             <th scope="col" class="govuk-table__header">Reported quantity</th>
             <th scope="col" class="govuk-table__header">Billable quantity</th>
@@ -94,7 +94,7 @@
         </thead>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ returnCycle }}</td>
+            <td class="govuk-table__cell">{{ billingVolume.chargePeriod.startDate | date }} to {{ billingVolume.chargePeriod.endDate | date}}</td>
             <td class="govuk-table__cell">{{ chargeElementQuantity(billingVolume.chargeElement) }}</td>
             <td class="govuk-table__cell">{{ reportedVolume(billingVolume) }}</td>
             <td class="govuk-table__cell">{{ billableVolume(billingVolume) }}</td>

--- a/test/internal/modules/billing/controllers/two-part-tariff.js
+++ b/test/internal/modules/billing/controllers/two-part-tariff.js
@@ -581,11 +581,6 @@ experiment('internal/modules/billing/controller/two-part-tariff', () => {
         expect(returnsLink).to.equal('/licences/test-document_id/returns');
       });
 
-      test('sets the return cycle in the view', async () => {
-        const [, { returnCycle }] = h.view.lastCall.args;
-        expect(returnCycle).to.equal('Winter and all year 2022');
-      });
-
       experiment('view.aggregateConditions', () => {
         let aggregateConditions;
         beforeEach(async () => {
@@ -837,11 +832,6 @@ experiment('internal/modules/billing/controller/two-part-tariff', () => {
     test('outputs the quantity to the view', async () => {
       const [, { quantity }] = h.view.lastCall.args;
       expect(quantity).to.equal(request.query.quantity);
-    });
-
-    test('sets the return cycle in the view', async () => {
-      const [, { returnCycle }] = h.view.lastCall.args;
-      expect(returnCycle).to.equal('Winter and all year 2022');
     });
 
     test('outputs the licence to the view', async () => {

--- a/test/internal/modules/billing/lib/mappers.js
+++ b/test/internal/modules/billing/lib/mappers.js
@@ -426,26 +426,4 @@ experiment('modules/billing/lib/mappers', () => {
       }]);
     });
   });
-
-  experiment('.mapReturnCycle', () => {
-    test('maps a winter/all year billing volume', async () => {
-      const str = mappers.mapReturnCycle({
-        isSummer: false,
-        financialYear: {
-          yearEnding: 2022
-        }
-      });
-      expect(str).to.equal('Winter and all year 2022');
-    });
-
-    test('maps a summer billing volume', async () => {
-      const str = mappers.mapReturnCycle({
-        isSummer: true,
-        financialYear: {
-          yearEnding: 2022
-        }
-      });
-      expect(str).to.equal('Summer 2022');
-    });
-  });
 });


### PR DESCRIPTION
Adds back the charge period to the TPT review screens, now that it is included in the billing volume API response