### PR TITLE
Always show zero volumes and TPT statuses

### DIFF
--- a/src/internal/modules/billing/lib/two-part-tariff.js
+++ b/src/internal/modules/billing/lib/two-part-tariff.js
@@ -53,7 +53,7 @@ const getBillingVolumeGroup = billingVolume => {
 };
 
 const getBillingVolumeError = billingVolume =>
-  billingVolume.twoPartTariffError ? statusMessages.get(billingVolume.twoPartTariffStatus) : null;
+  statusMessages.get(billingVolume.twoPartTariffStatus);
 
 /**
  * Decorates transactions with edit link and error message,

--- a/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
+++ b/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
@@ -15,7 +15,7 @@
 {% endmacro %}
 
 {% macro billableVolume(billingVolume) %}
-{% if billingVolume.volume > 0 and billingVolume.volume | isFinite %}
+{% if billingVolume.volume | isFinite %}
   {{ billingVolume.volume + 'ML' }}
   {% if billingVolume.volume != billingVolume.calculatedVolume and billingVolume.calculatedVolume | isFinite %}
     {{ ' - edited' }}


### PR DESCRIPTION
Minor UI tweaks in TPT review flow:
* Numeric volumes always visible (previously zero was hidden)
* Always shows TPT matching error, even when resolved 