### PR TITLE
Destroy the session if the user account is disabled

### DIFF
--- a/src/shared/lib/AuthConfig.js
+++ b/src/shared/lib/AuthConfig.js
@@ -86,6 +86,10 @@ class AuthConfig {
       const { error, data: user } = await this.connectors.idm.users.findOne(userId);
       throwIfError(error);
 
+      if (!user.enabled) {
+        return { valid: false };
+      }
+
       // Get user data and augment request
       const data = await this._mapUserRequestData(request, user);
 


### PR DESCRIPTION
When we have active session for an internal user and if we delete the user then the session is still active and user can perform all actions.

This change checks to see if the user account has been disabled and invalidates the session if it has.