### PR TITLE
BUGFIX WATER 3198 - create charge versions for future dated licences

### DIFF
--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -37,12 +37,13 @@ const getDates = licence => {
   const startDate = moment(licence.startDate);
   const minDate = moment().subtract(6, 'years');
   const isLicenceStart = startDate.isAfter(minDate);
-  return {
+  const ret = {
     licenceStartDate: licence.startDate,
     minDate: isLicenceStart ? licence.startDate : minDate.format(ISO_FORMAT),
     minType: isLicenceStart ? MIN_LICENCE_START : MIN_6_YEARS,
     maxDate: licence.endDate || '3000-01-01'
   };
+  return ret;
 };
 
 const minErrors = {
@@ -111,6 +112,8 @@ const getChoices = (dates, values, refDate, isChargeable) => {
         : getCustomEffectiveDateField(dates, values.customDate)
     ]
   }];
+  // if it is a future dated licence remove the today option
+  if (moment(dates.licenceStartDate).isAfter(moment())) allChoices.shift();
 
   return dates.minType === MIN_LICENCE_START ? allChoices : pullAt(allChoices, [0, 3]);
 };

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -112,11 +112,20 @@ const getChoices = (dates, values, refDate, isChargeable) => {
     ]
   }];
   // if it is a future dated licence remove the today option
-  if (moment(dates.licenceStartDate).isAfter(moment())) {
+  if (moment(dates.licenceStartDate).isAfter(moment()) || moment(dates.maxDate).isBefore(moment())) {
     allChoices.shift();
   }
 
-  return dates.minType === MIN_LICENCE_START ? allChoices : pullAt(allChoices, [0, 3]);
+  if (dates.minType === MIN_LICENCE_START) {
+    return allChoices;
+  } else {
+    if (allChoices[0].value === 'licenceStartDate') {
+      allChoices[2].label = 'Custom date';
+      return [allChoices[2]];
+    } else {
+      return pullAt(allChoices, [0, 3]);
+    }
+  }
 };
 
 /**

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -111,7 +111,7 @@ const getChoices = (dates, values, refDate, isChargeable) => {
         : getCustomEffectiveDateField(dates, values.customDate)
     ]
   }];
-  // if it is a future dated licence remove the today option
+  // if it is a future dated licence or the licence is expired remove the today option
   if (moment(dates.licenceStartDate).isAfter(moment()) || moment(dates.maxDate).isBefore(moment())) {
     allChoices.shift();
   }
@@ -120,9 +120,11 @@ const getChoices = (dates, values, refDate, isChargeable) => {
     return allChoices;
   } else {
     if (allChoices[0].value === 'licenceStartDate') {
+      // rename label and only display Custom date
       allChoices[2].label = 'Custom date';
       return [allChoices[2]];
     } else {
+      // if today's date is included as an option then pick 'today' and 'custom date' as radio options
       return pullAt(allChoices, [0, 3]);
     }
   }

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -112,7 +112,7 @@ const getChoices = (dates, values, refDate, isChargeable) => {
     ]
   }];
   // if it is a future dated licence remove the today option
-  if (moment(dates.licenceStartDate).isAfter(moment())) allChoices.shift();
+  if (moment(dates.licenceStartDate).isAfter(moment())) { allChoices.shift(); }
 
   return dates.minType === MIN_LICENCE_START ? allChoices : pullAt(allChoices, [0, 3]);
 };

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -37,13 +37,12 @@ const getDates = licence => {
   const startDate = moment(licence.startDate);
   const minDate = moment().subtract(6, 'years');
   const isLicenceStart = startDate.isAfter(minDate);
-  const ret = {
+  return {
     licenceStartDate: licence.startDate,
     minDate: isLicenceStart ? licence.startDate : minDate.format(ISO_FORMAT),
     minType: isLicenceStart ? MIN_LICENCE_START : MIN_6_YEARS,
     maxDate: licence.endDate || '3000-01-01'
   };
-  return ret;
 };
 
 const minErrors = {

--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -112,7 +112,9 @@ const getChoices = (dates, values, refDate, isChargeable) => {
     ]
   }];
   // if it is a future dated licence remove the today option
-  if (moment(dates.licenceStartDate).isAfter(moment())) { allChoices.shift(); }
+  if (moment(dates.licenceStartDate).isAfter(moment())) {
+    allChoices.shift();
+  }
 
   return dates.minType === MIN_LICENCE_START ? allChoices : pullAt(allChoices, [0, 3]);
 };

--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -6,6 +6,7 @@ const mappers = require('./lib/mappers');
 const { scope } = require('../../lib/constants');
 const { hasScope } = require('../../lib/permissions');
 const { featureToggles } = require('../../config');
+const moment = require('moment');
 
 const getDocumentId = doc => doc.document_id;
 
@@ -30,6 +31,7 @@ const getLicenceSummary = async (request, h) => {
     documentId,
     ...pick(request.pre, ['licence', 'bills', 'notifications', 'primaryUser', 'summary']),
     chargeVersions: mappers.mapChargeVersions(chargeVersions, chargeVersionWorkflows),
+    createChargeVersions: moment(licence.endDate).isBefore(moment().add(-6, 'years')),
     agreements: mappers.mapLicenceAgreements(agreements),
     returns: mappers.mapReturns(request, returns),
     links: {

--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -31,7 +31,7 @@ const getLicenceSummary = async (request, h) => {
     documentId,
     ...pick(request.pre, ['licence', 'bills', 'notifications', 'primaryUser', 'summary']),
     chargeVersions: mappers.mapChargeVersions(chargeVersions, chargeVersionWorkflows),
-    createChargeVersions: moment(licence.endDate).isBefore(moment().add(-6, 'years')),
+    createChargeVersions: moment(licence.endDate).isAfter(moment().subtract(6, 'years')),
     agreements: mappers.mapLicenceAgreements(agreements),
     returns: mappers.mapReturns(request, returns),
     links: {

--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -127,15 +127,14 @@
   <p>No charge information for this licence.</p>
 {% endif %}
 
-
-<a href="/licences/{{ licenceId }}/charge-information/create" role="button" draggable="false" class="govuk-button govuk-!-margin-right-3" data-module="govuk-button">
-  Set up a new charge
-</a>
-
-
-<a href="/licences/{{ licenceId }}/charge-information/non-chargeable-reason?start=1" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-  Make licence non-chargeable
-</a>
+{% if createChargeVersions %}
+  <a href="/licences/{{ licenceId }}/charge-information/create" role="button" draggable="false" class="govuk-button govuk-!-margin-right-3" data-module="govuk-button">
+    Set up a new charge
+  </a> 
+  <a href="/licences/{{ licenceId }}/charge-information/non-chargeable-reason?start=1" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+    Make licence non-chargeable
+  </a>
+{% endif %}
 
 {% if agreements.length %}
 
@@ -166,9 +165,10 @@
 {% else %}
   <p>No agreements for this licence.</p>
 {% endif %}
-
-{{ govukButton({
+{% if createChargeVersions %}
+  {{ govukButton({
   href : links.addAgreement,
   text: 'Set up a new agreement',
   classes: 'govuk-button--secondary'
 })}}
+{% endif %}

--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -128,11 +128,10 @@
 {% endif %}
 
 
-{% if licence.isActive %}
 <a href="/licences/{{ licenceId }}/charge-information/create" role="button" draggable="false" class="govuk-button govuk-!-margin-right-3" data-module="govuk-button">
   Set up a new charge
 </a>
-{% endif %}
+
 
 <a href="/licences/{{ licenceId }}/charge-information/non-chargeable-reason?start=1" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
   Make licence non-chargeable

--- a/test/internal/modules/charge-information/controllers/charge-information.js
+++ b/test/internal/modules/charge-information/controllers/charge-information.js
@@ -659,7 +659,7 @@ experiment('internal/modules/charge-information/controller', () => {
 
       test('an error is displayed', async () => {
         const [ form ] = h.postRedirectGet.lastCall.args;
-        const field = find(form.fields, { name: 'startDate' }).options.choices[3].fields[0];
+        const field = find(form.fields, { name: 'startDate' }).options.choices[2].fields[0];
         expect(field.errors[0].message).to.equal('You must enter a date before the licence end date');
       });
     });

--- a/test/internal/modules/charge-information/controllers/non-chargeable.js
+++ b/test/internal/modules/charge-information/controllers/non-chargeable.js
@@ -312,7 +312,7 @@ experiment('internal/modules/charge-information/controller', () => {
 
     test('an error is displayed', async () => {
       const [ form ] = h.postRedirectGet.lastCall.args;
-      const field = find(form.fields, { name: 'startDate' }).options.choices[3].fields[0];
+      const field = find(form.fields, { name: 'startDate' }).options.choices[2].fields[0];
       expect(field.errors[0].message).to.equal('You must enter a date before the licence end date');
     });
   });

--- a/test/internal/modules/charge-information/forms/start-date.js
+++ b/test/internal/modules/charge-information/forms/start-date.js
@@ -8,7 +8,7 @@ const { findField, findButton } = require('../../../../lib/form-test');
 const Joi = require('@hapi/joi');
 const moment = require('moment');
 
-const createRequest = (startDate, isChargeable = true, licenceStart = '2016-04-01') => ({
+const createRequest = (startDate, isChargeable = true, licenceStart = '2016-04-01', licenceEnd = '2030-03-31') => ({
   view: {
     csrfToken: 'token'
   },
@@ -17,7 +17,7 @@ const createRequest = (startDate, isChargeable = true, licenceStart = '2016-04-0
     licence: {
       id: 'test-licence-id',
       startDate: licenceStart,
-      endDate: '2030-03-31'
+      endDate: licenceEnd
     },
     draftChargeInformation: {
       dateRange: {
@@ -144,6 +144,13 @@ experiment('internal/modules/charge-information/forms/start-date', () => {
         experiment('when the licence start date is in the future', () => {
           test('the today start option is removed', () => {
             const dateForm = form(createRequest(moment(), false, moment().add(1, 'months').format('YYYY-MM-DD')));
+            const radio = findField(dateForm, 'startDate');
+            expect(radio.options.choices[0].label === 'Today').to.be.false();
+          });
+        });
+        experiment('when the licence end date is in the past i.e. expired', () => {
+          test('the today start option is removed', () => {
+            const dateForm = form(createRequest(moment(), false, moment().add(-1, 'years').format('YYYY-MM-DD'), moment().add(-1, 'months').format('YYYY-MM-DD')));
             const radio = findField(dateForm, 'startDate');
             expect(radio.options.choices[0].label === 'Today').to.be.false();
           });

--- a/test/internal/modules/charge-information/forms/start-date.js
+++ b/test/internal/modules/charge-information/forms/start-date.js
@@ -150,7 +150,7 @@ experiment('internal/modules/charge-information/forms/start-date', () => {
         });
         experiment('when the licence end date is in the past i.e. expired', () => {
           test('the today start option is removed', () => {
-            const dateForm = form(createRequest(moment(), false, moment().add(-1, 'years').format('YYYY-MM-DD'), moment().add(-1, 'months').format('YYYY-MM-DD')));
+            const dateForm = form(createRequest(moment(), false, moment().subtract(1, 'years').format('YYYY-MM-DD'), moment().subtract(1, 'months').format('YYYY-MM-DD')));
             const radio = findField(dateForm, 'startDate');
             expect(radio.options.choices[0].label === 'Today').to.be.false();
           });

--- a/test/internal/modules/charge-information/forms/start-date.js
+++ b/test/internal/modules/charge-information/forms/start-date.js
@@ -89,6 +89,22 @@ experiment('internal/modules/charge-information/forms/start-date', () => {
       });
     });
 
+    experiment('when the licence end date is in the past i.e. expired', () => {
+      test('the today start option is removed', () => {
+        const dateForm = form(createRequest(moment(), true, moment().subtract(8, 'years').format('YYYY-MM-DD'), moment().subtract(1, 'months').format('YYYY-MM-DD')));
+        const radio = findField(dateForm, 'startDate');
+        expect(radio.options.choices[0].label === 'Today').to.be.false();
+      });
+    });
+
+    experiment('when the licence is not future dated or expired', () => {
+      test('the today start option is available', () => {
+        const dateForm = form(createRequest(moment(), true, moment().subtract(8, 'years').format('YYYY-MM-DD'), moment().add(1, 'months').format('YYYY-MM-DD')));
+        const radio = findField(dateForm, 'startDate');
+        expect(radio.options.choices[0].label === 'Today').to.be.true();
+      });
+    });
+
     experiment('when the licence is set to be non-chargeable', () => {
       let dateForm;
 

--- a/test/internal/modules/view-licences/controller.js
+++ b/test/internal/modules/view-licences/controller.js
@@ -7,6 +7,7 @@ const {
   before
 } = exports.lab = require('@hapi/lab').script();
 
+const moment = require('moment');
 const sandbox = require('sinon').createSandbox();
 const uuid = require('uuid/v4');
 
@@ -200,6 +201,22 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
     test('includes a back link', async () => {
       const [, { back }] = h.view.lastCall.args;
       expect(back).to.equal('/licences');
+    });
+    experiment('when the licence has ended less than 6 years ago', () => {
+      test('createChargeVersions flag is true', async () => {
+        request.pre.licence.endDate = moment().add(-5, 'years');
+        await controller.getLicenceSummary(request, h);
+        const [, { createChargeVersions }] = h.view.lastCall.args;
+        expect(createChargeVersions).to.be.true();
+      });
+    });
+    experiment('when the licence has ended more than 6 years ago', () => {
+      test('createChargeVersions flag is false', async () => {
+        request.pre.licence.endDate = moment().add(-7, 'years');
+        await controller.getLicenceSummary(request, h);
+        const [, { createChargeVersions }] = h.view.lastCall.args;
+        expect(createChargeVersions).to.be.false();
+      });
     });
   });
 


### PR DESCRIPTION
bugfix/water-3198
-- remove today's date option for future dated licences