### PR TITLE
Allow create charge versions where licences end date is null

### DIFF
--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -31,7 +31,7 @@ const getLicenceSummary = async (request, h) => {
     documentId,
     ...pick(request.pre, ['licence', 'bills', 'notifications', 'primaryUser', 'summary']),
     chargeVersions: mappers.mapChargeVersions(chargeVersions, chargeVersionWorkflows),
-    createChargeVersions: moment(licence.endDate).isAfter(moment().subtract(6, 'years')),
+    createChargeVersions: moment(licence.endDate).isAfter(moment().subtract(6, 'years')) || licence.endDate === null,
     agreements: mappers.mapLicenceAgreements(agreements),
     returns: mappers.mapReturns(request, returns),
     links: {


### PR DESCRIPTION
bugfix/water-3198
-- licences with end date null can create charge versions