### PR TITLE
FIx issue with return status badge on internal licence page

### DIFF
--- a/src/internal/lib/mappers/returns.js
+++ b/src/internal/lib/mappers/returns.js
@@ -34,9 +34,8 @@ const mapReturn = (ret, request) => {
  * @param {Object} request - HAPI request interface
  * @return {Array} returns with isEditable flag added
  */
-const mapReturns = (returns, request) => {
-  return returns.map(row => mapReturn(row, request));
-};
+const mapReturns = (returns, request) =>
+  returns.map(row => mapReturn(row, request));
 
 exports.mapReturn = mapReturn;
 exports.mapReturns = mapReturns;

--- a/src/internal/lib/mappers/returns.js
+++ b/src/internal/lib/mappers/returns.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const dates = require('shared/lib/returns/dates');
+const badge = require('shared/lib/returns/badge');
+const { getReturnPath } = require('../return-path');
+
+/**
+ * Maps return data so that it includes the correct paths
+ * and data to render a badge and link
+ *
+ * @param {Object} ret
+ * @param {Object} request
+ * @returns {Object}
+ */
+const mapReturn = (ret, request) => {
+  const isPastDueDate = dates.isReturnPastDueDate(ret);
+  return {
+    ...ret,
+    badge: badge.getBadge(ret.status, isPastDueDate),
+    ...getReturnPath(ret, request)
+  };
+};
+
+/**
+ * Adds some flags to the returns to help with view rendering
+ *
+ * Adds an editable flag to each return in list
+ * This is based on the status of the return, and whether the user
+ * has internal returns role.
+ *
+ * Adds isPastDueDate flag to help with badge selection.
+ *
+ * @param {Array} returns - returned from returns service
+ * @param {Object} request - HAPI request interface
+ * @return {Array} returns with isEditable flag added
+ */
+const mapReturns = (returns, request) => {
+  return returns.map(row => mapReturn(row, request));
+};
+
+exports.mapReturn = mapReturn;
+exports.mapReturns = mapReturns;

--- a/src/internal/modules/internal-search/lib/api-response-mapper.js
+++ b/src/internal/modules/internal-search/lib/api-response-mapper.js
@@ -1,4 +1,5 @@
-const { mapReturns } = require('../../returns/lib/helpers');
+'use strict';
+const returnsMapper = require('../../../lib/mappers/returns');
 
 /**
  * Maps the response from the water service internal search API to a form
@@ -14,7 +15,7 @@ const mapResponseToView = (response, request) => {
   return {
     ...response,
     noResults,
-    returns: returns ? mapReturns(returns, request) : null,
+    returns: returns ? returnsMapper.mapReturns(returns, request) : null,
     billingAccounts: billingAccounts || null
   };
 };

--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const { pick } = require('lodash');
+const moment = require('moment');
 
 const mappers = require('./lib/mappers');
 const { scope } = require('../../lib/constants');
 const { hasScope } = require('../../lib/permissions');
 const { featureToggles } = require('../../config');
-const moment = require('moment');
+const returnsMapper = require('../../lib/mappers/returns');
 
 const getDocumentId = doc => doc.document_id;
 
@@ -33,7 +34,10 @@ const getLicenceSummary = async (request, h) => {
     chargeVersions: mappers.mapChargeVersions(chargeVersions, chargeVersionWorkflows),
     createChargeVersions: moment(licence.endDate).isAfter(moment().subtract(6, 'years')) || licence.endDate === null,
     agreements: mappers.mapLicenceAgreements(agreements),
-    returns: mappers.mapReturns(request, returns),
+    returns: {
+      pagination: returns.pagination,
+      data: returnsMapper.mapReturns(returns.data, request)
+    },
     links: {
       bills: `/licences/${licenceId}/bills`,
       returns: `/licences/${documentId}/returns`,

--- a/src/internal/modules/view-licences/lib/mappers.js
+++ b/src/internal/modules/view-licences/lib/mappers.js
@@ -3,7 +3,6 @@
 const moment = require('moment');
 const { sortBy } = require('lodash');
 const agreementMapper = require('shared/lib/mappers/agreements');
-const { getReturnPath } = require('../../../lib/return-path');
 
 const validityMessageMap = new Map()
   .set('expiredDate', 'expired on')
@@ -47,22 +46,7 @@ const mapLicenceAgreement = licenceAgreement => ({
 const mapLicenceAgreements = licenceAgreements =>
   licenceAgreements && licenceAgreements.map(mapLicenceAgreement);
 
-const mapReturns = (request, returns) => {
-  if (!returns) {
-    return null;
-  }
-  const { data, pagination } = returns;
-  return {
-    pagination,
-    data: data.map(ret => ({
-      ...ret,
-      ...getReturnPath(ret, request)
-    }))
-  };
-};
-
 exports.getValidityNotice = getValidityNotice;
 exports.mapChargeVersions = mapChargeVersions;
 exports.mapLicenceAgreement = mapLicenceAgreement;
 exports.mapLicenceAgreements = mapLicenceAgreements;
-exports.mapReturns = mapReturns;

--- a/src/internal/views/nunjucks/internal-search/index.njk
+++ b/src/internal/views/nunjucks/internal-search/index.njk
@@ -145,7 +145,7 @@
                 </td>
                 <td class="govuk-table__cell">{{ return.licence_ref }}</td>
                 <td class="govuk-table__cell">{{ return.region }}</td>
-                <td class="govuk-table__cell">{{ badge(return.badge.text, return.badge.status) }}</td>
+                <td class="govuk-table__cell">{{ badge(return | returnBadge) }}</td>
               </tr>
               {% endfor %}
             </tbody>

--- a/src/internal/views/nunjucks/view-licences/tabs/returns.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/returns.njk
@@ -38,7 +38,7 @@
   </h3>
 
   <p>{{ returnRequirementPurposes(return) }}
-    <br /><span class="govuk-caption-m link--no-underline">Due {{ return.due_date | date }}</span>
+    <br /><span class="govuk-caption-m link--no-underline">Due {{ return.dueDate | date }}</span>
   </p>
 
   {{ badge(return | returnBadge) }}

--- a/src/shared/lib/returns/dates.js
+++ b/src/shared/lib/returns/dates.js
@@ -2,8 +2,10 @@
 
 const moment = require('moment');
 
+const getDueDate = ret => ret.due_date || ret.dueDate;
+
 const isReturnPastDueDate = returnRow => {
-  const dueDate = moment(returnRow.due_date, 'YYYY-MM-DD');
+  const dueDate = moment(getDueDate(returnRow), 'YYYY-MM-DD');
   const today = moment().startOf('day');
   return dueDate.isBefore(today);
 };

--- a/test/internal/modules/contact-entry/controller.js
+++ b/test/internal/modules/contact-entry/controller.js
@@ -125,7 +125,6 @@ experiment('src/internal/modules/contact-entry/controller', () => {
         });
 
         test('the contact id is stored in the session', async () => {
-          console.log(session.merge.lastCall.args);
           expect(session.merge.calledWith(
             request, KEY, {
               data: request.pre.companyContacts[0]

--- a/test/internal/modules/view-licences/controller.js
+++ b/test/internal/modules/view-licences/controller.js
@@ -168,6 +168,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
           id: 'test-return-id-1',
           status: 'due',
           endDate: '2021-03-31',
+          badge: { text: 'Due', status: 'todo' },
           path: '/return/internal?returnId=test-return-id-1',
           isEdit: true
         },
@@ -175,6 +176,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
           id: 'test-return-id-2',
           status: 'completed',
           endDate: '2021-03-31',
+          badge: { text: 'Complete', status: 'success' },
           path: '/returns/return?id=test-return-id-2',
           isEdit: false
         }

--- a/test/internal/modules/view-licences/lib/mappers.js
+++ b/test/internal/modules/view-licences/lib/mappers.js
@@ -7,7 +7,6 @@ const {
 const uuid = require('uuid/v4');
 
 const mappers = require('internal/modules/view-licences/lib/mappers');
-const { scope } = require('internal/lib/constants');
 
 experiment('internal/modules/billing/controllers/lib/mappers', () => {
   experiment('.getValidityNotice', () => {
@@ -141,52 +140,6 @@ experiment('internal/modules/billing/controllers/lib/mappers', () => {
         id: agreements[0].id,
         agreement: { code: 'S127', description: 'Two-part tariff (S127)' }
       }]);
-    });
-  });
-
-  experiment('.mapReturns', () => {
-    const returns = {
-      data: [{
-        id: 'test-return-id-1',
-        status: 'due',
-        endDate: '2021-03-31'
-      }, {
-        id: 'test-return-id-2',
-        status: 'completed',
-        endDate: '2021-03-31'
-      }]
-    };
-
-    test('returns null when returns are null', async () => {
-      const result = mappers.mapReturns(null);
-      expect(result).to.be.null();
-    });
-
-    test('returns array of mapped returns when returns are not null', async () => {
-      const request = {
-        auth: {
-          credentials: {
-            scope: [scope.returns]
-          }
-        }
-      };
-      const result = mappers.mapReturns(request, returns);
-      expect(result.data).to.equal([
-        {
-          id: 'test-return-id-1',
-          status: 'due',
-          endDate: '2021-03-31',
-          path: '/return/internal?returnId=test-return-id-1',
-          isEdit: true
-        },
-        {
-          id: 'test-return-id-2',
-          status: 'completed',
-          endDate: '2021-03-31',
-          path: '/returns/return?id=test-return-id-2',
-          isEdit: false
-        }
-      ]);
     });
   });
 });


### PR DESCRIPTION
`WATER-3216`
* Fixes issue with "overdue" status not showing for returns
* Moves mapping of returns to shared location for internal site
* Other minor UI bugfixes