### PR TITLE
Bugfix/WATER-3269: Handle 'null' second line in address

### DIFF
--- a/test/internal/modules/address-entry/pre-handlers.js
+++ b/test/internal/modules/address-entry/pre-handlers.js
@@ -13,17 +13,29 @@ const services = require('internal/lib/connectors/services');
 
 const preHandlers = require('internal/modules/address-entry/pre-handlers');
 
-const POSTCODE = 'TT1 1TT';
+const POST_CODE = 'TT1 1TT';
+const ADDRESS1 = {
+  addressLine1: 'Line 1',
+  addressLine2: 'Line 2',
+  addressLine3: 'Line 3',
+  postcode: POST_CODE,
+}
+const INVALID_ADDRESS = {
+  addressLine1: 'Line 1',
+  addressLine2: null,
+  addressLine3: null,
+  postcode: POST_CODE,
+}
 
 experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesByPostcode', () => {
   let request, result;
   beforeEach(async () => {
     sandbox.stub(services.water.addressSearch, 'getAddressSearchResults')
-      .resolves({ data: { foo: 'bar' } });
+      .resolves({ data: [ADDRESS1, INVALID_ADDRESS] });
 
     request = {
       query: {
-        postcode: POSTCODE
+        postcode: POST_CODE
       }
     };
     result = await preHandlers.searchForAddressesByPostcode(request);
@@ -33,11 +45,11 @@ experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesB
 
   test('calls the address search with the postcode', () => {
     const [postcode] = services.water.addressSearch.getAddressSearchResults.lastCall.args;
-    expect(postcode).to.equal(POSTCODE);
+    expect(postcode).to.equal(POST_CODE);
   });
 
-  test('returns the data from the address search', () => {
-    expect(result).to.equal({ foo: 'bar' });
+  test('returns the data from the address search and omits invalid address', () => {
+    expect(result).to.equal([ ADDRESS1 ]);
   });
 
   test('returns a Boom not found error if a 404 is returned', async () => {
@@ -49,7 +61,7 @@ experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesB
     result = await preHandlers.searchForAddressesByPostcode(request);
 
     expect(result.isBoom).to.be.true();
-    expect(result.message).to.equal(`No addresses found for postcode ${POSTCODE}`);
+    expect(result.message).to.equal(`No addresses found for postcode ${POST_CODE}`);
   });
 
   test('throws error if an unexpected error is returned', async () => {

--- a/test/internal/modules/address-entry/pre-handlers.js
+++ b/test/internal/modules/address-entry/pre-handlers.js
@@ -18,14 +18,15 @@ const ADDRESS1 = {
   addressLine1: 'Line 1',
   addressLine2: 'Line 2',
   addressLine3: 'Line 3',
-  postcode: POST_CODE,
-}
+  postcode: POST_CODE
+};
+
 const INVALID_ADDRESS = {
   addressLine1: 'Line 1',
   addressLine2: null,
   addressLine3: null,
-  postcode: POST_CODE,
-}
+  postcode: POST_CODE
+};
 
 experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesByPostcode', () => {
   let request, result;

--- a/test/internal/modules/address-entry/pre-handlers.js
+++ b/test/internal/modules/address-entry/pre-handlers.js
@@ -59,6 +59,11 @@ experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesB
     expect(result).to.equal([ ADDRESS, ADDRESS ]);
   });
 
+  test('returns the data from the address search and omits invalid address', async () => {
+    const result = await addressSearch([INVALID_ADDRESS]);
+    expect(result).to.equal([ ADDRESS, ADDRESS ]);
+  });
+
   test('returns a Boom not found error if a 404 is returned', async () => {
     const err = new Error();
     err.statusCode = 404;

--- a/test/internal/modules/address-entry/pre-handlers.js
+++ b/test/internal/modules/address-entry/pre-handlers.js
@@ -14,7 +14,7 @@ const services = require('internal/lib/connectors/services');
 const preHandlers = require('internal/modules/address-entry/pre-handlers');
 
 const POST_CODE = 'TT1 1TT';
-const ADDRESS1 = {
+const ADDRESS = {
   addressLine1: 'Line 1',
   addressLine2: 'Line 2',
   addressLine3: 'Line 3',
@@ -29,28 +29,34 @@ const INVALID_ADDRESS = {
 };
 
 experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesByPostcode', () => {
-  let request, result;
-  beforeEach(async () => {
-    sandbox.stub(services.water.addressSearch, 'getAddressSearchResults')
-      .resolves({ data: [ADDRESS1, INVALID_ADDRESS] });
+  let stub;
+  const request = {
+    query: {
+      postcode: POST_CODE
+    }
+  };
 
-    request = {
-      query: {
-        postcode: POST_CODE
-      }
-    };
-    result = await preHandlers.searchForAddressesByPostcode(request);
+  beforeEach(async () => {
+    stub = sandbox.stub(services.water.addressSearch, 'getAddressSearchResults');
   });
 
   afterEach(() => sandbox.restore());
 
-  test('calls the address search with the postcode', () => {
+  function addressSearch (addresses = []) {
+    stub.resolves({ data: [ADDRESS, ADDRESS, ...addresses] });
+
+    return preHandlers.searchForAddressesByPostcode(request);
+  }
+
+  test('calls the address search with the postcode', async () => {
+    await addressSearch();
     const [postcode] = services.water.addressSearch.getAddressSearchResults.lastCall.args;
     expect(postcode).to.equal(POST_CODE);
   });
 
-  test('returns the data from the address search and omits invalid address', () => {
-    expect(result).to.equal([ ADDRESS1 ]);
+  test('returns the data from the address search', async () => {
+    const result = await addressSearch();
+    expect(result).to.equal([ ADDRESS, ADDRESS ]);
   });
 
   test('returns a Boom not found error if a 404 is returned', async () => {
@@ -59,7 +65,7 @@ experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesB
     services.water.addressSearch.getAddressSearchResults
       .rejects(err);
 
-    result = await preHandlers.searchForAddressesByPostcode(request);
+    const result = await preHandlers.searchForAddressesByPostcode(request);
 
     expect(result.isBoom).to.be.true();
     expect(result.message).to.equal(`No addresses found for postcode ${POST_CODE}`);
@@ -70,7 +76,7 @@ experiment('src/internal/modules/address-entry/pre-handlers .searchForAddressesB
     services.water.addressSearch.getAddressSearchResults
       .rejects(error);
     try {
-      result = await preHandlers.searchForAddressesByPostcode(request);
+      await preHandlers.searchForAddressesByPostcode(request);
     } catch (err) {
       expect(err).to.equal(error);
     }


### PR DESCRIPTION
Jira ticket: https://eaflood.atlassian.net/browse/WATER-3269

EA-address-facade returns some addresses that have a `null` value for both `addressLine2` and `addressLine3` which causes validation within the water service to blow up.

After discussions with the wider team, it was decided as an immediate fix to remove invalid address options within the select address form (see jira ticket for discussion).