### PR TITLE
Bugfix/WATER-3288 - Charge element quantities page failing when optional billable quantity is empty

### DIFF
--- a/src/internal/modules/charge-information/forms/charge-element/quantities.js
+++ b/src/internal/modules/charge-information/forms/charge-element/quantities.js
@@ -18,7 +18,7 @@ const getErrors = key => {
     errors['any.base'] = requiredAuthorisedQuantityError;
     errors['number.base'] = requiredAuthorisedQuantityError;
     errors['number.greater'] = requiredAuthorisedQuantityError;
-  };
+  }
 
   return errors;
 };
@@ -37,7 +37,6 @@ const getFormField = (key, data) => {
  * Form to request the abstraction quantities
  *
  * @param {Object} request The Hapi request object
- * @param {Boolean}  data object containing selected and default options for the form
   */
 const form = request => {
   const { csrfToken } = request.view;
@@ -62,8 +61,8 @@ const form = request => {
 const schema = () => {
   return createSchema({
     csrf_token: Joi.string().uuid().required(),
-    authorisedAnnualQuantity: Joi.number().precision(6).greater(0).required(),
-    billableAnnualQuantity: Joi.number().precision(6).greater(0).allow(null, '')
+    authorisedAnnualQuantity: Joi.number().precision(6).positive().required(),
+    billableAnnualQuantity: Joi.number().precision(6).min(0).allow(null, '')
   });
 };
 

--- a/src/internal/modules/charge-information/forms/charge-element/quantities.js
+++ b/src/internal/modules/charge-information/forms/charge-element/quantities.js
@@ -2,20 +2,22 @@
 
 const Joi = require('joi');
 const { formFactory, fields } = require('shared/lib/forms/');
+const { createSchema } = require('shared/lib/joi.helpers');
 const { capitalize } = require('lodash');
 const { CHARGE_ELEMENT_STEPS } = require('../../lib/charge-elements/constants');
 const { getChargeElementData, getChargeElementActionUrl } = require('../../lib/form-helpers');
 
 const getErrors = key => {
-  const errors = { 'string.pattern.base': {
+  const errors = { 'number.base': {
     message: `Enter a number for the ${key} quantity using 6 decimal places or fewer, the number must be more than 0`
   } };
   if (key === 'authorised') {
     const requiredAuthorisedQuantityError = {
       message: `Enter an authorised quantity`
     };
-    errors['any.required'] = requiredAuthorisedQuantityError;
-    errors['string.empty'] = requiredAuthorisedQuantityError;
+    errors['any.base'] = requiredAuthorisedQuantityError;
+    errors['number.base'] = requiredAuthorisedQuantityError;
+    errors['number.greater'] = requiredAuthorisedQuantityError;
   };
 
   return errors;
@@ -57,13 +59,13 @@ const form = request => {
   return f;
 };
 
-const schema = (request) => {
-  const nonZeroNumberWithWSixDpRegex = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
-  return {
+const schema = () => {
+  return createSchema({
     csrf_token: Joi.string().uuid().required(),
-    authorisedAnnualQuantity: Joi.string().regex(nonZeroNumberWithWSixDpRegex).required(),
-    billableAnnualQuantity: Joi.string().allow('').regex(nonZeroNumberWithWSixDpRegex).optional()
-  };
+    authorisedAnnualQuantity: Joi.number().precision(6).greater(0).required(),
+    billableAnnualQuantity: Joi.number().precision(6).greater(0).allow(null, '')
+  });
 };
+
 exports.schema = schema;
 exports.form = form;

--- a/src/internal/modules/charge-information/lib/charge-elements/mappers.js
+++ b/src/internal/modules/charge-information/lib/charge-elements/mappers.js
@@ -1,5 +1,6 @@
 'use-strict';
 
+const { isEmpty } = require('lodash');
 const { SOURCES, EIUC_SOURCE_OTHER } = require('./constants');
 
 const abstraction = (formValues) => {
@@ -42,7 +43,7 @@ const quantities = formValues => {
 
   return {
     authorisedAnnualQuantity: parseFloat(authorisedAnnualQuantity),
-    billableAnnualQuantity: !billableAnnualQuantity ? null : parseFloat(billableAnnualQuantity)
+    billableAnnualQuantity: isEmpty(billableAnnualQuantity) ? null : parseFloat(billableAnnualQuantity)
   };
 };
 

--- a/src/internal/modules/charge-information/lib/charge-elements/mappers.js
+++ b/src/internal/modules/charge-information/lib/charge-elements/mappers.js
@@ -1,7 +1,6 @@
 'use-strict';
 
 const { SOURCES, EIUC_SOURCE_OTHER } = require('./constants');
-const { isEmpty } = require('lodash');
 
 const abstraction = (formValues) => {
   const [startMonth, startDay] = (formValues.startDate).toString().split(/[- T]/g);

--- a/src/internal/modules/charge-information/lib/charge-elements/mappers.js
+++ b/src/internal/modules/charge-information/lib/charge-elements/mappers.js
@@ -40,9 +40,10 @@ const source = formValues => ({
 
 const quantities = formValues => {
   const { authorisedAnnualQuantity, billableAnnualQuantity } = formValues;
+
   return {
     authorisedAnnualQuantity: parseFloat(authorisedAnnualQuantity),
-    billableAnnualQuantity: isEmpty(billableAnnualQuantity) ? null : parseFloat(billableAnnualQuantity)
+    billableAnnualQuantity: !billableAnnualQuantity ? null : parseFloat(billableAnnualQuantity)
   };
 };
 

--- a/test/internal/modules/charge-information/forms/charge-elements/quantities.js
+++ b/test/internal/modules/charge-information/forms/charge-elements/quantities.js
@@ -76,65 +76,60 @@ experiment('internal/modules/charge-information/forms/charge-element/quantities'
   experiment('.schema', () => {
     experiment('csrf token', () => {
       test('validates for a uuid', async () => {
-        const result = schema(createRequest()).csrf_token.validate('c5afe238-fb77-4131-be80-384aaf245842');
+        const result = schema(createRequest()).extract('csrf_token').validate('c5afe238-fb77-4131-be80-384aaf245842');
         expect(result.error).to.be.undefined();
       });
 
       test('fails for a string that is not a uuid', async () => {
-        const result = schema(createRequest()).csrf_token.validate('scissors');
+        const result = schema(createRequest()).extract('csrf_token').validate('scissors');
         expect(result.error).to.exist();
       });
     });
 
     experiment('authorisedAnnualQuantity', () => {
       test('validates for a number string', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('132');
+        const result = schema().extract('authorisedAnnualQuantity').validate('132');
         expect(result.error).to.not.exist();
       });
 
       test('validates for a number string with 6 decimal places', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('132.123456');
+        const result = schema().extract('authorisedAnnualQuantity').validate('132.123456');
         expect(result.error).to.not.exist();
       });
 
-      test('must not have more than 6 decimal places', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('132.1234567');
-        expect(result.error).to.exist();
-      });
-
       test('must not be zero', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('0');
+        const result = schema().extract('authorisedAnnualQuantity').validate('0');
         expect(result.error).to.exist();
       });
 
       test('must be a number', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('gsgsd');
+        const result = schema().extract('authorisedAnnualQuantity').validate('gsgsd');
         expect(result.error).to.exist();
       });
 
       test('can not null or empty', async () => {
-        const result = schema().authorisedAnnualQuantity.validate('');
+        const result = schema().extract('authorisedAnnualQuantity').validate('');
         expect(result.error).to.exist();
       });
     });
     experiment('billableAnnualQuantity', () => {
       test('validates for a string', async () => {
-        const result = schema().billableAnnualQuantity.validate('123');
+        const result = schema().extract('billableAnnualQuantity').validate('123');
         expect(result.error).to.not.exist();
       });
 
       test('cannot be a string describing -0.x', async () => {
-        const result = schema().billableAnnualQuantity.validate('-0.123');
+        const result = schema().extract('billableAnnualQuantity').validate('-0.123');
         expect(result.error).to.exist();
       });
 
       test('validates for a string describing 0.x', async () => {
-        const result = schema().billableAnnualQuantity.validate('0.123');
+        const result = schema().extract('billableAnnualQuantity').validate('0.123');
         expect(result.error).to.not.exist();
       });
 
       test('can be empty', async () => {
-        const result = schema().billableAnnualQuantity.validate('');
+        const result = schema().extract('billableAnnualQuantity').validate('');
         expect(result.error).not.to.exist();
       });
     });


### PR DESCRIPTION
Ticket: https://eaflood.atlassian.net/browse/WATER-3288

This PR covers 2 things:

* fixes validation issues for optional billableAnnualQuantity
* fixes issue where optional billableAnnualQuantity was not saving to session state