### PR TITLE
WATER-3193:Edit contact name including salutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean:reports": "rm -rf cypress/reports/*",
     "pretest": "npm run clean:reports",
     "install-assets": "gulp build",
-    "test:ci": "lab -l --bail -t 55 -m 0 -r lcov -o coverage/lcov.info -r console -o stdout",
+    "test:ci": "lab -l --bail -t 55 -m 0 -r html -o coverage/coverage.html -r lcov -o coverage/lcov.info -r console -o stdout",
     "test": "lab",
     "test:bail": "lab --bail",
     "test:external": "lab ./test/external",

--- a/src/internal/modules/customers/forms/contact.js
+++ b/src/internal/modules/customers/forms/contact.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { formFactory, fields } = require('shared/lib/forms/');
+const Joi = require('joi');
+const { capitalize, camelCase, get } = require('lodash');
+const session = require('../session');
+
+const INPUT_WIDTH_20 = 'govuk-input govuk-input--width-20';
+const INPUT_WIDTH_5 = 'govuk-input govuk-input--width-5';
+
+const getOptionalInputField = (name, value, isInputWidth5 = false) =>
+  fields.text(camelCase(name), {
+    controlClass: isInputWidth5 ? INPUT_WIDTH_5 : INPUT_WIDTH_20,
+    label: `${capitalize(name)} (Optional)`
+  }, value);
+
+const getNameField = (name, value) =>
+  fields.text(camelCase(name), {
+    controlClass: INPUT_WIDTH_20,
+    errors: {
+      'string.empty': {
+        message: `Enter a ${name}`
+      } },
+    label: `${capitalize(name)}`
+  }, value);
+
+/**
+ * Returns an object to create a new contact
+ * @param {Object} request The Hapi request object
+  */
+const createContactForm = request => {
+  const f = formFactory(request.path);
+
+  const contact = get(session.get(request), 'contactFromDatabase');
+
+  f.fields.push(getOptionalInputField('title', contact.title));
+  f.fields.push(getNameField('first name', contact.firstName));
+  f.fields.push(getOptionalInputField('middle initials', contact.middleInitials), true);
+  f.fields.push(getNameField('last name', contact.lastName));
+  f.fields.push(getOptionalInputField('suffix', contact.suffix));
+  f.fields.push(getOptionalInputField('department', contact.department));
+
+  f.fields.push(fields.hidden('csrf_token', {}, request.view.csrfToken));
+  f.fields.push(fields.button(null, { label: 'Confirm' }));
+  return f;
+};
+
+const createContactSchema = () => Joi.object().keys({
+  csrf_token: Joi.string().uuid().required(),
+  title: Joi.string().trim().optional().allow(''),
+  firstName: Joi.string().trim().required(),
+  middleInitials: Joi.string().trim().optional().allow(''),
+  lastName: Joi.string().trim().required(),
+  department: Joi.string().trim().replace(/\./g, '').optional().allow(''),
+  suffix: Joi.string().trim().optional().allow('')
+});
+
+exports.schema = createContactSchema;
+exports.form = createContactForm;

--- a/src/internal/modules/customers/forms/index.js
+++ b/src/internal/modules/customers/forms/index.js
@@ -1,2 +1,3 @@
+exports.contact = require('./contact');
 exports.emailAddress = require('./email-address');
 exports.waterAbstractionAlertsPreference = require('./water-abstraction-alerts-preference');

--- a/src/internal/modules/customers/routes.js
+++ b/src/internal/modules/customers/routes.js
@@ -32,6 +32,32 @@ module.exports = {
       }
     }
   },
+  getUpdateCustomerContactName: {
+    method: 'GET',
+    path: '/customer/{companyId}/contacts/{contactId}/name',
+    handler: controllers.getUpdateCustomerContactName,
+    config: {
+      description: 'Gets the page for editing a contact\'s name',
+      validate: {
+        params: Joi.object().keys({
+          companyId: Joi.string().guid().required(),
+          contactId: Joi.string().guid().required()
+        }),
+        query: Joi.object().keys({
+          isNew: Joi.any().optional(),
+          form: Joi.string().guid().optional()
+        })
+      }
+    }
+  },
+  postAddCustomerContactName: {
+    method: 'POST',
+    path: '/customer/{companyId}/contacts/{contactId}/name',
+    handler: controllers.postUpdateCustomerContactName,
+    config: {
+      description: 'POSTs the page for editing a contact\'s name'
+    }
+  },
   getAddCustomerContactEmail: {
     method: 'GET',
     path: '/customer/{companyId}/contacts/{contactId}/email',

--- a/src/internal/views/nunjucks/customers/contact.njk
+++ b/src/internal/views/nunjucks/customers/contact.njk
@@ -14,8 +14,8 @@
                 {{contactName}}
              </dd>
              <dd class="govuk-summary-list__actions">
-              {% if companyContact.contact.dataSource == 'wrls' and 1==2 %}
-                <a class="govuk-link" href="">
+              {% if companyContact.contact.dataSource == 'wrls' %}
+                <a class="govuk-link" href="{{companyContact.contact.id}}/name">
                 Change<span class="govuk-visually-hidden"> name</span>
                 </a>
               {% elseif companyContact.contact.dataSource == 'nald' %}

--- a/test/internal/modules/customers/forms/contact.js
+++ b/test/internal/modules/customers/forms/contact.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const uuid = require('uuid/v4');
+const { expect } = require('@hapi/code');
+const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
+const sandbox = require('sinon').createSandbox();
+
+const createContact = require('internal/modules/customers/forms/contact');
+const { findField, findButton } = require('../../../../lib/form-test');
+const session = require('../../../../../src/internal/modules/customers/session.js');
+
+const createRequest = () => ({
+  view: {
+    csrfToken: uuid()
+  }
+});
+
+experiment('internal/modules/customers/forms/contact', () => {
+  let request;
+  beforeEach(() => {
+    const contactFromDatabase = {
+      title: 'Lance Corporal',
+      firstName: 'Valtteri',
+      lastName: 'Bottas'
+    };
+    sandbox.stub(session, 'get').returns({ contactFromDatabase });
+    request = createRequest();
+  });
+
+  afterEach(() => sandbox.restore());
+
+  experiment('.form', () => {
+    test('sets the form method to POST', async () => {
+      const form = createContact.form(request, {});
+      expect(form.method).to.equal('POST');
+    });
+
+    test('has CSRF token field', async () => {
+      const form = createContact.form(request, {});
+      const csrf = findField(form, 'csrf_token');
+      expect(csrf.value).to.equal(request.view.csrfToken);
+    });
+
+    test('has a title field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'title');
+      expect(field).to.exist();
+    });
+
+    test('has a firstName field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'firstName');
+      expect(field).to.exist();
+    });
+    test('has a middleInitials field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'middleInitials');
+      expect(field).to.exist();
+    });
+    test('has a lastName field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'lastName');
+      expect(field).to.exist();
+    });
+    test('has a suffix field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'suffix');
+      expect(field).to.exist();
+    });
+    test('has a department field', async () => {
+      const form = createContact.form(request, {});
+      const field = findField(form, 'department');
+      expect(field).to.exist();
+    });
+    test('has a submit button', async () => {
+      const form = createContact.form(request, {});
+      const button = findButton(form);
+      expect(button.options.label).to.equal('Confirm');
+    });
+
+    test('populates expected fields with data', () => {
+      const form = createContact.form(request, {});
+      const titleField = findField(form, 'title');
+      const firstNameField = findField(form, 'firstName');
+      const lastNameField = findField(form, 'lastName');
+      expect(titleField.value).to.equal('Lance Corporal');
+      expect(firstNameField.value).to.equal('Valtteri');
+      expect(lastNameField.value).to.equal('Bottas');
+    });
+  });
+
+  experiment('.schema', () => {
+    let data;
+    beforeEach(() => {
+      data = {
+        title: 'Lance Corporal',
+        firstName: 'Valtteri',
+        middleInitials: 'V',
+        lastName: 'Bottas',
+        suffix: 'suffix',
+        department: 'Mercedes Petronas AMG',
+        csrf_token: uuid()
+      };
+    });
+
+    test('validates when data is valid', () => {
+      const result = createContact.schema(request).validate(data);
+      expect(result.error).to.be.undefined();
+    });
+
+    experiment('csrf token', () => {
+      test('fails for a string that is not a uuid', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          csrf_token: 'noodles' });
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('title', () => {
+      test('does not fail if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          title: ''
+        });
+        expect(result.error).to.equal(undefined);
+      });
+    });
+
+    experiment('firstName', () => {
+      test('fails if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          firstName: ''
+        });
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('middleInitials', () => {
+      test('does not fail if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          middleInitials: ''
+        });
+        expect(result.error).to.equal(undefined);
+      });
+    });
+
+    experiment('lastName', () => {
+      test('fails if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          lastName: ''
+        });
+        expect(result.error).to.exist();
+      });
+    });
+
+    experiment('suffix', () => {
+      test('does not fail if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          suffix: ''
+        });
+        expect(result.error).to.equal(undefined);
+      });
+    });
+
+    experiment('department', () => {
+      test('does not fail if blank', async () => {
+        const result = createContact.schema(request).validate({
+          ...data,
+          department: '' });
+        expect(result.error).to.equal(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
See https://eaflood.atlassian.net/browse/WATER-3193
Please note this covers updating the contact name and forcing the entry of an email if it doesn't exist when setting the alerts to yes.

This requires both:
- https://github.com/DEFRA/water-abstraction-service/pull/1542
- https://github.com/DEFRA/water-abstraction-tactical-crm/pull/870

Please also note that the changes in the UI contain duplicates.  This was intentional as it would have been messy trying to reuse the code with one plugin, within another.
