### PR TITLE
WATER 3329: Addition of SLD as a unit type in the tagging flow

### DIFF
--- a/cypress/integration/internal/gauging-stations-and-water-abstraction-alerts.js
+++ b/cypress/integration/internal/gauging-stations-and-water-abstraction-alerts.js
@@ -32,6 +32,10 @@ describe('tag a licence to a gauging station, send a warning, and remove the tag
 
       // asserting the liecence to tag
       cy.get('.govuk-caption-l').contains('Test Station 500').should('be.visible');
+
+      // assert the Unit of measurement dropdown contains SLD as it's last option
+      cy.get('#unit option').last().contains('SLD');
+
       // assert the validations for submitting the empty details
       cy.get('form > .govuk-button').contains('Continue').click();
       cy.get('.govuk-error-summary').contains('There is a problem').should('be.visible');

--- a/src/internal/modules/gauging-stations/forms/new-tag/threshold-and-unit.js
+++ b/src/internal/modules/gauging-stations/forms/new-tag/threshold-and-unit.js
@@ -1,7 +1,7 @@
 const Joi = require('joi');
 const { get } = require('lodash');
 const { formFactory, fields } = require('shared/lib/forms/');
-const validUnits = ['Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mASD', 'm'];
+const validUnits = ['Ml/d', 'm3/s', 'm3/d', 'l/s', 'mAOD', 'mASD', 'm', 'SLD'];
 const session = require('../../lib/session');
 
 const newTagThresholdAndUnitForm = request => {

--- a/src/internal/modules/gauging-stations/lib/helpers.js
+++ b/src/internal/modules/gauging-stations/lib/helpers.js
@@ -164,7 +164,8 @@ const longFormDictionary = [
   { dbitem: 'mAOD', translation: 'Ordnance datum (mAOD)', context: 'Units' },
   { dbitem: 'stop_or_reduce', translation: 'Reduce', context: 'AlertType' },
   { dbitem: 'stop', translation: 'Stop', context: 'AlertType' },
-  { dbitem: 'reduce', translation: 'Reduce', context: 'AlertType' }
+  { dbitem: 'reduce', translation: 'Reduce', context: 'AlertType' },
+  { dbitem: 'SLD', translation: 'South Level Datum', context: 'Units' }
 ];
 
 /* Converts database representation into description of tags, e.g. Stop at 115 Megalitres per day */

--- a/test/internal/modules/gauging-stations/lib/helpers.js
+++ b/test/internal/modules/gauging-stations/lib/helpers.js
@@ -360,6 +360,7 @@ experiment('internal/modules/gauging-stations/controller', () => {
         expect(helpers.toLongForm('Ml/d', 'Units')).to.equal('Megalitres per day');
         expect(helpers.toLongForm('m³', 'Units')).to.equal('Cubic metres');
         expect(helpers.toLongForm('l/d', 'Units')).to.equal('Litres per day');
+        expect(helpers.toLongForm('SLD', 'Units')).to.equal('South Level Datum');
         expect(helpers.toLongForm('stop_or_reduce', 'AlertType')).to.equal('Reduce');
         expect(helpers.toLongForm('reduce', 'AlertType')).to.equal('Reduce');
         expect(helpers.toLongForm('stop', 'AlertType')).to.equal('Stop');
@@ -369,6 +370,7 @@ experiment('internal/modules/gauging-stations/controller', () => {
         expect(helpers.toLongForm('gal', '')).to.equal('Gallons');
         expect(helpers.toLongForm('Ml/d', '')).to.equal('Megalitres per day');
         expect(helpers.toLongForm('m³', '')).to.equal('Cubic metres');
+        expect(helpers.toLongForm('SLD', '')).to.equal('South Level Datum');
         expect(helpers.toLongForm('l/d', '')).to.equal('Litres per day');
         expect(helpers.toLongForm('stop_or_reduce', '')).to.equal('Reduce');
         expect(helpers.toLongForm('reduce', '')).to.equal('Reduce');


### PR DESCRIPTION
See: https://eaflood.atlassian.net/browse/WATER-3329
This is dependent upon: https://github.com/DEFRA/water-abstraction-service/pull/1583