### PR TITLE
WATER-3393 Removed restriction on start date

### DIFF
--- a/src/internal/modules/charge-information/forms/start-date.js
+++ b/src/internal/modules/charge-information/forms/start-date.js
@@ -8,7 +8,6 @@ const DATE_FORMAT = 'D MMMM YYYY';
 const ISO_FORMAT = 'YYYY-MM-DD';
 
 const MIN_LICENCE_START = 'licence_start';
-const MIN_5_YEARS = '5_years';
 
 const createValues = (startDate, customDate) => ({ startDate, customDate });
 
@@ -35,19 +34,18 @@ const getValues = (request, licence, refDate) => {
 
 const getDates = licence => {
   const startDate = moment(licence.startDate);
-  const minDate = moment().subtract(5, 'years');
+  const minDate = startDate;
   const isLicenceStart = startDate.isAfter(minDate);
   return {
     licenceStartDate: licence.startDate,
     minDate: isLicenceStart ? licence.startDate : minDate.format(ISO_FORMAT),
-    minType: isLicenceStart ? MIN_LICENCE_START : MIN_5_YEARS,
+    minType: MIN_LICENCE_START,
     maxDate: licence.endDate || '3000-01-01'
   };
 };
 
 const minErrors = {
-  [MIN_LICENCE_START]: 'You must enter a date after the licence start date',
-  [MIN_5_YEARS]: "Date must be today or up to five years' in the past"
+  [MIN_LICENCE_START]: 'You must enter a date after the licence start date'
 };
 
 const getCommomCustomDateErrors = dates => ({

--- a/test/internal/modules/charge-information/controllers/charge-information.js
+++ b/test/internal/modules/charge-information/controllers/charge-information.js
@@ -442,8 +442,8 @@ experiment('internal/modules/charge-information/controller', () => {
         expect(field.options.choices[0].hint).to.equal(getReadableDate());
 
         // Custom date
-        expect(field.options.choices[1].label).to.equal('Another date');
-        expect(field.options.choices[1].value).to.equal('customDate');
+        expect(field.options.choices[3].label).to.equal('Another date');
+        expect(field.options.choices[3].value).to.equal('customDate');
 
         expect(field.value).to.be.undefined();
       });
@@ -665,31 +665,6 @@ experiment('internal/modules/charge-information/controller', () => {
         const [ form ] = h.postRedirectGet.lastCall.args;
         const field = find(form.fields, { name: 'startDate' }).options.choices[2].fields[0];
         expect(field.errors[0].message).to.equal('You must enter a date before the licence end date');
-      });
-    });
-
-    experiment('when a custom date more than 6 years ago is posted', () => {
-      beforeEach(async () => {
-        request = createRequest();
-        request.pre.licence.startDate = '1990-01-01';
-        request.payload = {
-          csrf_token: request.view.csrfToken,
-          startDate: 'customDate',
-          'customDate-day': '02',
-          'customDate-month': '01',
-          'customDate-year': '1990'
-        };
-        await controller.postStartDate(request, h);
-      });
-
-      test('the draft charge information is not updated', async () => {
-        expect(request.setDraftChargeInformation.called).to.be.false();
-      });
-
-      test('an error is displayed', async () => {
-        const [ form ] = h.postRedirectGet.lastCall.args;
-        const field = find(form.fields, { name: 'startDate' }).options.choices[1].fields[0];
-        expect(field.errors[0].message).to.equal("Date must be today or up to five years' in the past");
       });
     });
   });

--- a/test/internal/modules/charge-information/controllers/non-chargeable.js
+++ b/test/internal/modules/charge-information/controllers/non-chargeable.js
@@ -316,29 +316,4 @@ experiment('internal/modules/charge-information/controller', () => {
       expect(field.errors[0].message).to.equal('You must enter a date before the licence end date');
     });
   });
-
-  experiment('when a custom date more than 6 years ago is posted', () => {
-    beforeEach(async () => {
-      request = createRequest();
-      request.pre.licence.startDate = '1990-01-01';
-      request.payload = {
-        csrf_token: request.view.csrfToken,
-        startDate: 'customDate',
-        'customDate-day': '02',
-        'customDate-month': '01',
-        'customDate-year': '1990'
-      };
-      await controller.postEffectiveDate(request, h);
-    });
-
-    test('the draft charge information is not updated', async () => {
-      expect(request.setDraftChargeInformation.called).to.be.false();
-    });
-
-    test('an error is displayed', async () => {
-      const [ form ] = h.postRedirectGet.lastCall.args;
-      const field = find(form.fields, { name: 'startDate' }).options.choices[1].fields[0];
-      expect(field.errors[0].message).to.equal("Date must be today or up to five years' in the past");
-    });
-  });
 });


### PR DESCRIPTION
Removed restriction for start date to be up to last 5 years now can be anytime after the licence start date and before end date of licence.