### PR TITLE
Update remind-licence-holders-submit-returns.spec.js

### DIFF
--- a/cypress/integration/internal/remind-licence-holders-submit-returns.spec.js
+++ b/cypress/integration/internal/remind-licence-holders-submit-returns.spec.js
@@ -35,7 +35,7 @@ describe('Sending returns reminders to users ', () => {
     });
 
     describe('continue and send returns reminders', () => {
-      cy.url({ timeout: 40000 }).should('contain', '/batch-notification');
+      cy.url({ timeout: 600000 }).should('contain', '/batch-notification');
       cy.get('.govuk-heading-l').should('contain', 'Send returns reminders');
       cy.get('#main-content').should('contain', 'Mailing list is ready to send');
       cy.get('form > .govuk-button').click();


### PR DESCRIPTION
This PR increases waiting time of the test to match with the amount of time the application is taking to assemble to the mailing list. 