### PR TITLE
WATER-3450: Charge Screens inconsistent in Volume display

### DIFF
--- a/src/internal/views/nunjucks/charge-information/macros/charge-element-table-sroc.njk
+++ b/src/internal/views/nunjucks/charge-information/macros/charge-element-table-sroc.njk
@@ -137,10 +137,10 @@ formErrorSummary %}
             <dd class="govuk-summary-list__value">
               <ul class="govuk-list">
                 <li>
-                  {{ chargePurpose.authorisedAnnualQuantity | number + 'ML authorised' }}
+                  {{ chargePurpose.authorisedAnnualQuantity + 'ML authorised' }}
                 </li>
                 <li>
-                  {{chargePurpose.billableAnnualQuantity | number + 'ML billable' if chargePurpose.billableAnnualQuantity else 'Billable not set' }}
+                  {{chargePurpose.billableAnnualQuantity + 'ML billable' if chargePurpose.billableAnnualQuantity else 'Billable not set' }}
                 </li>
               </ul>
             </dd>

--- a/src/internal/views/nunjucks/charge-information/macros/charge-element-table.njk
+++ b/src/internal/views/nunjucks/charge-information/macros/charge-element-table.njk
@@ -117,10 +117,10 @@ formErrorSummary %}
             <dd class="govuk-summary-list__value">
               <ul class="govuk-list">
                 <li>
-                  {{ chargeElement.authorisedAnnualQuantity | number + 'ML authorised' }}
+                  {{ chargeElement.authorisedAnnualQuantity + 'ML authorised' }}
                 </li>
                 <li>
-                  {{chargeElement.billableAnnualQuantity | number + 'ML billable' if chargeElement.billableAnnualQuantity else 'Billable not set' }}
+                  {{chargeElement.billableAnnualQuantity + 'ML billable' if chargeElement.billableAnnualQuantity else 'Billable not set' }}
                 </li>
               </ul>
             </dd>


### PR DESCRIPTION
The number filter has been removed to allow all 6 decimal places to be shown.

See: https://eaflood.atlassian.net/browse/WATER-3450