### PR TITLE
WATER-3451: Edit flag not set correctly

### DIFF
--- a/src/internal/modules/billing/forms/two-part-tariff-quantity.js
+++ b/src/internal/modules/billing/forms/two-part-tariff-quantity.js
@@ -6,9 +6,10 @@ const { formFactory, fields } = require('shared/lib/forms/');
 /**
  * Gets an array of form choices for the billable quantity
  * @param {Number} authorisedAnnualQuantity
+ * @param {Number} volume
  * @return {Array}
  */
-const getRadioChoices = authorisedAnnualQuantity => [{
+const getRadioChoices = (authorisedAnnualQuantity, volume) => [{
   label: `Authorised (${authorisedAnnualQuantity}Ml)`,
   value: 'authorised'
 }, {
@@ -29,37 +30,42 @@ const getRadioChoices = authorisedAnnualQuantity => [{
         },
         'number.max': {
           message: 'The quantity must be the same as or less than the authorised amount'
+        },
+        'number.custom': {
+          message: 'The quantity must contain no more than 6 decimal places'
         }
       }
-    })
+    }, volume)
   ]
 }];
 
 /**
  * Gets a form field object for the billable quantity radio button
  * @param {Number} authorisedAnnualQuantity
+ * @param {Number} volume
  * @return {Object} form radio object
  */
-const getQuantityRadio = authorisedAnnualQuantity => fields.radio('quantity', {
+const getQuantityRadio = (authorisedAnnualQuantity, volume = authorisedAnnualQuantity) => fields.radio('quantity', {
   errors: {
     'any.required': {
       message: 'Select the billable quantity'
     }
   },
-  choices: getRadioChoices(authorisedAnnualQuantity)
+  choices: getRadioChoices(authorisedAnnualQuantity, volume)
 });
 
 const twoPartTariffQuantityForm = (request, billingVolume) => {
   const { csrfToken } = request.view;
 
   const { batchId, licenceId, billingVolumeId } = request.params;
-  const { authorisedAnnualQuantity } = billingVolume.chargeElement;
+  const { volume, chargeElement } = billingVolume;
+  const { authorisedAnnualQuantity } = chargeElement;
 
   const action = `/billing/batch/${batchId}/two-part-tariff/licence/${licenceId}/billing-volume/${billingVolumeId}`;
 
   const f = formFactory(action, 'POST');
 
-  f.fields.push(getQuantityRadio(authorisedAnnualQuantity));
+  f.fields.push(getQuantityRadio(authorisedAnnualQuantity, volume));
   f.fields.push(fields.hidden('csrf_token', {}, csrfToken));
   f.fields.push(fields.button(null, { label: 'Confirm' }));
   return f;
@@ -72,7 +78,16 @@ const twoPartTariffQuantitySchema = billingVolume => {
     quantity: Joi.string().valid('authorised', 'custom').required(),
     customQuantity: Joi.when('quantity', {
       is: 'custom',
-      then: Joi.number().required().min(0).max(maxQuantity).precision(6)
+      then: Joi
+        .number().required().min(0).max(maxQuantity)
+        .custom((value, helper) => {
+          const { error, original } = helper;
+          const [, decimals = ''] = original.split('.');
+          if (decimals.length <= 6) {
+            return value;
+          }
+          return error('number.custom');
+        })
     })
   });
 };

--- a/test/internal/modules/billing/controllers/two-part-tariff.js
+++ b/test/internal/modules/billing/controllers/two-part-tariff.js
@@ -596,7 +596,7 @@ experiment('internal/modules/billing/controller/two-part-tariff', () => {
             expect(subField.options.label).to.equal('Billable quantity');
             expect(subField.options.type).to.equal('number');
             expect(subField.options.controlClass).to.equal('govuk-!-width-one-third');
-            expect(subField.value).to.be.undefined();
+            expect(subField.value).to.be.equal(2.5);
           });
         });
 

--- a/test/internal/modules/billing/forms/two-part-tariff-quantity.js
+++ b/test/internal/modules/billing/forms/two-part-tariff-quantity.js
@@ -68,7 +68,7 @@ experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
           const experiment1 = tptSchema.validate({
             csrf_token: uuid(),
             quantity: 'custom',
-            customQuantity: 2
+            customQuantity: '2'
           });
           expect(experiment1.error).to.be.undefined();
 
@@ -76,7 +76,7 @@ experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
             csrf_token: uuid(),
             quantity: 'custom'
           });
-          expect(experiment2.error).to.exist();
+          expect(experiment2.error.details[0].type).to.equal('any.required');
         });
       });
 
@@ -85,7 +85,7 @@ experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
           csrf_token: uuid(),
           quantity: 'Cypress Hill'
         });
-        expect(result.error).to.exist();
+        expect(result.error.details[0].type).to.equal('any.only');
       });
 
       test('is required', async () => {
@@ -93,7 +93,7 @@ experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
           csrf_token: uuid(),
           quantity: null
         });
-        expect(result.error).to.exist();
+        expect(result.error.details[0].type).to.equal('any.only');
       });
     });
 
@@ -106,27 +106,39 @@ experiment('internal/modules/billing/forms/two-part-tariff-quantity', () => {
 
       experiment('when the quantity is of type "custom', () => {
         test('the customQuantity cannot be less than 0', async () => {
-          const data = getData({ customQuantity: -1 });
+          const data = getData({ customQuantity: '-1' });
           const result = tptSchema.validate(data);
-          expect(result.error).to.exist();
+          expect(result.error.details[0].type).to.equal('number.min');
         });
 
         test('the customQuantity cannot be greater than the maxAnnualQuantity', async () => {
-          const data = getData({ customQuantity: 4 });
+          const data = getData({ customQuantity: '4' });
           const result = tptSchema.validate(data);
-          expect(result.error).to.exist();
+          expect(result.error.details[0].type).to.equal('number.max');
         });
 
         test('the customQuantity can equal the maxAnnualQuantity', async () => {
-          const data = getData({ customQuantity: 3 });
+          const data = getData({ customQuantity: '3' });
           const result = tptSchema.validate(data);
           expect(result.error).to.be.undefined();
         });
 
         test('the customQuantity can be greater than zero and less that the maxAnnualQuantity', async () => {
-          const data = getData({ customQuantity: 2 });
+          const data = getData({ customQuantity: '2' });
           const result = tptSchema.validate(data);
           expect(result.error).to.be.undefined();
+        });
+
+        test('the customQuantity can have up to 6 decimal places', async () => {
+          const data = getData({ customQuantity: '2.123456' });
+          const result = tptSchema.validate(data);
+          expect(result.error).to.be.undefined();
+        });
+
+        test('the customQuantity cannot have more than 6 decimal places', async () => {
+          const data = getData({ customQuantity: '2.1234567' });
+          const result = tptSchema.validate(data);
+          expect(result.error.details[0].type).to.equal('number.custom');
         });
       });
     });


### PR DESCRIPTION
See: https://eaflood.atlassian.net/browse/WATER-3451

- Prepopulate custom volume in the UI with the current volume when editing
- Add validation to prevent more than six decimals being entered in the UI for the custom volume 

Please note that this depends on: https://github.com/DEFRA/water-abstraction-service/pull/1603