### PR TITLE
bugfix/water-3393

### DIFF
--- a/src/internal/modules/charge-information/routes/non-chargeable.js
+++ b/src/internal/modules/charge-information/routes/non-chargeable.js
@@ -1,6 +1,7 @@
 const controller = require('../controllers/non-chargeable');
 const preHandlers = require('../pre-handlers');
 const { VALID_GUID } = require('shared/lib/validators');
+const sharedPreHandlers = require('shared/lib/pre-handlers/licences');
 const Joi = require('joi');
 const { chargeVersionWorkflowEditor, chargeVersionWorkflowReviewer } = require('internal/lib/constants').scope;
 const allowedScopes = [chargeVersionWorkflowEditor, chargeVersionWorkflowReviewer];
@@ -99,8 +100,8 @@ module.exports = {
       pre: [
         { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
         { method: preHandlers.loadLicence, assign: 'licence' },
-        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' }
-
+        { method: preHandlers.loadIsChargeable, assign: 'isChargeable' },
+        { method: sharedPreHandlers.loadLicenceVersions, assign: 'licenceVersions' }
       ]
     }
   },
@@ -130,7 +131,8 @@ module.exports = {
       },
       pre: [
         { method: preHandlers.loadDraftChargeInformation, assign: 'draftChargeInformation' },
-        { method: preHandlers.loadLicence, assign: 'licence' }
+        { method: preHandlers.loadLicence, assign: 'licence' },
+        { method: sharedPreHandlers.loadLicenceVersions, assign: 'licenceVersions' }
       ]
     }
   }

--- a/test/internal/modules/charge-information/forms/start-date.js
+++ b/test/internal/modules/charge-information/forms/start-date.js
@@ -96,7 +96,6 @@ experiment('internal/modules/charge-information/forms/start-date', () => {
       test('the today start option is removed', () => {
         const dateForm = form(createRequest(moment(), true, moment().subtract(8, 'years').format('YYYY-MM-DD'), moment().subtract(1, 'months').format('YYYY-MM-DD')));
         const radio = findField(dateForm, 'startDate');
-        console.log(radio.options.choices);
         expect(radio.options.choices[0].label === 'Today').to.be.false();
       });
     });

--- a/test/internal/modules/charge-information/routes/non-chargeable.js
+++ b/test/internal/modules/charge-information/routes/non-chargeable.js
@@ -7,6 +7,7 @@ const {
 const { v4: uuid } = require('uuid');
 const { expect } = require('@hapi/code');
 const preHandlers = require('internal/modules/charge-information/pre-handlers');
+const sharedPreHandlers = require('shared/lib/pre-handlers/licences');
 const routes = require('internal/modules/charge-information/routes/non-chargeable');
 const testHelpers = require('../../../test-helpers');
 
@@ -120,13 +121,15 @@ experiment('internal/modules/charge-information/routes/non-chargeable', () => {
     });
 
     test('has the expected pre handlers', async () => {
-      expect(routes.getEffectiveDate.options.pre.length).to.equal(3);
+      expect(routes.getEffectiveDate.options.pre.length).to.equal(4);
       expect(routes.getEffectiveDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.getEffectiveDate.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.getEffectiveDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.getEffectiveDate.options.pre[1].assign).to.equal('licence');
       expect(routes.getEffectiveDate.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
       expect(routes.getEffectiveDate.options.pre[2].assign).to.equal('isChargeable');
+      expect(routes.getEffectiveDate.options.pre[3].method).to.equal(sharedPreHandlers.loadLicenceVersions);
+      expect(routes.getEffectiveDate.options.pre[3].assign).to.equal('licenceVersions');
     });
   });
 
@@ -157,11 +160,15 @@ experiment('internal/modules/charge-information/routes/non-chargeable', () => {
     });
 
     test('has the expected pre handlers', async () => {
-      expect(routes.postEffectiveDate.options.pre.length).to.equal(2);
+      expect(routes.postEffectiveDate.options.pre.length).to.equal(3);
       expect(routes.postEffectiveDate.options.pre[0].method).to.equal(preHandlers.loadDraftChargeInformation);
       expect(routes.postEffectiveDate.options.pre[0].assign).to.equal('draftChargeInformation');
       expect(routes.postEffectiveDate.options.pre[1].method).to.equal(preHandlers.loadLicence);
       expect(routes.postEffectiveDate.options.pre[1].assign).to.equal('licence');
+      expect(routes.getEffectiveDate.options.pre[2].method).to.equal(preHandlers.loadIsChargeable);
+      expect(routes.getEffectiveDate.options.pre[2].assign).to.equal('isChargeable');
+      expect(routes.getEffectiveDate.options.pre[3].method).to.equal(sharedPreHandlers.loadLicenceVersions);
+      expect(routes.getEffectiveDate.options.pre[3].assign).to.equal('licenceVersions');
     });
   });
 });


### PR DESCRIPTION
-- new prehandlers added to non chargeable routes
to fix setting the effective date