### PR TITLE
WATER-3496: Fix back button when adding a new charge version

### DIFF
--- a/src/internal/modules/charge-information/lib/reducer.js
+++ b/src/internal/modules/charge-information/lib/reducer.js
@@ -32,9 +32,8 @@ const reducer = (state, action) => {
         chargeElements: [
           ...state.chargeElements,
           {
-            id: action.payload.id,
-            isSection127AgreementEnabled: true,
-            scheme: action.payload.scheme
+            ...action.payload,
+            isSection127AgreementEnabled: true
           }
         ]
       };


### PR DESCRIPTION
See: https://eaflood.atlassian.net/browse/WATER-3496

Actual issue is the status of draft from the payload was not being saved when creating a charge element.