### PR TITLE
WATER-3476: Add the Remove element button on charge info review page

### DIFF
--- a/src/internal/views/nunjucks/charge-information/macros/charge-element-table-alcs.njk
+++ b/src/internal/views/nunjucks/charge-information/macros/charge-element-table-alcs.njk
@@ -81,7 +81,7 @@ formErrorSummary %}
   {% endif %}
 {% endmacro %}
 
-{% macro chargeElementTableAlcs(chargeElements, isEditable, licenceId, scheme, chargeVersionWorkflowId) %}
+{% macro chargeElementTableAlcs(chargeElements, isEditable, licenceId, scheme, chargeVersionWorkflowId, chargeElementCount) %}
     {% if chargeElements.length > 0 %}
       {% for chargeElement in chargeElements %}
 
@@ -147,7 +147,7 @@ formErrorSummary %}
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-full">
                 <span class=" govuk-body  govuk-!-font-size-19">
-                  {% if chargeElements.length > 1 %}
+                  {% if chargeElementCount > 1 %}
                   {{ removeElementButton(chargeElement) }}
                 {% endif %}
                 {% if loop.last %}

--- a/src/internal/views/nunjucks/charge-information/view.njk
+++ b/src/internal/views/nunjucks/charge-information/view.njk
@@ -102,9 +102,9 @@ formErrorSummary %}
     <input type="hidden" name="csrf_token" value="{{ csrfToken }}"/>
     {% if chargeVersion.scheme == 'sroc' and isSrocChargeInfoEnabled  %}
         {{ chargeElementTableSroc(chargeVersion.chargeElements | arrayFilter('scheme', 'sroc'), isEditable, licenceId, chargeVersionWorkflowId)}}
-        {{ chargeElementTableAlcs(chargeVersion.chargeElements | arrayFilter('scheme','alcs'), isEditable, licenceId, 'sroc', chargeVersionWorkflowId)}}
+        {{ chargeElementTableAlcs(chargeVersion.chargeElements | arrayFilter('scheme','alcs'), isEditable, licenceId, 'sroc', chargeVersionWorkflowId, chargeVersion.chargeElements.length)}}
     {% else %}
-      {{ chargeElementTableAlcs(chargeVersion.chargeElements, isEditable, licenceId, 'alcs', chargeVersionWorkflowId) }}
+      {{ chargeElementTableAlcs(chargeVersion.chargeElements, isEditable, licenceId, 'alcs', chargeVersionWorkflowId, chargeVersion.chargeElements.length ) }}
     {% endif %}
 </form>
 


### PR DESCRIPTION
Note: Only had to implement that the remove element button is shown when there is more than one element including charge categories.

See: https://eaflood.atlassian.net/browse/WATER-3476?focusedCommentId=378983