### PR TITLE
enhancement/water-3446 - Two part tariff `No returns received` message

### DIFF
--- a/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
+++ b/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
@@ -15,10 +15,10 @@
 {% endmacro %}
 
 {% macro reportedVolume(billingVolume) %}
-{% if billingVolume.calculatedVolume | isFinite %}
+{% if billingVolume.error != 'No returns received' | isFinite %}
   {{ billingVolume.calculatedVolume + 'Ml' }}
 {% else %}
-  0Ml
+  No returns received
 {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3446

Currently the two-part tariff page displays `0Ml` for reported return if no return has been received. This could be misleading so we change it to display `No returns received` instead.