### PR TITLE
enhancement/water-3446 - Fix logic when displaying `No returns received`

### DIFF
--- a/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
+++ b/src/internal/views/nunjucks/billing/macros/two-part-tariff-review-quantities.njk
@@ -15,7 +15,7 @@
 {% endmacro %}
 
 {% macro reportedVolume(billingVolume) %}
-{% if billingVolume.error != 'No returns received' | isFinite %}
+{% if billingVolume.error != 'No returns received' %}
   {{ billingVolume.calculatedVolume + 'Ml' }}
 {% else %}
   No returns received


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/WATER/boards/96?modal=detail&selectedIssue=WATER-3446

Following QA feedback, we amend the logic to ensure `No returns received` is correctly displayed when there is no return.