### PR TITLE
bugfix/water-3634 - resize charge creation factor fields

### DIFF
--- a/src/internal/modules/charge-information/forms/charge-category/adjustments.js
+++ b/src/internal/modules/charge-information/forms/charge-category/adjustments.js
@@ -59,7 +59,7 @@ const form = request => {
                   hint: item.hint || '',
                   mapper: 'numberMapper',
                   label: 'Factor',
-                  controlClass: 'govuk-input--width-4'
+                  controlClass: 'govuk-input--width-20'
                 }, data.adjustments[item.value])
             ]
           : []


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3634

The adjustment factor fields have been changed in the prototype to allow numbers with a large number of decimal places to be correctly displayed. We therefore change `controlClass` from `govuk-input--width-4` to `govuk-input--width-20` as specified in the prototype.