### PR TITLE
Bugfix/water-3632 - allow charge category volume of 0ML

### DIFF
--- a/cypress/integration/internal/sroc-charge-version-flow.spec.js
+++ b/cypress/integration/internal/sroc-charge-version-flow.spec.js
@@ -208,8 +208,15 @@ describe('Create SRoC Charge version workflow journey', () => {
           checkNoErrorMessage();
           cy.get('.govuk-back-link').click();
         });
-        describe('user inputs amount', () => {
+        describe('user inputs value of 0', () => {
           // We use .clear() to delete any previously accepted input
+          cy.get('#volume').clear().type('0');
+          cy.get('form > .govuk-button').contains('Continue').click();
+          // Check that no error message was generated, then go back from the page we arrived at
+          checkNoErrorMessage();
+          cy.get('.govuk-back-link').click();
+        });
+        describe('user inputs amount', () => {
           cy.get('#volume').clear().type('150');
           cy.get('form > .govuk-button').contains('Continue').click();
         });

--- a/src/internal/modules/charge-information/forms/charge-category/volume.js
+++ b/src/internal/modules/charge-information/forms/charge-category/volume.js
@@ -51,7 +51,7 @@ const schema = () => {
   return Joi.object().keys({
     csrf_token: Joi.string().uuid().required(),
     volume: Joi
-      .number().positive().required().min(0).max(1000000000000000)
+      .number().required().min(0).max(1000000000000000)
       .custom((value, helper) => {
         const { error, original } = helper;
         const [, decimals = ''] = original.split('.');


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3632

During QA we found that we weren't accepting a value of `0` for charge category volume. This came down to an error in the validation -- we changed the minimum to `0` but didn't realise that the `.positive()` rule still prevented `0` from being allowed. Since we are enforcing positive values simply by having a minimum, we remove this rule. We also add an extra Cypress test to confirm that `0` is accepted.