### PR TITLE
bugfix/water-3633 - Allow `&*()` in charge reference description

### DIFF
--- a/cypress/integration/internal/sroc-charge-version-flow.spec.js
+++ b/cypress/integration/internal/sroc-charge-version-flow.spec.js
@@ -165,11 +165,19 @@ describe('Create SRoC Charge version workflow journey', () => {
           cy.get('#description').type('@ is an unsupported character');
           cy.get('form > .govuk-button').contains('Continue').click();
           checkInlineAndSummaryErrorMessage(
-            'The description must only include letters a-z, hyphens, numbers and be 180 characters or fewer.');
+            'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.');
           cy.reload();
         });
+        describe('user description contains an unusual but supported character', () => {
+          cy.get('#description').type('* is an supported character');
+          cy.get('form > .govuk-button').contains('Continue').click();
+          // Check that no error message was generated, then go back from the page we arrived at
+          checkNoErrorMessage();
+          cy.get('.govuk-back-link').click();
+        });
         describe('user enters a description', () => {
-          cy.get('#description').type('Automation-Test');
+          // We use .clear() to delete any previously accepted input
+          cy.get('#description').clear().type('Automation-Test');
           cy.get('form > .govuk-button').contains('Continue').click();
         });
       });

--- a/cypress/integration/internal/sroc-charge-version-flow.spec.js
+++ b/cypress/integration/internal/sroc-charge-version-flow.spec.js
@@ -169,7 +169,7 @@ describe('Create SRoC Charge version workflow journey', () => {
           cy.reload();
         });
         describe('user description contains an unusual but supported character', () => {
-          cy.get('#description').type('* is an supported character');
+          cy.get('#description').type('-\'.,()&* are supported characters');
           cy.get('form > .govuk-button').contains('Continue').click();
           // Check that no error message was generated, then go back from the page we arrived at
           checkNoErrorMessage();

--- a/cypress/integration/internal/sroc-charge-version-flow.spec.js
+++ b/cypress/integration/internal/sroc-charge-version-flow.spec.js
@@ -165,7 +165,7 @@ describe('Create SRoC Charge version workflow journey', () => {
           cy.get('#description').type('@ is an unsupported character');
           cy.get('form > .govuk-button').contains('Continue').click();
           checkInlineAndSummaryErrorMessage(
-            'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.');
+            'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters');
           cy.reload();
         });
         describe('user description contains an unusual but supported character', () => {

--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -27,7 +27,7 @@ const form = request => {
         message: 'Enter a description for the charge reference'
       },
       'string.pattern.base': {
-        message: 'The description must only include letters a-z, hyphens, numbers and be 180 characters or fewer.'
+        message: 'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.'
       }
     }
   }, data.description || ''));
@@ -38,7 +38,7 @@ const form = request => {
 };
 
 const schema = () => {
-  const descriptionRegex = /^[a-zA-Z/s 0-9-'.,]{1,180}$/;
+  const descriptionRegex = /^[a-zA-Z/s 0-9-'.,()&*]{1,180}$/;
   return Joi.object().keys({
     csrf_token: Joi.string().uuid().required(),
     description: Joi.string().pattern(descriptionRegex).required()

--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -27,7 +27,7 @@ const form = request => {
         message: 'Enter a description for the charge reference'
       },
       'string.pattern.base': {
-        message: 'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.'
+        message: 'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters'
       }
     }
   }, data.description || ''));

--- a/test/internal/modules/charge-information/forms/charge-categories/description.js
+++ b/test/internal/modules/charge-information/forms/charge-categories/description.js
@@ -51,7 +51,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice');
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference');
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference');
-      expect(descriptionField.options.errors['string.pattern.base'].message).to.equal('You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.');
+      expect(descriptionField.options.errors['string.pattern.base'].message).to.equal('You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters');
     });
 
     test('has a submit button', async () => {

--- a/test/internal/modules/charge-information/forms/charge-categories/description.js
+++ b/test/internal/modules/charge-information/forms/charge-categories/description.js
@@ -51,7 +51,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice');
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference');
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference');
-      expect(descriptionField.options.errors['string.pattern.base'].message).to.equal('The description must only include letters a-z, hyphens, numbers and be 180 characters or fewer.');
+      expect(descriptionField.options.errors['string.pattern.base'].message).to.equal('You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters.');
     });
 
     test('has a submit button', async () => {
@@ -100,7 +100,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
           description: '@'
         }, { allowUnknown: true });
         expect(result.error).to.be.an.instanceof(Error);
-        expect(result.error.message).to.equal('"description" with value "@" fails to match the required pattern: /^[a-zA-Z/s 0-9-\'.,]{1,180}$/');
+        expect(result.error.message).to.equal('"description" with value "@" fails to match the required pattern: /^[a-zA-Z/s 0-9-\'.,()&*]{1,180}$/');
       });
       test('validates for the descriptionRegex - bigger than 180 chars', async () => {
         const stringBiggerThan180Chars = 'w5OyHN3NWsL9KTKU7afHDMlN1FUzzV3Fj30ci1sr9z1RK1jPxuOv6rFa9yb6tzGvZ6i5uaRF73V5FgwATfN08kdeYisXysk7gc90s1IVI2uyji04Tw8H1ij1o0tAh22r99C8aupphswIQt2I9CBNFhZr4rxaS413lFIb05BrQQ5OQPYVei3k4H6jEKfjCvW1iCMtReZYKE64C6EA9fGjUMrt2wNFKnoQoXo3A66yIS5iCJhV8g94fWEYzI8ZfozqWLR15Sg92HQQsT6Nr37uUFr3zIy79t0pDvcp75Ctq87Dx4eRLNHBTjzB';
@@ -109,7 +109,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
           description: stringBiggerThan180Chars
         }, { allowUnknown: true });
         expect(result.error).to.be.an.instanceof(Error);
-        expect(result.error.message).to.equal(`"description" with value "${stringBiggerThan180Chars}" fails to match the required pattern: /^[a-zA-Z/s 0-9-'.,]{1,180}$/`);
+        expect(result.error.message).to.equal(`"description" with value "${stringBiggerThan180Chars}" fails to match the required pattern: /^[a-zA-Z/s 0-9-'.,()&*]{1,180}$/`);
       });
     });
   });


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3633

We update the UI validation to accept characters `&*()` in the charge reference description. The description in the card only refers to `&()`; the ACs however state that `&*()` should be accepted, and we use these as our "single source of truth". This also matches the validation rules required for import so we can be assured that we are being consistent across both manual and automated methods of entry.

Note that the import validation mentioned in AC3 has been added to the WIP import branch, so will be active once that branch is merged.