### PR TITLE
fix: billing contact account name

### DIFF
--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -42,21 +42,23 @@
 {% macro billingContactCell(invoice) %}
   <td class="govuk-table__cell">
 
-{#    1 - invoiceAccountAddresses.contact #}
-    FAO: {{ invoice.faoContact | titleCase }}
-    <br>
-{#    2 - invoiceAccountAddresses.agentCompany #}
-    Agent Name: {{ invoice.billingContact.agentCompanyName | titleCase }}
-    <br>
-{#    3 - company.companyContact.contact #}
-{#    contact id then agent then name#}
-    Licence Holder = {{  invoice.billingContact.roleContact.licenceHolder }}
-    <br>
-    Billing contact = {{  invoice.billingContact.roleContact.billing }}
+    {% if invoice.faoContact  %}
+      {{ invoice.faoContact | titleCase }}
 
-{#    4 - company.companyContact.contact #}
-    <br>
-name: {{ invoice.name | titleCase }}
+      {% elif invoice.billingContact.agentCompanyName %}
+      {{ invoice.billingContact.agentCompanyName | titleCase }}
+
+      {% elif invoice.billingContact.roleContact.licenceHolder %}
+      {{  invoice.billingContact.roleContact.licenceHolder }}
+
+      {% elif invoice.billingContact.roleContact.billing %}
+      {{  invoice.billingContact.roleContact.billing }}
+
+    {% else %}
+      {{ invoice.name | titleCase }}
+    {% endif %}
+
+
   </td>
 {% endmacro %}
 

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -40,7 +40,11 @@
 
 {% macro billingContactCell(invoice) %}
   <td class="govuk-table__cell">
-    {{ invoice.name | titleCase }}
+    {% if invoice.billingContact.agentCompanyName %}
+      {{ invoice.billingContact.agentCompanyName | titleCase }}
+    {% else %}
+      {{ invoice.name | titleCase }}
+    {% endif %}
   </td>
 {% endmacro %}
 
@@ -198,7 +202,7 @@
         {{row.invoice.displayLabel}}
       </a>
       {{displayRebillingState(row.invoice)}}
-      
+
       {% if row.invoice.isFlaggedForRebilling %}
       <p class="govuk-body-s govuk-!-margin-bottom-0">Marked for reissue</p>
       {% endif %}

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -40,10 +40,14 @@
 
 {% macro billingContactCell(invoice) %}
   <td class="govuk-table__cell">
+    Billing roles licenceHolder = {{  invoice.billingContact.roleContact.licenceHolder }}
+    <br>
+    Billing role billing = {{  invoice.billingContact.roleContact.billing }}
+    <br>
     {% if invoice.billingContact.agentCompanyName %}
-      {{ invoice.billingContact.agentCompanyName | titleCase }}
+      agentName: {{ invoice.billingContact.agentCompanyName | titleCase }}
     {% else %}
-      {{ invoice.name | titleCase }}
+      name: {{ invoice.name | titleCase }}
     {% endif %}
   </td>
 {% endmacro %}

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -43,10 +43,10 @@
   <td class="govuk-table__cell">
 
     {% if invoice.faoContact  %}
-      {{ invoice.faoContact | titleCase }}
+      {{ invoice.faoContact }}
 
       {% elif invoice.billingContact.agentCompanyName %}
-      {{ invoice.billingContact.agentCompanyName | titleCase }}
+      {{ invoice.billingContact.agentCompanyName }}
 
       {% elif invoice.billingContact.roleContact.licenceHolder %}
       {{  invoice.billingContact.roleContact.licenceHolder }}

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -26,6 +26,7 @@
   </thead>
 {% endmacro %}
 
+
 {% macro billingAccountCell(invoice) %}
   <td class="govuk-table__cell">
     {% if invoice.invoiceAccount %}
@@ -40,15 +41,22 @@
 
 {% macro billingContactCell(invoice) %}
   <td class="govuk-table__cell">
-    Billing roles licenceHolder = {{  invoice.billingContact.roleContact.licenceHolder }}
+
+{#    1 - invoiceAccountAddresses.contact #}
+    FAO: {{ invoice.faoContact | titleCase }}
     <br>
-    Billing role billing = {{  invoice.billingContact.roleContact.billing }}
+{#    2 - invoiceAccountAddresses.agentCompany #}
+    Agent Name: {{ invoice.billingContact.agentCompanyName | titleCase }}
     <br>
-    {% if invoice.billingContact.agentCompanyName %}
-      agentName: {{ invoice.billingContact.agentCompanyName | titleCase }}
-    {% else %}
-      name: {{ invoice.name | titleCase }}
-    {% endif %}
+{#    3 - company.companyContact.contact #}
+{#    contact id then agent then name#}
+    Licence Holder = {{  invoice.billingContact.roleContact.licenceHolder }}
+    <br>
+    Billing contact = {{  invoice.billingContact.roleContact.billing }}
+
+{#    4 - company.companyContact.contact #}
+    <br>
+name: {{ invoice.name | titleCase }}
   </td>
 {% endmacro %}
 


### PR DESCRIPTION
WATER 3644

Theres are multiple names associated with companies this work will introduce a new flow to determine what name to show (just an if else in the UI )

```
if invoice.faoContact 
elif invoice.billingContact.agentCompanyName 
elif invoice.billingContact.roleContact.licenceHolder
elif invoice.billingContact.roleContact.billing
else invoice.name
```
