### PR TITLE
Export bill run CSV file for sroc

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -168,7 +168,7 @@ const getBillingBatchConfirmSuccess = (request, h) => {
 const getTransactionsCSV = async (request, h) => {
   const { batchId } = request.params
   const { invoices, chargeVersions } = await services.water.billingBatches.getBatchDownloadData(batchId)
-  const csvData = await transactionsCSV.createCSV(invoices, chargeVersions, request.pre.batch.scheme)
+  const csvData = transactionsCSV.createCSV(invoices, chargeVersions, request.pre.batch.scheme)
   const fileName = transactionsCSV.getCSVFileName(request.pre.batch)
   return csv.csvDownload(h, csvData, fileName)
 }

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -168,7 +168,7 @@ const getBillingBatchConfirmSuccess = (request, h) => {
 const getTransactionsCSV = async (request, h) => {
   const { batchId } = request.params
   const { invoices, chargeVersions } = await services.water.billingBatches.getBatchDownloadData(batchId)
-  const csvData = await transactionsCSV.createCSV(invoices, chargeVersions)
+  const csvData = await transactionsCSV.createCSV(invoices, chargeVersions, request.pre.batch.scheme)
   const fileName = transactionsCSV.getCSVFileName(request.pre.batch)
   return csv.csvDownload(h, csvData, fileName)
 }

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -4,15 +4,28 @@ const moment = require('moment')
 const numberFormatter = require('../../../../shared/lib/number-formatter')
 const { mapValues, sortBy, get } = require('lodash')
 const mappers = require('../lib/mappers')
+const { logger } = require('../../../logger')
 
-const createCSV = async (invoices, chargeVersions) => {
+const createCSV = async (invoices, chargeVersions, scheme) => {
   const sortedInvoices = sortBy(invoices, 'invoiceAccountaNumber', 'billingInvoiceLicences[0].licence.licenceRef')
   const dataForCSV = []
 
   sortedInvoices.forEach(invoice => {
     invoice.billingInvoiceLicences.forEach(invoiceLicence => {
       invoiceLicence.billingTransactions.forEach(transaction => {
-        dataForCSV.push(_csvLine(invoice, invoiceLicence, transaction, chargeVersions))
+        let csvLine
+
+        switch (scheme) {
+          case 'alcs':
+            csvLine = _csvLine(invoice, invoiceLicence, transaction, chargeVersions)
+            break
+          case 'sroc':
+            csvLine = _csvLine(invoice, invoiceLicence, transaction, chargeVersions)
+            break
+          default:
+            logger.error(`Scheme ${scheme} not recognised when exporting batch ${invoice.billingBatchId}`)
+        }
+        dataForCSV.push(csvLine)
       })
     })
   })

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -6,7 +6,7 @@ const { mapValues, sortBy, get } = require('lodash')
 const mappers = require('../lib/mappers')
 const { logger } = require('../../../logger')
 
-const createCSV = async (invoices, chargeVersions, scheme) => {
+const createCSV = (invoices, chargeVersions, scheme) => {
   const sortedInvoices = sortBy(invoices, 'invoiceAccountaNumber', 'billingInvoiceLicences[0].licence.licenceRef')
   const dataForCSV = []
 

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -117,7 +117,8 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Charge reference description': transaction.chargeCategoryDescription,
     Source: transaction.source,
     Loss: transaction.loss,
-    Volume: transaction.volume,
+    // In the UI, "Volume" is taken from authorisedAnnualQuantity
+    Volume: transaction.chargeElement.authorisedAnnualQuantity,
     'Water available Y/N': transaction.chargeElement.isRestrictedSource ? 'N' : 'Y',
     Modelling: transaction.chargeElement.waterModel,
     'Public water supply Y/N': transaction.isWaterCompanyCharge ? 'Y' : 'N',
@@ -139,7 +140,8 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Historical area': invoiceLicence.licence.regions.historicalAreaCode,
     'EIC region': transaction.chargeElement.eiucRegion,
     'Calculated quantity': _billingVolume(transaction),
-    Quantity: transaction.volume // looks like a repeat of line 120
+    // In the UI, "Quantity" is taken from volume
+    Quantity: transaction.volume
   }
 
   return _rowToStrings(csvLine)

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -134,12 +134,12 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Is second part charge? Y/N': transaction.isTwoPartSecondPartCharge ? 'Y' : 'N',
     'Compensation charge Y/N': transaction.isCompensationCharge ? 'Y' : 'N',
     'Compensation charge applicable Y/N': invoiceLicence.licence.isWaterUndertaker ? 'N' : 'Y',
-    'De minimis rule Y/N': '',
+    'De minimis rule Y/N': invoice.isDeMinimis ? 'Y' : 'N',
     Region: invoiceLicence.licence.region.displayName,
     'Historical area': invoiceLicence.licence.regions.historicalAreaCode,
     'EIC region': transaction.chargeElement.eiucRegion,
     'Calculated quantity': _billingVolume(transaction),
-    Quantity: transaction.volume
+    Quantity: transaction.volume // looks like a repeat of line 120
   }
 
   return _rowToStrings(csvLine)

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -38,33 +38,6 @@ const getCSVFileName = batch => {
   return `${batch.region.displayName} ${batchType.toLowerCase()} bill run ${batch.billRunNumber}.csv`
 }
 
-function _billingVolume (transaction) {
-  if (!transaction.volume) {
-    return null
-  }
-
-  const transactionYear = new Date(transaction.endDate).getFullYear()
-  const billingVolume = transaction.billingVolume.find(row => row.financialYear === transactionYear)
-
-  return billingVolume ? billingVolume.calculatedVolume : null
-}
-
-function _changeReason (chargeVersions, transaction) {
-  const chargeVersionId = get(transaction, 'chargeElement.chargeVersionId')
-  const chargeVersion = chargeVersions.find(cv => cv.id === chargeVersionId)
-  return (chargeVersion && chargeVersion.changeReason)
-    ? chargeVersion.changeReason.description
-    : null
-}
-
-function _creditLineValue (isCredit, value) {
-  if (!isCredit) {
-    return null
-  }
-
-  return numberFormatter.penceToPound(value, true)
-}
-
 function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
   const csvLine = {
     'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
@@ -102,13 +75,13 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
       'Purpose code': transaction.chargeElement.purposeUse.legacyId,
       'Purpose name': transaction.chargeElement.purposeUse.description,
       'Abstraction period start date': moment()
-        .month(transaction.abstractionPeriod.startMonth - 1)
-        .date(transaction.abstractionPeriod.startDay)
-        .format('D MMM'),
+      .month(transaction.abstractionPeriod.startMonth - 1)
+      .date(transaction.abstractionPeriod.startDay)
+      .format('D MMM'),
       'Abstraction period end date': moment()
-        .month(transaction.abstractionPeriod.endMonth - 1)
-        .date(transaction.abstractionPeriod.endDay)
-        .format('D MMM')
+      .month(transaction.abstractionPeriod.endMonth - 1)
+      .date(transaction.abstractionPeriod.endDay)
+      .format('D MMM')
     }),
     'Charge period start date': transaction.startDate,
     'Charge period end date': transaction.endDate,
@@ -123,6 +96,33 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
   }
 
   return _rowToStrings(csvLine)
+}
+
+function _billingVolume (transaction) {
+  if (!transaction.volume) {
+    return null
+  }
+
+  const transactionYear = new Date(transaction.endDate).getFullYear()
+  const billingVolume = transaction.billingVolume.find(row => row.financialYear === transactionYear)
+
+  return billingVolume ? billingVolume.calculatedVolume : null
+}
+
+function _changeReason(chargeVersions, transaction) {
+  const chargeVersionId = get(transaction, 'chargeElement.chargeVersionId')
+  const chargeVersion = chargeVersions.find(cv => cv.id === chargeVersionId)
+  return (chargeVersion && chargeVersion.changeReason)
+    ? chargeVersion.changeReason.description
+    : null
+}
+
+function _creditLineValue (isCredit, value) {
+  if (!isCredit) {
+    return null
+  }
+
+  return numberFormatter.penceToPound(value, true)
 }
 
 function _debitLineValue (isCredit, value) {

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -75,13 +75,13 @@ function _csvLineAlcs (invoice, invoiceLicence, transaction, chargeVersions) {
       'Purpose code': transaction.chargeElement.purposeUse.legacyId,
       'Purpose name': transaction.chargeElement.purposeUse.description,
       'Abstraction period start date': moment()
-      .month(transaction.abstractionPeriod.startMonth - 1)
-      .date(transaction.abstractionPeriod.startDay)
-      .format('D MMM'),
+        .month(transaction.abstractionPeriod.startMonth - 1)
+        .date(transaction.abstractionPeriod.startDay)
+        .format('D MMM'),
       'Abstraction period end date': moment()
-      .month(transaction.abstractionPeriod.endMonth - 1)
-      .date(transaction.abstractionPeriod.endDay)
-      .format('D MMM')
+        .month(transaction.abstractionPeriod.endMonth - 1)
+        .date(transaction.abstractionPeriod.endDay)
+        .format('D MMM')
     }),
     'Charge period start date': transaction.startDate,
     'Charge period end date': transaction.endDate,
@@ -98,7 +98,7 @@ function _csvLineAlcs (invoice, invoiceLicence, transaction, chargeVersions) {
   return _rowToStrings(csvLine)
 }
 
-function _csvLineSroc(invoice, invoiceLicence, transaction, chargeVersions) {
+function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
   const csvLine = {
     'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
     'Customer name': invoice.invoiceAccount.company.name,
@@ -115,11 +115,11 @@ function _csvLineSroc(invoice, invoiceLicence, transaction, chargeVersions) {
     'Billable days': transaction.billableDays,
     'Charge reference': transaction.chargeCategoryCode,
     'Charge reference description': transaction.chargeCategoryDescription,
-    'Source': transaction.source,
-    'Loss': transaction.loss,
-    'Volume': transaction.volume,
+    Source: transaction.source,
+    Loss: transaction.loss,
+    Volume: transaction.volume,
     'Water available Y/N': transaction.chargeElement.isRestrictedSource ? 'N' : 'Y',
-    'Modelling': transaction.chargeElement.waterModel,
+    Modelling: transaction.chargeElement.waterModel,
     'Public water supply Y/N': transaction.isWaterCompanyCharge ? 'Y' : 'N',
     'Supported source Y/N': transaction.isSupportedSource ? 'Y' : 'N',
     'Supported source name': transaction.supportedSourceName,
@@ -156,7 +156,7 @@ function _billingVolume (transaction) {
   return billingVolume ? billingVolume.calculatedVolume : null
 }
 
-function _changeReason(chargeVersions, transaction) {
+function _changeReason (chargeVersions, transaction) {
   const chargeVersionId = get(transaction, 'chargeElement.chargeVersionId')
   const chargeVersion = chargeVersions.find(cv => cv.id === chargeVersionId)
   return (chargeVersion && chargeVersion.changeReason)

--- a/test/internal/modules/billing/controllers/bill-run.js
+++ b/test/internal/modules/billing/controllers/bill-run.js
@@ -653,7 +653,7 @@ experiment('internal/modules/billing/controller', () => {
       services.water.billingBatches.getBatchDownloadData.resolves({ invoices, chargeVersions })
 
       csvData = [['header1', 'header2', 'header2'], ['transaction', 'line', 1]]
-      transactionsCSV.createCSV.resolves(csvData)
+      transactionsCSV.createCSV.returns(csvData)
 
       await controller.getTransactionsCSV(request, h)
     })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -248,8 +248,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         scheme = 'alcs'
       })
 
-      test('formats each CSV row as expected', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      test('formats each CSV row as expected', () => {
+        result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Billing account number']).to.equal('A12345678A')
         expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
@@ -295,15 +295,15 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0]['S130 agreement value']).to.equal('')
       })
 
-      test('creates a line for each transaction', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      test('creates a line for each transaction', () => {
+        result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
       })
 
       experiment('when the invoice is a debit', () => {
-        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Invoice amount' and 'Credit amount' correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Invoice amount']).to.equal('1,234.56')
           expect(result[0]['Credit amount']).to.equal('')
@@ -316,8 +316,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.netAmount = -123456
         })
 
-        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Invoice amount' and 'Credit amount' correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Invoice amount']).to.equal('')
           expect(result[0]['Credit amount']).to.equal('-1,234.56')
@@ -325,8 +325,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       experiment('when the transaction is a debit', () => {
-        test("sets the 'Net transaction line amount' fields correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets the 'Net transaction line amount' fields correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('')
@@ -341,8 +341,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets the 'Net transaction line amount' fields correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets the 'Net transaction line amount' fields correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
@@ -356,8 +356,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("states 'Error - not calculated' in the transaction line amount fields", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("states 'Error - not calculated' in the transaction line amount fields", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
@@ -370,8 +370,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             chargeVersions[0].id = 'notgonnafindme'
           })
 
-          test("sets the 'Charge information reason' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Charge information reason' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Charge information reason']).to.equal('')
           })
@@ -382,8 +382,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             chargeVersions[0].changeReason = null
           })
 
-          test("sets the 'Charge information reason' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Charge information reason' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Charge information reason']).to.equal('')
           })
@@ -395,8 +395,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.isDeMinimis = true
         })
 
-        test("sets 'De minimis rule Y/N' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'De minimis rule Y/N' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['De minimis rule Y/N']).to.equal('Y')
         })
@@ -407,8 +407,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
         })
 
-        test("sets 'Water company Y/N' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Water company Y/N' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Water company Y/N']).to.equal('Y')
         })
@@ -421,8 +421,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Compensation charge Y/N' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Compensation charge Y/N' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Compensation charge Y/N']).to.equal('Y')
         })
@@ -435,8 +435,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test('drops a number of columns', async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test('drops a number of columns', () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
           expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
@@ -464,8 +464,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Adjusted source type' to 'tidal'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Adjusted source type' to 'tidal'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Adjusted source type']).to.equal('tidal')
         })
@@ -479,8 +479,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             })
           })
 
-          test("sets the 'Calculated quantity' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Calculated quantity' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Calculated quantity']).to.equal('')
           })
@@ -493,8 +493,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             })
           })
 
-          test("sets the 'Calculated quantity' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Calculated quantity' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Calculated quantity']).to.equal('')
           })
@@ -508,8 +508,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'S127 agreement (Y/N)' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'S127 agreement (Y/N)' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
         })
@@ -522,8 +522,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'S127 agreement value' to empty", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'S127 agreement value' to empty", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['S127 agreement value']).to.equal('')
         })
@@ -537,8 +537,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         scheme = 'sroc'
       })
 
-      test('formats each CSV row as expected', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      test('formats each CSV row as expected', () => {
+        result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Billing account number']).to.equal('A12345678A')
         expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
@@ -583,15 +583,15 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0].Quantity).to.equal('9.1')
       })
 
-      test('creates a line for each transaction', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      test('creates a line for each transaction', () => {
+        result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
       })
 
       experiment('when the invoice is a debit', () => {
-        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Invoice amount' and 'Credit amount' correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Invoice amount']).to.equal('1,234.56')
           expect(result[0]['Credit amount']).to.equal('')
@@ -604,8 +604,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.netAmount = -123456
         })
 
-        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Invoice amount' and 'Credit amount' correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Invoice amount']).to.equal('')
           expect(result[0]['Credit amount']).to.equal('-1,234.56')
@@ -613,8 +613,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       experiment('when the transaction is a debit', () => {
-        test("sets the 'Net transaction line amount' fields correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets the 'Net transaction line amount' fields correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('')
@@ -629,8 +629,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets the 'Net transaction line amount' fields correctly", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets the 'Net transaction line amount' fields correctly", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
@@ -644,8 +644,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("states 'Error - not calculated' in the transaction line amount fields", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("states 'Error - not calculated' in the transaction line amount fields", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
           expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
@@ -658,8 +658,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             chargeVersions[0].id = 'notgonnafindme'
           })
 
-          test("sets the 'Charge information reason' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Charge information reason' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Charge information reason']).to.equal('')
           })
@@ -670,8 +670,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             chargeVersions[0].changeReason = null
           })
 
-          test("sets the 'Charge information reason' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Charge information reason' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Charge information reason']).to.equal('')
           })
@@ -685,8 +685,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Water available Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Water available Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Water available Y/N']).to.equal('N')
         })
@@ -699,8 +699,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Public water supply Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Public water supply Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Public water supply Y/N']).to.equal('N')
         })
@@ -713,8 +713,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Supported source Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Supported source Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Supported source Y/N']).to.equal('N')
         })
@@ -727,8 +727,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Is second part charge? Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Is second part charge? Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Is second part charge? Y/N']).to.equal('Y')
         })
@@ -741,8 +741,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Is second part charge? Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Is second part charge? Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Is second part charge? Y/N']).to.equal('Y')
         })
@@ -755,8 +755,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           })
         })
 
-        test("sets 'Compensation charge Y/N' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Compensation charge Y/N' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Compensation charge Y/N']).to.equal('Y')
         })
@@ -767,8 +767,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
         })
 
-        test("sets 'Compensation charge applicable Y/N' to 'N'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'Compensation charge applicable Y/N' to 'N'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Compensation charge applicable Y/N']).to.equal('N')
         })
@@ -779,8 +779,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           invoice.isDeMinimis = true
         })
 
-        test("sets 'De minimis rule Y/N' to 'Y'", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+        test("sets 'De minimis rule Y/N' to 'Y'", () => {
+          result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['De minimis rule Y/N']).to.equal('Y')
         })
@@ -794,8 +794,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             })
           })
 
-          test("sets the 'Calculated quantity' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Calculated quantity' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Calculated quantity']).to.equal('')
           })
@@ -808,8 +808,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             })
           })
 
-          test("sets the 'Calculated quantity' to empty", async () => {
-            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+          test("sets the 'Calculated quantity' to empty", () => {
+            result = transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
             expect(result[0]['Calculated quantity']).to.equal('')
           })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -205,14 +205,16 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     let chargeVersions
     let invoice
     let result
+    let scheme
 
     beforeEach(() => {
       invoice = GeneralHelper.cloneObject(invoiceData)
       chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
+      scheme = 'alcs'
     })
 
     test('formats each CSV row as expected', async () => {
-      result = await transactionsCSV.createCSV([invoice], chargeVersions)
+      result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
       expect(result[0]['Billing account number']).to.equal('A12345678A')
       expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
@@ -259,14 +261,14 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     })
 
     test('creates a line for each transaction', async () => {
-      result = await transactionsCSV.createCSV([invoice], chargeVersions)
+      result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
       expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
     })
 
     experiment('when the invoice is a debit', () => {
       test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Invoice amount']).to.equal('1,234.56')
         expect(result[0]['Credit amount']).to.equal('')
@@ -280,7 +282,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Invoice amount']).to.equal('')
         expect(result[0]['Credit amount']).to.equal('-1,234.56')
@@ -289,7 +291,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
 
     experiment('when the transaction is a debit', () => {
       test("sets the 'Net transaction line amount' fields correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('')
@@ -305,7 +307,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets the 'Net transaction line amount' fields correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Net transaction line amount(debit)']).to.equal('')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
@@ -320,7 +322,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("states 'Error - not calculated' in the transaction line amount fields", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
@@ -334,7 +336,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         })
 
         test("sets the 'Charge information reason' to empty", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Charge information reason']).to.equal('')
         })
@@ -346,7 +348,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         })
 
         test("sets the 'Charge information reason' to empty", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Charge information reason']).to.equal('')
         })
@@ -359,7 +361,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'De minimis rule Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['De minimis rule Y/N']).to.equal('Y')
       })
@@ -371,7 +373,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'Water company Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Water company Y/N']).to.equal('Y')
       })
@@ -385,7 +387,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'Compensation charge Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Compensation charge Y/N']).to.equal('Y')
       })
@@ -399,7 +401,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test('drops a number of columns', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
         expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
@@ -428,7 +430,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'Adjusted source type' to 'tidal'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['Adjusted source type']).to.equal('tidal')
       })
@@ -443,7 +445,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         })
 
         test("sets the 'Calculated quantity' to empty", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Calculated quantity']).to.equal('')
         })
@@ -457,7 +459,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         })
 
         test("sets the 'Calculated quantity' to empty", async () => {
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
           expect(result[0]['Calculated quantity']).to.equal('')
         })
@@ -472,7 +474,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'S127 agreement (Y/N)' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
       })
@@ -486,7 +488,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test("sets 'S127 agreement value' to empty", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
         expect(result[0]['S127 agreement value']).to.equal('')
       })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -13,7 +13,7 @@ const batch = {
   dateCreated: '2020-01-14',
   type: 'two_part_tariff',
   region: {
-    displayName: 'South West',
+    displayName: 'Anglian',
     id: '7c9e4745-c474-41a4-823a-e18c57e85d4c'
   },
   billRunNumber: 2345
@@ -69,7 +69,11 @@ const invoiceData =
                 type: 'use',
                 legacyId: '420',
                 description: 'Spray Irrigation - Storage'
-              }
+              },
+              // These are sroc transaction line properties
+              isRestrictedSource: false,
+              waterModel: 'no model',
+              eiucRegion: 'Anglian (EIC)'
             },
             volume: 9.1,
             calcEiucFactor: 1,
@@ -81,7 +85,20 @@ const invoiceData =
             calcS126Factor: 1.0,
             calcS127Factor: 0.5,
             section130Agreement: 'S130W',
-            section127Agreement: false
+            section127Agreement: false,
+            // These are sroc transaction lines
+            chargeCategoryCode: '4.5.55',
+            chargeCategoryDescription: 'Medium loss, non-tidal',
+            source: 'non-tidal',
+            loss: 'medium',
+            isWaterCompanyCharge: true,
+            isSupportedSource: true,
+            supportedSourceName: 'Name of supported source',
+            calcWinterDiscountFactor: null,
+            calcS130Factor: null,
+            aggregateFactor: 1,
+            adjustmentFactor: 1,
+            isTwoPartSecondPartCharge: false
           },
           {
             value: 4006,
@@ -124,7 +141,11 @@ const invoiceData =
                 type: 'use',
                 code: '420',
                 name: 'Spray Irrigation - Storage'
-              }
+              },
+              // These are sroc transaction line properties
+              isRestrictedSource: false,
+              waterModel: 'no model',
+              eiucRegion: 'Anglian (EIC)'
             },
             volume: 9.1,
             billingVolume: [
@@ -141,7 +162,20 @@ const invoiceData =
             calcLossFactor: 0.5,
             calcEiucSourceFactor: 0.5,
             calcS126FactorValue: 1.0,
-            calcS127FactorValue: 0.5
+            calcS127FactorValue: 0.5,
+            // These are sroc transaction lines
+            chargeCategoryCode: '4.5.55',
+            chargeCategoryDescription: 'Medium loss, non-tidal',
+            source: 'non-tidal',
+            loss: 'medium',
+            isWaterCompanyCharge: true,
+            isSupportedSource: true,
+            supportedSourceName: 'Name of supported source',
+            calcWinterDiscountFactor: null,
+            calcS130Factor: null,
+            aggregateFactor: 1,
+            adjustmentFactor: 1,
+            isTwoPartSecondPartCharge: false
           }
         ],
         licence: {
@@ -207,290 +241,579 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     let result
     let scheme
 
-    beforeEach(() => {
-      invoice = GeneralHelper.cloneObject(invoiceData)
-      chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
-      scheme = 'alcs'
-    })
+    experiment('for an ALCS batch', () => {
+      beforeEach(() => {
+        invoice = GeneralHelper.cloneObject(invoiceData)
+        chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
+        scheme = 'alcs'
+      })
 
-    test('formats each CSV row as expected', async () => {
-      result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-      expect(result[0]['Billing account number']).to.equal('A12345678A')
-      expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
-      expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
-      expect(result[0]['Bill number']).to.equal('IIA123456')
-      expect(result[0]['Financial year']).to.equal('2019')
-      expect(result[0]['Invoice amount']).to.equal('1,234.56')
-      expect(result[0]['Credit amount']).to.equal('')
-      expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
-      expect(result[0]['Net transaction line amount(credit)']).to.equal('')
-      expect(result[0]['Charge information reason']).to.equal('change reason description')
-      expect(result[0].Region).to.equal('Anglian')
-      expect(result[0]['De minimis rule Y/N']).to.equal('N')
-      expect(result[0]['Transaction description']).to.equal('The description - with 007')
-      expect(result[0]['Water company Y/N']).to.equal('N')
-      expect(result[0]['Historical area']).to.equal('AREA')
-      expect(result[0]['Compensation charge Y/N']).to.equal('N')
-      expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
-      expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-      expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
-      expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
-      expect(result[0]['Source type']).to.equal('unsupported')
-      expect(result[0]['Source factor']).to.equal('0.5')
-      expect(result[0]['Adjusted source type']).to.equal('other')
-      expect(result[0]['Adjusted source factor']).to.equal('0.5')
-      expect(result[0].Season).to.equal('winter')
-      expect(result[0]['Season factor']).to.equal('0.5')
-      expect(result[0].Loss).to.equal('high')
-      expect(result[0]['Loss factor']).to.equal('0.5')
-      expect(result[0]['Purpose code']).to.equal('420')
-      expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
-      expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
-      expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
-      expect(result[0]['Charge period start date']).to.equal('2019-04-01')
-      expect(result[0]['Charge period end date']).to.equal('2020-03-31')
-      expect(result[0]['Authorised days']).to.equal('152')
-      expect(result[0]['Billable days']).to.equal('152')
-      expect(result[0]['Calculated quantity']).to.equal('10.3')
-      expect(result[0].Quantity).to.equal('9.1')
-      expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
-      expect(result[0]['S127 agreement value']).to.equal('0.5')
-      expect(result[0]['S130 agreement']).to.equal('S130W')
-      expect(result[0]['S130 agreement value']).to.equal('')
-    })
-
-    test('creates a line for each transaction', async () => {
-      result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-      expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
-    })
-
-    experiment('when the invoice is a debit', () => {
-      test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
+      test('formats each CSV row as expected', async () => {
         result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
+        expect(result[0]['Billing account number']).to.equal('A12345678A')
+        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(result[0]['Bill number']).to.equal('IIA123456')
+        expect(result[0]['Financial year']).to.equal('2019')
         expect(result[0]['Invoice amount']).to.equal('1,234.56')
         expect(result[0]['Credit amount']).to.equal('')
-      })
-    })
-
-    experiment('when the invoice is a credit', () => {
-      beforeEach(() => {
-        invoice.isCredit = true
-        invoice.netAmount = -123456
-      })
-
-      test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['Invoice amount']).to.equal('')
-        expect(result[0]['Credit amount']).to.equal('-1,234.56')
-      })
-    })
-
-    experiment('when the transaction is a debit', () => {
-      test("sets the 'Net transaction line amount' fields correctly", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
         expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+        expect(result[0]['Charge information reason']).to.equal('change reason description')
+        expect(result[0].Region).to.equal('Anglian')
+        expect(result[0]['De minimis rule Y/N']).to.equal('N')
+        expect(result[0]['Transaction description']).to.equal('The description - with 007')
+        expect(result[0]['Water company Y/N']).to.equal('N')
+        expect(result[0]['Historical area']).to.equal('AREA')
+        expect(result[0]['Compensation charge Y/N']).to.equal('N')
+        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Source type']).to.equal('unsupported')
+        expect(result[0]['Source factor']).to.equal('0.5')
+        expect(result[0]['Adjusted source type']).to.equal('other')
+        expect(result[0]['Adjusted source factor']).to.equal('0.5')
+        expect(result[0].Season).to.equal('winter')
+        expect(result[0]['Season factor']).to.equal('0.5')
+        expect(result[0].Loss).to.equal('high')
+        expect(result[0]['Loss factor']).to.equal('0.5')
+        expect(result[0]['Purpose code']).to.equal('420')
+        expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+        expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
+        expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
+        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(result[0]['Authorised days']).to.equal('152')
+        expect(result[0]['Billable days']).to.equal('152')
+        expect(result[0]['Calculated quantity']).to.equal('10.3')
+        expect(result[0].Quantity).to.equal('9.1')
+        expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
+        expect(result[0]['S127 agreement value']).to.equal('0.5')
+        expect(result[0]['S130 agreement']).to.equal('S130W')
+        expect(result[0]['S130 agreement value']).to.equal('')
       })
-    })
 
-    experiment('when the transaction is a credit', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.isCredit = true
-          transaction.netAmount = -61728
-        })
-      })
-
-      test("sets the 'Net transaction line amount' fields correctly", async () => {
+      test('creates a line for each transaction', async () => {
         result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-        expect(result[0]['Net transaction line amount(debit)']).to.equal('')
-        expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
-      })
-    })
-
-    experiment('when `netAmount` in the transactions is null', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.netAmount = null
-        })
+        expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
       })
 
-      test("states 'Error - not calculated' in the transaction line amount fields", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
-        expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
-      })
-    })
-
-    experiment('when charge information is missing', () => {
-      experiment('such as the charge version not being found', () => {
-        beforeEach(() => {
-          chargeVersions[0].id = 'notgonnafindme'
-        })
-
-        test("sets the 'Charge information reason' to empty", async () => {
+      experiment('when the invoice is a debit', () => {
+        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
           result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-          expect(result[0]['Charge information reason']).to.equal('')
+          expect(result[0]['Invoice amount']).to.equal('1,234.56')
+          expect(result[0]['Credit amount']).to.equal('')
         })
       })
 
-      experiment('such as the change reason being null', () => {
+      experiment('when the invoice is a credit', () => {
         beforeEach(() => {
-          chargeVersions[0].changeReason = null
+          invoice.isCredit = true
+          invoice.netAmount = -123456
         })
 
-        test("sets the 'Charge information reason' to empty", async () => {
+        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
           result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-          expect(result[0]['Charge information reason']).to.equal('')
-        })
-      })
-    })
-
-    experiment('when deminimis is true', () => {
-      beforeEach(() => {
-        invoice.isDeMinimis = true
-      })
-
-      test("sets 'De minimis rule Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['De minimis rule Y/N']).to.equal('Y')
-      })
-    })
-
-    experiment('when water company is true', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
-      })
-
-      test("sets 'Water company Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['Water company Y/N']).to.equal('Y')
-      })
-    })
-
-    experiment('when compensation charge is true', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.isCompensationCharge = true
+          expect(result[0]['Invoice amount']).to.equal('')
+          expect(result[0]['Credit amount']).to.equal('-1,234.56')
         })
       })
 
-      test("sets 'Compensation charge Y/N' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      experiment('when the transaction is a debit', () => {
+        test("sets the 'Net transaction line amount' fields correctly", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-        expect(result[0]['Compensation charge Y/N']).to.equal('Y')
-      })
-    })
-
-    experiment('when the transaction charge type is minimum charge', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.chargeType = 'minimum_charge'
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('')
         })
       })
 
-      test('drops a number of columns', async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
-        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
-        expect(result[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
-        expect(result[0]['Billable annual quantity (megalitres)']).to.be.undefined()
-        expect(result[0]['Source type']).to.be.undefined()
-        expect(result[0]['Source factor']).to.be.undefined()
-        expect(result[0]['Adjusted source type']).to.be.undefined()
-        expect(result[0]['Adjusted source factor']).to.be.undefined()
-        expect(result[0].Season).to.be.undefined()
-        expect(result[0]['Season factor']).to.be.undefined()
-        expect(result[0].Loss).to.be.undefined()
-        expect(result[0]['Loss factor']).to.be.undefined()
-        expect(result[0]['Purpose code']).to.be.undefined()
-        expect(result[0]['Purpose name']).to.be.undefined()
-        expect(result[0]['Abstraction period start date']).to.be.undefined()
-        expect(result[0]['Abstraction period end date']).to.be.undefined()
-      })
-    })
-
-    experiment('when the transaction charge element source type is tidal', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.chargeElement.source = 'tidal'
-        })
-      })
-
-      test("sets 'Adjusted source type' to 'tidal'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
-
-        expect(result[0]['Adjusted source type']).to.equal('tidal')
-      })
-    })
-
-    experiment('when billing volume data is missing', () => {
-      experiment('such as transaction volumn being null', () => {
+      experiment('when the transaction is a credit', () => {
         beforeEach(() => {
           invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-            transaction.volume = null
+            transaction.isCredit = true
+            transaction.netAmount = -61728
           })
         })
 
-        test("sets the 'Calculated quantity' to empty", async () => {
+        test("sets the 'Net transaction line amount' fields correctly", async () => {
           result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-          expect(result[0]['Calculated quantity']).to.equal('')
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
         })
       })
 
-      experiment('such as the billing volumes not having a matching financial year for transaction end date', () => {
+      experiment('when `netAmount` in the transactions is null', () => {
         beforeEach(() => {
           invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-            transaction.billingVolume[0].financialYear = 2018
+            transaction.netAmount = null
           })
         })
 
-        test("sets the 'Calculated quantity' to empty", async () => {
+        test("states 'Error - not calculated' in the transaction line amount fields", async () => {
           result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-          expect(result[0]['Calculated quantity']).to.equal('')
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
+        })
+      })
+
+      experiment('when charge information is missing', () => {
+        experiment('such as the charge version not being found', () => {
+          beforeEach(() => {
+            chargeVersions[0].id = 'notgonnafindme'
+          })
+
+          test("sets the 'Charge information reason' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Charge information reason']).to.equal('')
+          })
+        })
+
+        experiment('such as the change reason being null', () => {
+          beforeEach(() => {
+            chargeVersions[0].changeReason = null
+          })
+
+          test("sets the 'Charge information reason' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Charge information reason']).to.equal('')
+          })
+        })
+      })
+
+      experiment('when deminimis is true', () => {
+        beforeEach(() => {
+          invoice.isDeMinimis = true
+        })
+
+        test("sets 'De minimis rule Y/N' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['De minimis rule Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when water company is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
+        })
+
+        test("sets 'Water company Y/N' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Water company Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when compensation charge is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isCompensationCharge = true
+          })
+        })
+
+        test("sets 'Compensation charge Y/N' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Compensation charge Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when the transaction charge type is minimum charge', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.chargeType = 'minimum_charge'
+          })
+        })
+
+        test('drops a number of columns', async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
+          expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
+          expect(result[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
+          expect(result[0]['Billable annual quantity (megalitres)']).to.be.undefined()
+          expect(result[0]['Source type']).to.be.undefined()
+          expect(result[0]['Source factor']).to.be.undefined()
+          expect(result[0]['Adjusted source type']).to.be.undefined()
+          expect(result[0]['Adjusted source factor']).to.be.undefined()
+          expect(result[0].Season).to.be.undefined()
+          expect(result[0]['Season factor']).to.be.undefined()
+          expect(result[0].Loss).to.be.undefined()
+          expect(result[0]['Loss factor']).to.be.undefined()
+          expect(result[0]['Purpose code']).to.be.undefined()
+          expect(result[0]['Purpose name']).to.be.undefined()
+          expect(result[0]['Abstraction period start date']).to.be.undefined()
+          expect(result[0]['Abstraction period end date']).to.be.undefined()
+        })
+      })
+
+      experiment('when the transaction charge element source type is tidal', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.chargeElement.source = 'tidal'
+          })
+        })
+
+        test("sets 'Adjusted source type' to 'tidal'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Adjusted source type']).to.equal('tidal')
+        })
+      })
+
+      experiment('when billing volume data is missing', () => {
+        experiment('such as transaction volumn being null', () => {
+          beforeEach(() => {
+            invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+              transaction.volume = null
+            })
+          })
+
+          test("sets the 'Calculated quantity' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Calculated quantity']).to.equal('')
+          })
+        })
+
+        experiment('such as the billing volumes not having a matching financial year for transaction end date', () => {
+          beforeEach(() => {
+            invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+              transaction.billingVolume[0].financialYear = 2018
+            })
+          })
+
+          test("sets the 'Calculated quantity' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Calculated quantity']).to.equal('')
+          })
+        })
+      })
+
+      experiment('when section 127 agreement is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.section127Agreement = true
+          })
+        })
+
+        test("sets 'S127 agreement (Y/N)' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
+        })
+      })
+
+      experiment('when the calculated S127 value is null', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.calcS127Factor = null
+          })
+        })
+
+        test("sets 'S127 agreement value' to empty", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['S127 agreement value']).to.equal('')
         })
       })
     })
 
-    experiment('when section 127 agreement is true', () => {
+    experiment('for an SROC batch', () => {
       beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.section127Agreement = true
+        invoice = GeneralHelper.cloneObject(invoiceData)
+        chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
+        scheme = 'sroc'
+      })
+
+      test('formats each CSV row as expected', async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+        expect(result[0]['Billing account number']).to.equal('A12345678A')
+        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(result[0]['Bill number']).to.equal('IIA123456')
+        expect(result[0]['Financial year']).to.equal('2019')
+        expect(result[0]['Invoice amount']).to.equal('1,234.56')
+        expect(result[0]['Credit amount']).to.equal('')
+        expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+        expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(result[0]['Authorised days']).to.equal('152')
+        expect(result[0]['Billable days']).to.equal('152')
+        expect(result[0]['Charge reference']).to.equal('4.5.55')
+        expect(result[0]['Charge reference description']).to.equal('Medium loss, non-tidal')
+        expect(result[0]['Charge reference']).to.equal('4.5.55')
+        expect(result[0].Source).to.equal('non-tidal')
+        expect(result[0].Loss).to.equal('medium')
+        expect(result[0].Volume).to.equal('9.1')
+        expect(result[0]['Water available Y/N']).to.equal('Y')
+        expect(result[0].Modelling).to.equal('no model')
+        expect(result[0]['Public water supply Y/N']).to.equal('Y')
+        expect(result[0]['Supported source Y/N']).to.equal('Y')
+        expect(result[0]['Supported source name']).to.equal('Name of supported source')
+        expect(result[0]['Winter discount']).to.equal('')
+        expect(result[0]['Canal and Rivers trust agreement']).to.equal('')
+        expect(result[0]['Aggregate factor']).to.equal('1')
+        expect(result[0]['Charge adjustment factor']).to.equal('1')
+        expect(result[0]['Abatement factor']).to.equal('1')
+        expect(result[0]['Two part tariff']).to.equal('0.5')
+        expect(result[0]['Transaction description']).to.equal('The description - with 007')
+        expect(result[0]['Charge information reason']).to.equal('change reason description')
+        expect(result[0]['Is second part charge? Y/N']).to.equal('N')
+        expect(result[0]['Compensation charge Y/N']).to.equal('N')
+        expect(result[0]['Compensation charge applicable Y/N']).to.equal('Y')
+        expect(result[0]['De minimis rule Y/N']).to.equal('N')
+        expect(result[0].Region).to.equal('Anglian')
+        expect(result[0]['Historical area']).to.equal('AREA')
+        expect(result[0]['EIC region']).to.equal('Anglian (EIC)')
+        expect(result[0]['Calculated quantity']).to.equal('10.3')
+        expect(result[0].Quantity).to.equal('9.1')
+      })
+
+      test('creates a line for each transaction', async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+        expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
+      })
+
+      experiment('when the invoice is a debit', () => {
+        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Invoice amount']).to.equal('1,234.56')
+          expect(result[0]['Credit amount']).to.equal('')
         })
       })
 
-      test("sets 'S127 agreement (Y/N)' to 'Y'", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      experiment('when the invoice is a credit', () => {
+        beforeEach(() => {
+          invoice.isCredit = true
+          invoice.netAmount = -123456
+        })
 
-        expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
-      })
-    })
+        test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-    experiment('when the calculated S127 value is null', () => {
-      beforeEach(() => {
-        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-          transaction.calcS127Factor = null
+          expect(result[0]['Invoice amount']).to.equal('')
+          expect(result[0]['Credit amount']).to.equal('-1,234.56')
         })
       })
 
-      test("sets 'S127 agreement value' to empty", async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+      experiment('when the transaction is a debit', () => {
+        test("sets the 'Net transaction line amount' fields correctly", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
 
-        expect(result[0]['S127 agreement value']).to.equal('')
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+        })
+      })
+
+      experiment('when the transaction is a credit', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isCredit = true
+            transaction.netAmount = -61728
+          })
+        })
+
+        test("sets the 'Net transaction line amount' fields correctly", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
+        })
+      })
+
+      experiment('when `netAmount` in the transactions is null', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.netAmount = null
+          })
+        })
+
+        test("states 'Error - not calculated' in the transaction line amount fields", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
+          expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
+        })
+      })
+
+      experiment('when charge information is missing', () => {
+        experiment('such as the charge version not being found', () => {
+          beforeEach(() => {
+            chargeVersions[0].id = 'notgonnafindme'
+          })
+
+          test("sets the 'Charge information reason' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Charge information reason']).to.equal('')
+          })
+        })
+
+        experiment('such as the change reason being null', () => {
+          beforeEach(() => {
+            chargeVersions[0].changeReason = null
+          })
+
+          test("sets the 'Charge information reason' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Charge information reason']).to.equal('')
+          })
+        })
+      })
+
+      experiment('when isRestrictedSource is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.chargeElement.isRestrictedSource = true
+          })
+        })
+
+        test("sets 'Water available Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Water available Y/N']).to.equal('N')
+        })
+      })
+
+      experiment('when isWaterCompanyCharge is false', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isWaterCompanyCharge = false
+          })
+        })
+
+        test("sets 'Public water supply Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Public water supply Y/N']).to.equal('N')
+        })
+      })
+
+      experiment('when isSupportedSource is false', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isSupportedSource = false
+          })
+        })
+
+        test("sets 'Supported source Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Supported source Y/N']).to.equal('N')
+        })
+      })
+
+      experiment('when isTwoPartSecondPartCharge is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isTwoPartSecondPartCharge = true
+          })
+        })
+
+        test("sets 'Is second part charge? Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Is second part charge? Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when isTwoPartSecondPartCharge is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isTwoPartSecondPartCharge = true
+          })
+        })
+
+        test("sets 'Is second part charge? Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Is second part charge? Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when compensation charge is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+            transaction.isCompensationCharge = true
+          })
+        })
+
+        test("sets 'Compensation charge Y/N' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Compensation charge Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when water undertaker is true', () => {
+        beforeEach(() => {
+          invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
+        })
+
+        test("sets 'Compensation charge applicable Y/N' to 'N'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['Compensation charge applicable Y/N']).to.equal('N')
+        })
+      })
+
+      experiment('when deminimis is true', () => {
+        beforeEach(() => {
+          invoice.isDeMinimis = true
+        })
+
+        test("sets 'De minimis rule Y/N' to 'Y'", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+          expect(result[0]['De minimis rule Y/N']).to.equal('Y')
+        })
+      })
+
+      experiment('when billing volume data is missing', () => {
+        experiment('such as transaction volumn being null', () => {
+          beforeEach(() => {
+            invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+              transaction.volume = null
+            })
+          })
+
+          test("sets the 'Calculated quantity' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Calculated quantity']).to.equal('')
+          })
+        })
+
+        experiment('such as the billing volumes not having a matching financial year for transaction end date', () => {
+          beforeEach(() => {
+            invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+              transaction.billingVolume[0].financialYear = 2018
+            })
+          })
+
+          test("sets the 'Calculated quantity' to empty", async () => {
+            result = await transactionsCSV.createCSV([invoice], chargeVersions, scheme)
+
+            expect(result[0]['Calculated quantity']).to.equal('')
+          })
+        })
       })
     })
   })
@@ -499,7 +822,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     test('returns expected file name', () => {
       const result = transactionsCSV.getCSVFileName(batch)
 
-      expect(result).to.equal('South West two-part tariff bill run 2345.csv')
+      expect(result).to.equal('Anglian two-part tariff bill run 2345.csv')
     })
   })
 })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -63,7 +63,7 @@ const invoiceData =
               eiucSource: 'other',
               season: 'winter',
               loss: 'high',
-              authorisedAnnualQuantity: '9.1',
+              authorisedAnnualQuantity: '8.1',
               billableAnnualQuantity: '9.1',
               purposeUse: {
                 type: 'use',
@@ -269,7 +269,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0]['Compensation charge Y/N']).to.equal('N')
         expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
         expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('8.1')
         expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
         expect(result[0]['Source type']).to.equal('unsupported')
         expect(result[0]['Source factor']).to.equal('0.5')
@@ -558,7 +558,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0]['Charge reference']).to.equal('4.5.55')
         expect(result[0].Source).to.equal('non-tidal')
         expect(result[0].Loss).to.equal('medium')
-        expect(result[0].Volume).to.equal('9.1')
+        expect(result[0].Volume).to.equal('8.1')
         expect(result[0]['Water available Y/N']).to.equal('Y')
         expect(result[0].Modelling).to.equal('no model')
         expect(result[0]['Public water supply Y/N']).to.equal('Y')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3586

We are updating the "download bill run" functionality to support sroc, which entails checking the bill run scheme and using a different set of output fields for alcs and sroc.