### PR TITLE
Tidy up .../billing/services/transactions-csv.js

### DIFF
--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -71,14 +71,14 @@ const getDebitCreditLines = (value, isCredit, debitLabel, creditLabel) => {
   }
 }
 
-const _getInvoiceData = invoice => {
-  const { netAmount, isCredit } = invoice
-  return {
-    'Bill number': invoice.invoiceNumber,
-    'Financial year': invoice.financialYearEnding,
-    ...getDebitCreditLines(netAmount, isCredit, 'Invoice amount', 'Credit amount')
-  }
-}
+// const _getInvoiceData = invoice => {
+//   const { netAmount, isCredit } = invoice
+//   return {
+//     'Bill number': invoice.invoiceNumber,
+//     'Financial year': invoice.financialYearEnding,
+//     ...getDebitCreditLines(netAmount, isCredit, 'Invoice amount', 'Credit amount')
+//   }
+// }
 
 const _getTransactionAmounts = trans => {
   const { netAmount, isCredit } = trans
@@ -107,7 +107,10 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
     'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
     'Customer name': invoice.invoiceAccount.company.name,
     'Licence number': invoiceLicence.licenceRef,
-    ..._getInvoiceData(invoice),
+    'Bill number': invoice.invoiceNumber,
+    'Financial year': invoice.financialYearEnding,
+    'Invoice amount': invoice.isCredit ? null : numberFormatter.penceToPound(invoice.netAmount, true),
+    'Credit amount': invoice.isCredit ? numberFormatter.penceToPound(invoice.netAmount, true) : null,
     ..._getTransactionAmounts(transaction),
     'Charge information reason': getChangeReason(chargeVersions, transaction),
     Region: invoiceLicence.licence.region.displayName,

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -138,9 +138,6 @@ const getCSVFileName = batch => {
 }
 
 module.exports = {
-  _getInvoiceData,
-  _getTransactionData,
-  _getTransactionAmounts,
   createCSV,
   getCSVFileName
 }

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -57,11 +57,6 @@ const _getTransactionData = trans => ({
   'S130 agreement value': null
 })
 
-const _getInvoiceAccountData = invoiceAccount => ({
-  'Billing account number': invoiceAccount.invoiceAccountNumber,
-  'Customer name': invoiceAccount.company.name
-})
-
 const getDebitCreditLines = (value, isCredit, debitLabel, creditLabel) => {
   const formattedValue = numberFormatter.penceToPound(value, true)
   if (isCredit) {
@@ -109,7 +104,8 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
   const { isDeMinimis } = invoice
   const { description, ...transactionData } = _getTransactionData(transaction)
   const csvLine = {
-    ..._getInvoiceAccountData(invoice.invoiceAccount),
+    'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
+    'Customer name': invoice.invoiceAccount.company.name,
     'Licence number': invoiceLicence.licenceRef,
     ..._getInvoiceData(invoice),
     ..._getTransactionAmounts(transaction),

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -41,7 +41,7 @@ const getBillingVolume = trans => {
   return billingVolume ? billingVolume.calculatedVolume : null
 }
 
-const getTransactionData = trans => ({
+const _getTransactionData = trans => ({
   description: trans.description,
   'Compensation charge Y/N': trans.isCompensationCharge ? 'Y' : 'N',
   ...getChargeElementData(trans),
@@ -57,7 +57,7 @@ const getTransactionData = trans => ({
   'S130 agreement value': null
 })
 
-const getInvoiceAccountData = invoiceAccount => ({
+const _getInvoiceAccountData = invoiceAccount => ({
   'Billing account number': invoiceAccount.invoiceAccountNumber,
   'Customer name': invoiceAccount.company.name
 })
@@ -76,7 +76,7 @@ const getDebitCreditLines = (value, isCredit, debitLabel, creditLabel) => {
   }
 }
 
-const getInvoiceData = invoice => {
+const _getInvoiceData = invoice => {
   const { netAmount, isCredit } = invoice
   return {
     'Bill number': invoice.invoiceNumber,
@@ -85,7 +85,7 @@ const getInvoiceData = invoice => {
   }
 }
 
-const getTransactionAmounts = trans => {
+const _getTransactionAmounts = trans => {
   const { netAmount, isCredit } = trans
 
   if (isNull(netAmount)) {
@@ -111,12 +111,12 @@ const createCSV = async (invoices, chargeVersions) => {
     invoice.billingInvoiceLicences.forEach(invLic => {
       const { isDeMinimis } = invoice
       invLic.billingTransactions.forEach(trans => {
-        const { description, ...transactionData } = getTransactionData(trans)
+        const { description, ...transactionData } = _getTransactionData(trans)
         const csvLine = {
-          ...getInvoiceAccountData(invoice.invoiceAccount),
+          ..._getInvoiceAccountData(invoice.invoiceAccount),
           'Licence number': invLic.licenceRef,
-          ...getInvoiceData(invoice),
-          ...getTransactionAmounts(trans),
+          ..._getInvoiceData(invoice),
+          ..._getTransactionAmounts(trans),
           'Charge information reason': getChangeReason(chargeVersions, trans),
           Region: invLic.licence.region.displayName,
           'De minimis rule Y/N': isDeMinimis ? 'Y' : 'N',
@@ -137,9 +137,11 @@ const getCSVFileName = batch => {
   return `${batch.region.displayName} ${batchType.toLowerCase()} bill run ${batch.billRunNumber}.csv`
 }
 
-exports._getInvoiceData = getInvoiceData
-exports._getInvoiceAccountData = getInvoiceAccountData
-exports._getTransactionData = getTransactionData
-exports._getTransactionAmounts = getTransactionAmounts
-exports.createCSV = createCSV
-exports.getCSVFileName = getCSVFileName
+module.exports = {
+  _getInvoiceData,
+  _getInvoiceAccountData,
+  _getTransactionData,
+  _getTransactionAmounts,
+  createCSV,
+  getCSVFileName
+}

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const moment = require('moment')
 const numberFormatter = require('../../../../shared/lib/number-formatter')
 const { mapValues, isNull, sortBy, get } = require('lodash')
@@ -135,6 +136,7 @@ const getCSVFileName = batch => {
   const batchType = mappers.mapBatchType(batch.type)
   return `${batch.region.displayName} ${batchType.toLowerCase()} bill run ${batch.billRunNumber}.csv`
 }
+
 exports._getInvoiceData = getInvoiceData
 exports._getInvoiceAccountData = getInvoiceAccountData
 exports._getTransactionData = getTransactionData

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -2,12 +2,8 @@
 
 const moment = require('moment')
 const numberFormatter = require('../../../../shared/lib/number-formatter')
-const { mapValues, isNull, sortBy, get } = require('lodash')
+const { mapValues, sortBy, get } = require('lodash')
 const mappers = require('../lib/mappers')
-
-const isNullOrUndefined = value => isNull(value) || value === undefined
-const valueToString = value => isNullOrUndefined(value) ? '' : value.toString()
-const rowToStrings = row => mapValues(row, valueToString)
 
 const createCSV = async (invoices, chargeVersions) => {
   const sortedInvoices = sortBy(invoices, 'invoiceAccountaNumber', 'billingInvoiceLicences[0].licence.licenceRef')
@@ -113,7 +109,7 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
     'S130 agreement value': null
   }
 
-  return rowToStrings(csvLine)
+  return _rowToStrings(csvLine)
 }
 
 function _debitLineValue (isCredit, value) {
@@ -122,6 +118,12 @@ function _debitLineValue (isCredit, value) {
   }
 
   return numberFormatter.penceToPound(value, true)
+}
+
+function _rowToStrings (row) {
+  return mapValues(row, (value) => {
+    return value ? value.toString() : ''
+  })
 }
 
 function _transactionLineValue (isDebit, isCredit, value) {

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -139,7 +139,6 @@ const getCSVFileName = batch => {
 
 module.exports = {
   _getInvoiceData,
-  _getInvoiceAccountData,
   _getTransactionData,
   _getTransactionAmounts,
   createCSV,

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -15,19 +15,6 @@ const getBillingVolume = trans => {
   return billingVolume ? billingVolume.calculatedVolume : null
 }
 
-const _getTransactionData = trans => ({
-  'Charge period start date': trans.startDate,
-  'Charge period end date': trans.endDate,
-  'Authorised days': trans.authorisedDays,
-  'Billable days': trans.billableDays,
-  'Calculated quantity': trans.volume ? getBillingVolume(trans) : null,
-  Quantity: trans.volume,
-  'S127 agreement (Y/N)': trans.section127Agreement ? 'Y' : 'N',
-  'S127 agreement value': trans.calcS127Factor || null,
-  'S130 agreement': trans.section130Agreement,
-  'S130 agreement value': null
-})
-
 function _changeReason (chargeVersions, transaction) {
   const chargeVersionId = get(transaction, 'chargeElement.chargeVersionId')
   const chargeVersion = chargeVersions.find(cv => cv.id === chargeVersionId)
@@ -109,7 +96,16 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
         .date(transaction.abstractionPeriod.endDay)
         .format('D MMM')
     }),
-    ..._getTransactionData(transaction)
+    'Charge period start date': transaction.startDate,
+    'Charge period end date': transaction.endDate,
+    'Authorised days': transaction.authorisedDays,
+    'Billable days': transaction.billableDays,
+    'Calculated quantity': transaction.volume ? getBillingVolume(transaction) : null,
+    Quantity: transaction.volume,
+    'S127 agreement (Y/N)': transaction.section127Agreement ? 'Y' : 'N',
+    'S127 agreement value': transaction.calcS127Factor || null,
+    'S130 agreement': transaction.section130Agreement,
+    'S130 agreement value': null
   }
 
   return rowToStrings(csvLine)

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -9,9 +9,14 @@ const isNullOrUndefined = value => isNull(value) || value === undefined
 const valueToString = value => isNullOrUndefined(value) ? '' : value.toString()
 const rowToStrings = row => mapValues(row, valueToString)
 
-const getBillingVolume = trans => {
-  const transactionYear = new Date(trans.endDate).getFullYear()
-  const billingVolume = trans.billingVolume.find(row => row.financialYear === transactionYear)
+function _billingVolume (transaction) {
+  if (!transaction.volume) {
+    return null
+  }
+
+  const transactionYear = new Date(transaction.endDate).getFullYear()
+  const billingVolume = transaction.billingVolume.find(row => row.financialYear === transactionYear)
+
   return billingVolume ? billingVolume.calculatedVolume : null
 }
 
@@ -100,7 +105,7 @@ function _csvLine (invoice, invoiceLicence, transaction, chargeVersions) {
     'Charge period end date': transaction.endDate,
     'Authorised days': transaction.authorisedDays,
     'Billable days': transaction.billableDays,
-    'Calculated quantity': transaction.volume ? getBillingVolume(transaction) : null,
+    'Calculated quantity': _billingVolume(transaction),
     Quantity: transaction.volume,
     'S127 agreement (Y/N)': transaction.section127Agreement ? 'Y' : 'N',
     'S127 agreement value': transaction.calcS127Factor || null,

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -230,6 +230,15 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Source type']).to.equal('unsupported')
         expect(csvData[0]['Source factor']).to.equal('0.5')
         expect(csvData[0]['Adjusted source type']).to.equal('other')
+        expect(csvData[0]['Adjusted source factor']).to.equal('0.5')
+        expect(csvData[0].Season).to.equal('winter')
+        expect(csvData[0]['Season factor']).to.equal('0.5')
+        expect(csvData[0].Loss).to.equal('high')
+        expect(csvData[0]['Loss factor']).to.equal('0.5')
+        expect(csvData[0]['Purpose code']).to.equal('420')
+        expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+        expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
+        expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
       })
     })
 
@@ -270,6 +279,15 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Source type']).to.equal('unsupported')
         expect(csvData[0]['Source factor']).to.equal('0.5')
         expect(csvData[0]['Adjusted source type']).to.equal('other')
+        expect(csvData[0]['Adjusted source factor']).to.equal('0.5')
+        expect(csvData[0].Season).to.equal('winter')
+        expect(csvData[0]['Season factor']).to.equal('0.5')
+        expect(csvData[0].Loss).to.equal('high')
+        expect(csvData[0]['Loss factor']).to.equal('0.5')
+        expect(csvData[0]['Purpose code']).to.equal('420')
+        expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+        expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
+        expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
       })
     })
 
@@ -415,18 +433,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     beforeEach(() => {
       transaction = invoice.billingInvoiceLicences[0].billingTransactions[0]
       transactionData = transactionsCSV._getTransactionData(transaction)
-    })
-
-    test('charge element data to user friendly headings', () => {
-      expect(transactionData['Adjusted source factor']).to.equal(transaction.calcEiucSourceFactor)
-      expect(transactionData.Season).to.equal(transaction.chargeElement.season)
-      expect(transactionData['Season factor']).to.equal(transaction.calcSeasonFactor)
-      expect(transactionData.Loss).to.equal(transaction.chargeElement.loss)
-      expect(transactionData['Loss factor']).to.equal(transaction.calcLossFactor)
-      expect(transactionData['Purpose code']).to.equal(transaction.chargeElement.purposeUse.legacyId)
-      expect(transactionData['Purpose name']).to.equal(transaction.chargeElement.purposeUse.description)
-      expect(transactionData['Abstraction period start date']).to.equal('1 Nov')
-      expect(transactionData['Abstraction period end date']).to.equal('31 Mar')
     })
 
     test('agreement to user friendly heading', () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -296,6 +296,18 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when deminimis is true', () => {
+      beforeEach(async () => {
+        invoice.isDeMinimis = true
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'De minimis rule Y/N' to 'Y'", () => {
+        expect(csvData[0]['De minimis rule Y/N']).to.equal('Y')
+      })
+    })
+
     test('description is mapped to user friendly heading', async () => {
       expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
     })
@@ -304,16 +316,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
       csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
       expect(csvData[0]['Water company Y/N']).to.equal('Y')
-    })
-
-    test('DeMinimis is mapped to user friendly heading', async () => {
-      csvData = await transactionsCSV.createCSV([
-        {
-          ...invoice,
-          isDeMinimis: true
-        }
-      ], chargeVersions)
-      expect(csvData[0]['De minimis rule Y/N']).to.equal('Y')
     })
 
     test('historical area is mapped to user friendly heading', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -308,10 +308,16 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
-    test('water company when true is mapped to user friendly heading', async () => {
-      invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
-      csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
-      expect(csvData[0]['Water company Y/N']).to.equal('Y')
+    experiment('when water company is true', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'Water company Y/N' to 'Y'", () => {
+        expect(csvData[0]['Water company Y/N']).to.equal('Y')
+      })
     })
 
     test('historical area is mapped to user friendly heading', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -207,11 +207,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test('formats each CSV row as expected', async () => {
-        expect(csvData[0]['Billing account number']).to.equal(invoice.invoiceAccount.invoiceAccountNumber)
-        expect(csvData[0]['Customer name']).to.equal(invoice.invoiceAccount.company.name)
-        expect(csvData[0]['Licence number']).to.equal(invoice.billingInvoiceLicences[0].licence.licenceRef)
-        expect(csvData[0]['Bill number']).to.equal(invoice.invoiceNumber)
-        expect(csvData[0]['Financial year']).to.equal(invoice.financialYearEnding.toString())
+        expect(csvData[0]['Billing account number']).to.equal('A12345678A')
+        expect(csvData[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(csvData[0]['Bill number']).to.equal('IIA123456')
+        expect(csvData[0]['Financial year']).to.equal('2019')
         expect(csvData[0]['Invoice amount']).to.equal('1,234.56')
         expect(csvData[0]['Credit amount']).to.equal('')
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('617.28')
@@ -233,11 +233,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
 
       test('formats each CSV row as expected', async () => {
-        expect(csvData[0]['Billing account number']).to.equal(invoice.invoiceAccount.invoiceAccountNumber)
-        expect(csvData[0]['Customer name']).to.equal(invoice.invoiceAccount.company.name)
-        expect(csvData[0]['Licence number']).to.equal(invoice.billingInvoiceLicences[0].licence.licenceRef)
-        expect(csvData[0]['Bill number']).to.equal(invoice.invoiceNumber)
-        expect(csvData[0]['Financial year']).to.equal(invoice.financialYearEnding.toString())
+        expect(csvData[0]['Billing account number']).to.equal('A12345678A')
+        expect(csvData[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(csvData[0]['Bill number']).to.equal('IIA123456')
+        expect(csvData[0]['Financial year']).to.equal('2019')
         expect(csvData[0]['Invoice amount']).to.equal('')
         expect(csvData[0]['Credit amount']).to.equal('-1,234.56')
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('')

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -244,6 +244,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Authorised days']).to.equal('152')
         expect(csvData[0]['Billable days']).to.equal('152')
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
+        expect(csvData[0].Quantity).to.equal('9.1')
       })
     })
 
@@ -298,6 +299,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Authorised days']).to.equal('152')
         expect(csvData[0]['Billable days']).to.equal('152')
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
+        expect(csvData[0].Quantity).to.equal('9.1')
       })
     })
 
@@ -478,10 +480,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     test('agreement to user friendly heading', () => {
       expect(transactionData['S130 agreement']).to.equal('S130W')
       expect(transactionData['S130 agreement value']).to.equal(null)
-    })
-
-    test('quantities to user friendly heading', () => {
-      expect(transactionData.Quantity).to.equal(transaction.volume)
     })
 
     test('handles multiple agreements', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -217,6 +217,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('617.28')
         expect(csvData[0]['Net transaction line amount(credit)']).to.equal('')
         expect(csvData[0]['Charge information reason']).to.equal('change reason description')
+        expect(csvData[0].Region).to.equal('Anglian')
+        expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
       })
     })
 
@@ -244,6 +246,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('')
         expect(csvData[0]['Net transaction line amount(credit)']).to.equal('-617.28')
         expect(csvData[0]['Charge information reason']).to.equal('change reason description')
+        expect(csvData[0].Region).to.equal('Anglian')
+        expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
       })
     })
 
@@ -286,14 +290,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           expect(csvData[0]['Charge information reason']).to.equal('')
         })
       })
-    })
-
-    test('region is mapped to user friendly heading', async () => {
-      expect(csvData[0].Region).to.equal('Anglian')
-    })
-
-    test('de minimis is mapped to user friendly heading', async () => {
-      expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
     })
 
     test('description is mapped to user friendly heading', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -495,9 +495,9 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
 
   experiment('.getCSVFileName', () => {
     test('returns expected file name', () => {
-      const expectedFileName = 'South West two-part tariff bill run 2345.csv'
-      const fileName = transactionsCSV.getCSVFileName(batch)
-      expect(fileName).to.equal(expectedFileName)
+      const result = transactionsCSV.getCSVFileName(batch)
+
+      expect(result).to.equal('South West two-part tariff bill run 2345.csv')
     })
   })
 })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -222,6 +222,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
         expect(csvData[0]['Water company Y/N']).to.equal('N')
         expect(csvData[0]['Historical area']).to.equal('AREA')
+        expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
       })
     })
 
@@ -254,6 +255,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
         expect(csvData[0]['Water company Y/N']).to.equal('N')
         expect(csvData[0]['Historical area']).to.equal('AREA')
+        expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
       })
     })
 
@@ -322,6 +324,20 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when compensation charge is true', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+          transaction.isCompensationCharge = true
+        })
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'Compensation charge Y/N' to 'Y'", () => {
+        expect(csvData[0]['Compensation charge Y/N']).to.equal('Y')
+      })
+    })
+
     test('creates a line for each transaction', async () => {
       const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
       expect(csvData[0]['Licence number']).to.equal(licenceRef)
@@ -342,10 +358,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     beforeEach(() => {
       transaction = invoice.billingInvoiceLicences[0].billingTransactions[0]
       transactionData = transactionsCSV._getTransactionData(transaction)
-    })
-
-    test('compensation charge as Y/N to user friendly heading', () => {
-      expect(transactionData['Compensation charge Y/N']).to.equal('N')
     })
 
     test('charge element data to user friendly headings', () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -201,6 +201,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
     })
 
+    test('formats each CSV row as expected', async () => {
+      expect(csvData[0]['Billing account number']).to.equal(invoice.invoiceAccount.invoiceAccountNumber)
+      expect(csvData[0]['Customer name']).to.equal(invoice.invoiceAccount.company.name)
+    })
+
     test('licence number is mapped to user friendly heading', async () => {
       expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
     })
@@ -426,22 +431,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           expect(invoiceData['Credit amount']).to.equal('-1,234.56')
         })
       })
-    })
-  })
-
-  experiment('_getInvoiceAccountData', () => {
-    let invoiceAccount, invoiceAccountData
-    beforeEach(() => {
-      invoiceAccount = invoice.invoiceAccount
-      invoiceAccountData = transactionsCSV._getInvoiceAccountData(invoiceAccount)
-    })
-
-    test('maps account number to user friendly heading', async () => {
-      expect(invoiceAccountData['Billing account number']).to.equal(invoiceAccount.invoiceAccountNumber)
-    })
-
-    test('maps account number to user friendly heading', async () => {
-      expect(invoiceAccountData['Customer name']).to.equal(invoiceAccount.company.name)
     })
   })
 

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -204,10 +204,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     test('formats each CSV row as expected', async () => {
       expect(csvData[0]['Billing account number']).to.equal(invoice.invoiceAccount.invoiceAccountNumber)
       expect(csvData[0]['Customer name']).to.equal(invoice.invoiceAccount.company.name)
-    })
-
-    test('licence number is mapped to user friendly heading', async () => {
-      expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
+      expect(csvData[0]['Licence number']).to.equal(invoice.billingInvoiceLicences[0].licence.licenceRef)
     })
 
     test('correct charge information reason is mapped', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -3,6 +3,9 @@
 const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
+// Test helpers
+const GeneralHelper = require('../../../../support/helpers/general.helper.js')
+
 const transactionsCSV = require('internal/modules/billing/services/transactions-csv')
 
 const batch = {
@@ -16,7 +19,7 @@ const batch = {
   billRunNumber: 2345
 }
 
-const invoice =
+const invoiceData =
   {
     id: '0817794f-b5b4-47e8-8172-3411bd6165bd',
     isDeMinimis: false,
@@ -185,7 +188,7 @@ const invoice =
     invoiceNumber: 'IIA123456'
   }
 
-const chargeVersions = [{
+const chargeVersionsData = [{
   id: '967a1db8-e161-4fd7-b45f-9e96db97202e',
   changeReason: {
     description: 'change reason description'
@@ -199,60 +202,67 @@ const chargeVersions = [{
 
 experiment('internal/modules/billing/services/transactions-csv', () => {
   experiment('.createCSV', () => {
-    let csvData
+    let chargeVersions
+    let invoice
+    let result
+
+    beforeEach(() => {
+      invoice = GeneralHelper.cloneObject(invoiceData)
+      chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
+    })
 
     experiment('when the invoice is a debit', () => {
       beforeEach(async () => {
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test('formats each CSV row as expected', async () => {
-        expect(csvData[0]['Billing account number']).to.equal('A12345678A')
-        expect(csvData[0]['Customer name']).to.equal('R G Applehead & sons LTD')
-        expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
-        expect(csvData[0]['Bill number']).to.equal('IIA123456')
-        expect(csvData[0]['Financial year']).to.equal('2019')
-        expect(csvData[0]['Invoice amount']).to.equal('1,234.56')
-        expect(csvData[0]['Credit amount']).to.equal('')
-        expect(csvData[0]['Net transaction line amount(debit)']).to.equal('617.28')
-        expect(csvData[0]['Net transaction line amount(credit)']).to.equal('')
-        expect(csvData[0]['Charge information reason']).to.equal('change reason description')
-        expect(csvData[0].Region).to.equal('Anglian')
-        expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
-        expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
-        expect(csvData[0]['Water company Y/N']).to.equal('N')
-        expect(csvData[0]['Historical area']).to.equal('AREA')
-        expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
-        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
-        expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
-        expect(csvData[0]['Source type']).to.equal('unsupported')
-        expect(csvData[0]['Source factor']).to.equal('0.5')
-        expect(csvData[0]['Adjusted source type']).to.equal('other')
-        expect(csvData[0]['Adjusted source factor']).to.equal('0.5')
-        expect(csvData[0].Season).to.equal('winter')
-        expect(csvData[0]['Season factor']).to.equal('0.5')
-        expect(csvData[0].Loss).to.equal('high')
-        expect(csvData[0]['Loss factor']).to.equal('0.5')
-        expect(csvData[0]['Purpose code']).to.equal('420')
-        expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
-        expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
-        expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
-        expect(csvData[0]['Charge period start date']).to.equal('2019-04-01')
-        expect(csvData[0]['Charge period end date']).to.equal('2020-03-31')
-        expect(csvData[0]['Authorised days']).to.equal('152')
-        expect(csvData[0]['Billable days']).to.equal('152')
-        expect(csvData[0]['Calculated quantity']).to.equal('10.3')
-        expect(csvData[0].Quantity).to.equal('9.1')
-        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
-        expect(csvData[0]['S127 agreement value']).to.equal('0.5')
-        expect(csvData[0]['S130 agreement']).to.equal('S130W')
-        expect(csvData[0]['S130 agreement value']).to.equal('')
+        expect(result[0]['Billing account number']).to.equal('A12345678A')
+        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(result[0]['Bill number']).to.equal('IIA123456')
+        expect(result[0]['Financial year']).to.equal('2019')
+        expect(result[0]['Invoice amount']).to.equal('1,234.56')
+        expect(result[0]['Credit amount']).to.equal('')
+        expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+        expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+        expect(result[0]['Charge information reason']).to.equal('change reason description')
+        expect(result[0].Region).to.equal('Anglian')
+        expect(result[0]['De minimis rule Y/N']).to.equal('N')
+        expect(result[0]['Transaction description']).to.equal('The description - with 007')
+        expect(result[0]['Water company Y/N']).to.equal('N')
+        expect(result[0]['Historical area']).to.equal('AREA')
+        expect(result[0]['Compensation charge Y/N']).to.equal('N')
+        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Source type']).to.equal('unsupported')
+        expect(result[0]['Source factor']).to.equal('0.5')
+        expect(result[0]['Adjusted source type']).to.equal('other')
+        expect(result[0]['Adjusted source factor']).to.equal('0.5')
+        expect(result[0].Season).to.equal('winter')
+        expect(result[0]['Season factor']).to.equal('0.5')
+        expect(result[0].Loss).to.equal('high')
+        expect(result[0]['Loss factor']).to.equal('0.5')
+        expect(result[0]['Purpose code']).to.equal('420')
+        expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+        expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
+        expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
+        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(result[0]['Authorised days']).to.equal('152')
+        expect(result[0]['Billable days']).to.equal('152')
+        expect(result[0]['Calculated quantity']).to.equal('10.3')
+        expect(result[0].Quantity).to.equal('9.1')
+        expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
+        expect(result[0]['S127 agreement value']).to.equal('0.5')
+        expect(result[0]['S130 agreement']).to.equal('S130W')
+        expect(result[0]['S130 agreement value']).to.equal('')
       })
 
       test('creates a line for each transaction', async () => {
-        expect(csvData.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
+        expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
       })
     })
 
@@ -266,52 +276,52 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.netAmount = -61728
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test('formats each CSV row as expected', async () => {
-        expect(csvData[0]['Billing account number']).to.equal('A12345678A')
-        expect(csvData[0]['Customer name']).to.equal('R G Applehead & sons LTD')
-        expect(csvData[0]['Licence number']).to.equal('1/23/45/*S/6789')
-        expect(csvData[0]['Bill number']).to.equal('IIA123456')
-        expect(csvData[0]['Financial year']).to.equal('2019')
-        expect(csvData[0]['Invoice amount']).to.equal('')
-        expect(csvData[0]['Credit amount']).to.equal('-1,234.56')
-        expect(csvData[0]['Net transaction line amount(debit)']).to.equal('')
-        expect(csvData[0]['Net transaction line amount(credit)']).to.equal('-617.28')
-        expect(csvData[0]['Charge information reason']).to.equal('change reason description')
-        expect(csvData[0].Region).to.equal('Anglian')
-        expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
-        expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
-        expect(csvData[0]['Water company Y/N']).to.equal('N')
-        expect(csvData[0]['Historical area']).to.equal('AREA')
-        expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
-        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
-        expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
-        expect(csvData[0]['Source type']).to.equal('unsupported')
-        expect(csvData[0]['Source factor']).to.equal('0.5')
-        expect(csvData[0]['Adjusted source type']).to.equal('other')
-        expect(csvData[0]['Adjusted source factor']).to.equal('0.5')
-        expect(csvData[0].Season).to.equal('winter')
-        expect(csvData[0]['Season factor']).to.equal('0.5')
-        expect(csvData[0].Loss).to.equal('high')
-        expect(csvData[0]['Loss factor']).to.equal('0.5')
-        expect(csvData[0]['Purpose code']).to.equal('420')
-        expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
-        expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
-        expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
-        expect(csvData[0]['Charge period start date']).to.equal('2019-04-01')
-        expect(csvData[0]['Charge period end date']).to.equal('2020-03-31')
-        expect(csvData[0]['Authorised days']).to.equal('152')
-        expect(csvData[0]['Billable days']).to.equal('152')
-        expect(csvData[0]['Calculated quantity']).to.equal('10.3')
-        expect(csvData[0].Quantity).to.equal('9.1')
-        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
-        expect(csvData[0]['S127 agreement value']).to.equal('0.5')
-        expect(csvData[0]['S130 agreement']).to.equal('S130W')
-        expect(csvData[0]['S130 agreement value']).to.equal('')
+        expect(result[0]['Billing account number']).to.equal('A12345678A')
+        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
+        expect(result[0]['Bill number']).to.equal('IIA123456')
+        expect(result[0]['Financial year']).to.equal('2019')
+        expect(result[0]['Invoice amount']).to.equal('')
+        expect(result[0]['Credit amount']).to.equal('-1,234.56')
+        expect(result[0]['Net transaction line amount(debit)']).to.equal('')
+        expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
+        expect(result[0]['Charge information reason']).to.equal('change reason description')
+        expect(result[0].Region).to.equal('Anglian')
+        expect(result[0]['De minimis rule Y/N']).to.equal('N')
+        expect(result[0]['Transaction description']).to.equal('The description - with 007')
+        expect(result[0]['Water company Y/N']).to.equal('N')
+        expect(result[0]['Historical area']).to.equal('AREA')
+        expect(result[0]['Compensation charge Y/N']).to.equal('N')
+        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+        expect(result[0]['Source type']).to.equal('unsupported')
+        expect(result[0]['Source factor']).to.equal('0.5')
+        expect(result[0]['Adjusted source type']).to.equal('other')
+        expect(result[0]['Adjusted source factor']).to.equal('0.5')
+        expect(result[0].Season).to.equal('winter')
+        expect(result[0]['Season factor']).to.equal('0.5')
+        expect(result[0].Loss).to.equal('high')
+        expect(result[0]['Loss factor']).to.equal('0.5')
+        expect(result[0]['Purpose code']).to.equal('420')
+        expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+        expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
+        expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
+        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(result[0]['Authorised days']).to.equal('152')
+        expect(result[0]['Billable days']).to.equal('152')
+        expect(result[0]['Calculated quantity']).to.equal('10.3')
+        expect(result[0].Quantity).to.equal('9.1')
+        expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
+        expect(result[0]['S127 agreement value']).to.equal('0.5')
+        expect(result[0]['S130 agreement']).to.equal('S130W')
+        expect(result[0]['S130 agreement value']).to.equal('')
       })
     })
 
@@ -321,12 +331,12 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.netAmount = null
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("states 'Error - not calculated' in the transaction line amount fields", async () => {
-        expect(csvData[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
-        expect(csvData[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
+        expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
+        expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
       })
     })
 
@@ -335,11 +345,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         beforeEach(async () => {
           chargeVersions[0].id = 'notgonnafindme'
 
-          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
         test("sets the 'Charge information reason' to empty", () => {
-          expect(csvData[0]['Charge information reason']).to.equal('')
+          expect(result[0]['Charge information reason']).to.equal('')
         })
       })
 
@@ -347,11 +357,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         beforeEach(async () => {
           chargeVersions[0].changeReason = null
 
-          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
         test("sets the 'Charge information reason' to empty", () => {
-          expect(csvData[0]['Charge information reason']).to.equal('')
+          expect(result[0]['Charge information reason']).to.equal('')
         })
       })
     })
@@ -360,11 +370,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       beforeEach(async () => {
         invoice.isDeMinimis = true
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'De minimis rule Y/N' to 'Y'", () => {
-        expect(csvData[0]['De minimis rule Y/N']).to.equal('Y')
+        expect(result[0]['De minimis rule Y/N']).to.equal('Y')
       })
     })
 
@@ -372,11 +382,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       beforeEach(async () => {
         invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'Water company Y/N' to 'Y'", () => {
-        expect(csvData[0]['Water company Y/N']).to.equal('Y')
+        expect(result[0]['Water company Y/N']).to.equal('Y')
       })
     })
 
@@ -386,11 +396,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.isCompensationCharge = true
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'Compensation charge Y/N' to 'Y'", () => {
-        expect(csvData[0]['Compensation charge Y/N']).to.equal('Y')
+        expect(result[0]['Compensation charge Y/N']).to.equal('Y')
       })
     })
 
@@ -400,26 +410,26 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.chargeType = 'minimum_charge'
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test('drops a number of columns', () => {
-        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
-        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
-        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
-        expect(csvData[0]['Billable annual quantity (megalitres)']).to.be.undefined()
-        expect(csvData[0]['Source type']).to.be.undefined()
-        expect(csvData[0]['Source factor']).to.be.undefined()
-        expect(csvData[0]['Adjusted source type']).to.be.undefined()
-        expect(csvData[0]['Adjusted source factor']).to.be.undefined()
-        expect(csvData[0].Season).to.be.undefined()
-        expect(csvData[0]['Season factor']).to.be.undefined()
-        expect(csvData[0].Loss).to.be.undefined()
-        expect(csvData[0]['Loss factor']).to.be.undefined()
-        expect(csvData[0]['Purpose code']).to.be.undefined()
-        expect(csvData[0]['Purpose name']).to.be.undefined()
-        expect(csvData[0]['Abstraction period start date']).to.be.undefined()
-        expect(csvData[0]['Abstraction period end date']).to.be.undefined()
+        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
+        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
+        expect(result[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
+        expect(result[0]['Billable annual quantity (megalitres)']).to.be.undefined()
+        expect(result[0]['Source type']).to.be.undefined()
+        expect(result[0]['Source factor']).to.be.undefined()
+        expect(result[0]['Adjusted source type']).to.be.undefined()
+        expect(result[0]['Adjusted source factor']).to.be.undefined()
+        expect(result[0].Season).to.be.undefined()
+        expect(result[0]['Season factor']).to.be.undefined()
+        expect(result[0].Loss).to.be.undefined()
+        expect(result[0]['Loss factor']).to.be.undefined()
+        expect(result[0]['Purpose code']).to.be.undefined()
+        expect(result[0]['Purpose name']).to.be.undefined()
+        expect(result[0]['Abstraction period start date']).to.be.undefined()
+        expect(result[0]['Abstraction period end date']).to.be.undefined()
       })
     })
 
@@ -429,11 +439,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.chargeElement.source = 'tidal'
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'Adjusted source type' to 'tidal'", () => {
-        expect(csvData[0]['Adjusted source type']).to.equal('tidal')
+        expect(result[0]['Adjusted source type']).to.equal('tidal')
       })
     })
 
@@ -444,11 +454,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             transaction.volume = null
           })
 
-          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
         test("sets the 'Calculated quantity' to empty", () => {
-          expect(csvData[0]['Calculated quantity']).to.equal('')
+          expect(result[0]['Calculated quantity']).to.equal('')
         })
       })
 
@@ -458,11 +468,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
             transaction.billingVolume[0].financialYear = 2018
           })
 
-          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
         test("sets the 'Calculated quantity' to empty", () => {
-          expect(csvData[0]['Calculated quantity']).to.equal('')
+          expect(result[0]['Calculated quantity']).to.equal('')
         })
       })
     })
@@ -473,11 +483,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.section127Agreement = true
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'S127 agreement (Y/N)' to 'Y'", () => {
-        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('Y')
+        expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
       })
     })
 
@@ -487,11 +497,11 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
           transaction.calcS127Factor = null
         })
 
-        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("sets 'S127 agreement value' to empty", () => {
-        expect(csvData[0]['S127 agreement value']).to.equal('')
+        expect(result[0]['S127 agreement value']).to.equal('')
       })
     })
   })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -211,130 +211,117 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       chargeVersions = GeneralHelper.cloneObject(chargeVersionsData)
     })
 
-    experiment('when the invoice is a debit', () => {
-      beforeEach(async () => {
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
-      })
+    test('formats each CSV row as expected', async () => {
+      result = await transactionsCSV.createCSV([invoice], chargeVersions)
 
-      test('formats each CSV row as expected', async () => {
-        expect(result[0]['Billing account number']).to.equal('A12345678A')
-        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
-        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
-        expect(result[0]['Bill number']).to.equal('IIA123456')
-        expect(result[0]['Financial year']).to.equal('2019')
+      expect(result[0]['Billing account number']).to.equal('A12345678A')
+      expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
+      expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
+      expect(result[0]['Bill number']).to.equal('IIA123456')
+      expect(result[0]['Financial year']).to.equal('2019')
+      expect(result[0]['Invoice amount']).to.equal('1,234.56')
+      expect(result[0]['Credit amount']).to.equal('')
+      expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+      expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+      expect(result[0]['Charge information reason']).to.equal('change reason description')
+      expect(result[0].Region).to.equal('Anglian')
+      expect(result[0]['De minimis rule Y/N']).to.equal('N')
+      expect(result[0]['Transaction description']).to.equal('The description - with 007')
+      expect(result[0]['Water company Y/N']).to.equal('N')
+      expect(result[0]['Historical area']).to.equal('AREA')
+      expect(result[0]['Compensation charge Y/N']).to.equal('N')
+      expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+      expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+      expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+      expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+      expect(result[0]['Source type']).to.equal('unsupported')
+      expect(result[0]['Source factor']).to.equal('0.5')
+      expect(result[0]['Adjusted source type']).to.equal('other')
+      expect(result[0]['Adjusted source factor']).to.equal('0.5')
+      expect(result[0].Season).to.equal('winter')
+      expect(result[0]['Season factor']).to.equal('0.5')
+      expect(result[0].Loss).to.equal('high')
+      expect(result[0]['Loss factor']).to.equal('0.5')
+      expect(result[0]['Purpose code']).to.equal('420')
+      expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
+      expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
+      expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
+      expect(result[0]['Charge period start date']).to.equal('2019-04-01')
+      expect(result[0]['Charge period end date']).to.equal('2020-03-31')
+      expect(result[0]['Authorised days']).to.equal('152')
+      expect(result[0]['Billable days']).to.equal('152')
+      expect(result[0]['Calculated quantity']).to.equal('10.3')
+      expect(result[0].Quantity).to.equal('9.1')
+      expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
+      expect(result[0]['S127 agreement value']).to.equal('0.5')
+      expect(result[0]['S130 agreement']).to.equal('S130W')
+      expect(result[0]['S130 agreement value']).to.equal('')
+    })
+
+    test('creates a line for each transaction', async () => {
+      result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
+      expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
+    })
+
+    experiment('when the invoice is a debit', () => {
+      test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Invoice amount']).to.equal('1,234.56')
         expect(result[0]['Credit amount']).to.equal('')
-        expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
-        expect(result[0]['Net transaction line amount(credit)']).to.equal('')
-        expect(result[0]['Charge information reason']).to.equal('change reason description')
-        expect(result[0].Region).to.equal('Anglian')
-        expect(result[0]['De minimis rule Y/N']).to.equal('N')
-        expect(result[0]['Transaction description']).to.equal('The description - with 007')
-        expect(result[0]['Water company Y/N']).to.equal('N')
-        expect(result[0]['Historical area']).to.equal('AREA')
-        expect(result[0]['Compensation charge Y/N']).to.equal('N')
-        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
-        expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
-        expect(result[0]['Source type']).to.equal('unsupported')
-        expect(result[0]['Source factor']).to.equal('0.5')
-        expect(result[0]['Adjusted source type']).to.equal('other')
-        expect(result[0]['Adjusted source factor']).to.equal('0.5')
-        expect(result[0].Season).to.equal('winter')
-        expect(result[0]['Season factor']).to.equal('0.5')
-        expect(result[0].Loss).to.equal('high')
-        expect(result[0]['Loss factor']).to.equal('0.5')
-        expect(result[0]['Purpose code']).to.equal('420')
-        expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
-        expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
-        expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
-        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
-        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
-        expect(result[0]['Authorised days']).to.equal('152')
-        expect(result[0]['Billable days']).to.equal('152')
-        expect(result[0]['Calculated quantity']).to.equal('10.3')
-        expect(result[0].Quantity).to.equal('9.1')
-        expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
-        expect(result[0]['S127 agreement value']).to.equal('0.5')
-        expect(result[0]['S130 agreement']).to.equal('S130W')
-        expect(result[0]['S130 agreement value']).to.equal('')
-      })
-
-      test('creates a line for each transaction', async () => {
-        expect(result.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
       })
     })
 
     experiment('when the invoice is a credit', () => {
-      beforeEach(async () => {
-        invoice.netAmount = -123456
+      beforeEach(() => {
         invoice.isCredit = true
+        invoice.netAmount = -123456
+      })
 
+      test("sets 'Invoice amount' and 'Credit amount' correctly", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
+        expect(result[0]['Invoice amount']).to.equal('')
+        expect(result[0]['Credit amount']).to.equal('-1,234.56')
+      })
+    })
+
+    experiment('when the transaction is a debit', () => {
+      test("sets the 'Net transaction line amount' fields correctly", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
+        expect(result[0]['Net transaction line amount(debit)']).to.equal('617.28')
+        expect(result[0]['Net transaction line amount(credit)']).to.equal('')
+      })
+    })
+
+    experiment('when the transaction is a credit', () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.isCredit = true
           transaction.netAmount = -61728
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test('formats each CSV row as expected', async () => {
-        expect(result[0]['Billing account number']).to.equal('A12345678A')
-        expect(result[0]['Customer name']).to.equal('R G Applehead & sons LTD')
-        expect(result[0]['Licence number']).to.equal('1/23/45/*S/6789')
-        expect(result[0]['Bill number']).to.equal('IIA123456')
-        expect(result[0]['Financial year']).to.equal('2019')
-        expect(result[0]['Invoice amount']).to.equal('')
-        expect(result[0]['Credit amount']).to.equal('-1,234.56')
+      test("sets the 'Net transaction line amount' fields correctly", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Net transaction line amount(debit)']).to.equal('')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('-617.28')
-        expect(result[0]['Charge information reason']).to.equal('change reason description')
-        expect(result[0].Region).to.equal('Anglian')
-        expect(result[0]['De minimis rule Y/N']).to.equal('N')
-        expect(result[0]['Transaction description']).to.equal('The description - with 007')
-        expect(result[0]['Water company Y/N']).to.equal('N')
-        expect(result[0]['Historical area']).to.equal('AREA')
-        expect(result[0]['Compensation charge Y/N']).to.equal('N')
-        expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
-        expect(result[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
-        expect(result[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
-        expect(result[0]['Source type']).to.equal('unsupported')
-        expect(result[0]['Source factor']).to.equal('0.5')
-        expect(result[0]['Adjusted source type']).to.equal('other')
-        expect(result[0]['Adjusted source factor']).to.equal('0.5')
-        expect(result[0].Season).to.equal('winter')
-        expect(result[0]['Season factor']).to.equal('0.5')
-        expect(result[0].Loss).to.equal('high')
-        expect(result[0]['Loss factor']).to.equal('0.5')
-        expect(result[0]['Purpose code']).to.equal('420')
-        expect(result[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
-        expect(result[0]['Abstraction period start date']).to.equal('1 Nov')
-        expect(result[0]['Abstraction period end date']).to.equal('31 Mar')
-        expect(result[0]['Charge period start date']).to.equal('2019-04-01')
-        expect(result[0]['Charge period end date']).to.equal('2020-03-31')
-        expect(result[0]['Authorised days']).to.equal('152')
-        expect(result[0]['Billable days']).to.equal('152')
-        expect(result[0]['Calculated quantity']).to.equal('10.3')
-        expect(result[0].Quantity).to.equal('9.1')
-        expect(result[0]['S127 agreement (Y/N)']).to.equal('N')
-        expect(result[0]['S127 agreement value']).to.equal('0.5')
-        expect(result[0]['S130 agreement']).to.equal('S130W')
-        expect(result[0]['S130 agreement value']).to.equal('')
       })
     })
 
     experiment('when `netAmount` in the transactions is null', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.netAmount = null
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
       test("states 'Error - not calculated' in the transaction line amount fields", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Net transaction line amount(debit)']).to.equal('Error - not calculated')
         expect(result[0]['Net transaction line amount(credit)']).to.equal('Error - not calculated')
       })
@@ -342,78 +329,78 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
 
     experiment('when charge information is missing', () => {
       experiment('such as the charge version not being found', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           chargeVersions[0].id = 'notgonnafindme'
-
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
-        test("sets the 'Charge information reason' to empty", () => {
+        test("sets the 'Charge information reason' to empty", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
           expect(result[0]['Charge information reason']).to.equal('')
         })
       })
 
       experiment('such as the change reason being null', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           chargeVersions[0].changeReason = null
-
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
-        test("sets the 'Charge information reason' to empty", () => {
+        test("sets the 'Charge information reason' to empty", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
           expect(result[0]['Charge information reason']).to.equal('')
         })
       })
     })
 
     experiment('when deminimis is true', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.isDeMinimis = true
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'De minimis rule Y/N' to 'Y'", () => {
+      test("sets 'De minimis rule Y/N' to 'Y'", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['De minimis rule Y/N']).to.equal('Y')
       })
     })
 
     experiment('when water company is true', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'Water company Y/N' to 'Y'", () => {
+      test("sets 'Water company Y/N' to 'Y'", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Water company Y/N']).to.equal('Y')
       })
     })
 
     experiment('when compensation charge is true', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.isCompensationCharge = true
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'Compensation charge Y/N' to 'Y'", () => {
+      test("sets 'Compensation charge Y/N' to 'Y'", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Compensation charge Y/N']).to.equal('Y')
       })
     })
 
     experiment('when the transaction charge type is minimum charge', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.chargeType = 'minimum_charge'
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test('drops a number of columns', () => {
+      test('drops a number of columns', async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
         expect(result[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
         expect(result[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
@@ -434,73 +421,73 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     })
 
     experiment('when the transaction charge element source type is tidal', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.chargeElement.source = 'tidal'
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'Adjusted source type' to 'tidal'", () => {
+      test("sets 'Adjusted source type' to 'tidal'", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['Adjusted source type']).to.equal('tidal')
       })
     })
 
     experiment('when billing volume data is missing', () => {
       experiment('such as transaction volumn being null', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
             transaction.volume = null
           })
-
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
-        test("sets the 'Calculated quantity' to empty", () => {
+        test("sets the 'Calculated quantity' to empty", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
           expect(result[0]['Calculated quantity']).to.equal('')
         })
       })
 
       experiment('such as the billing volumes not having a matching financial year for transaction end date', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
             transaction.billingVolume[0].financialYear = 2018
           })
-
-          result = await transactionsCSV.createCSV([invoice], chargeVersions)
         })
 
-        test("sets the 'Calculated quantity' to empty", () => {
+        test("sets the 'Calculated quantity' to empty", async () => {
+          result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
           expect(result[0]['Calculated quantity']).to.equal('')
         })
       })
     })
 
     experiment('when section 127 agreement is true', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.section127Agreement = true
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'S127 agreement (Y/N)' to 'Y'", () => {
+      test("sets 'S127 agreement (Y/N)' to 'Y'", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['S127 agreement (Y/N)']).to.equal('Y')
       })
     })
 
     experiment('when the calculated S127 value is null', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
           transaction.calcS127Factor = null
         })
-
-        result = await transactionsCSV.createCSV([invoice], chargeVersions)
       })
 
-      test("sets 'S127 agreement value' to empty", () => {
+      test("sets 'S127 agreement value' to empty", async () => {
+        result = await transactionsCSV.createCSV([invoice], chargeVersions)
+
         expect(result[0]['S127 agreement value']).to.equal('')
       })
     })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -308,10 +308,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
-    test('description is mapped to user friendly heading', async () => {
-      expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
-    })
-
     test('water company when true is mapped to user friendly heading', async () => {
       invoice.billingInvoiceLicences[0].licence.isWaterUndertaker = true
       csvData = await transactionsCSV.createCSV([invoice], chargeVersions)

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -247,6 +247,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0].Quantity).to.equal('9.1')
         expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
         expect(csvData[0]['S127 agreement value']).to.equal('0.5')
+        expect(csvData[0]['S130 agreement']).to.equal('S130W')
+        expect(csvData[0]['S130 agreement value']).to.equal('')
       })
     })
 
@@ -304,6 +306,8 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0].Quantity).to.equal('9.1')
         expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
         expect(csvData[0]['S127 agreement value']).to.equal('0.5')
+        expect(csvData[0]['S130 agreement']).to.equal('S130W')
+        expect(csvData[0]['S130 agreement value']).to.equal('')
       })
     })
 
@@ -499,28 +503,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       const expectedFileName = 'South West two-part tariff bill run 2345.csv'
       const fileName = transactionsCSV.getCSVFileName(batch)
       expect(fileName).to.equal(expectedFileName)
-    })
-  })
-
-  experiment('_getTransactionData maps', () => {
-    let transaction, transactionData
-    beforeEach(() => {
-      transaction = invoice.billingInvoiceLicences[0].billingTransactions[0]
-      transactionData = transactionsCSV._getTransactionData(transaction)
-    })
-
-    test('agreement to user friendly heading', () => {
-      expect(transactionData['S130 agreement']).to.equal('S130W')
-      expect(transactionData['S130 agreement value']).to.equal(null)
-    })
-
-    test('handles multiple agreements', async () => {
-      const transactionData = transactionsCSV._getTransactionData({
-        ...transaction,
-        agreements: [{ code: 'S130W' }]
-      })
-      expect(transactionData['S130 agreement']).to.equal('S130W')
-      expect(transactionData['S130 agreement value']).to.equal(null)
     })
   })
 })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -216,6 +216,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Credit amount']).to.equal('')
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('617.28')
         expect(csvData[0]['Net transaction line amount(credit)']).to.equal('')
+        expect(csvData[0]['Charge information reason']).to.equal('change reason description')
       })
     })
 
@@ -242,6 +243,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Credit amount']).to.equal('-1,234.56')
         expect(csvData[0]['Net transaction line amount(debit)']).to.equal('')
         expect(csvData[0]['Net transaction line amount(credit)']).to.equal('-617.28')
+        expect(csvData[0]['Charge information reason']).to.equal('change reason description')
       })
     })
 
@@ -260,8 +262,30 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
-    test('correct charge information reason is mapped', async () => {
-      expect(csvData[0]['Charge information reason']).to.equal('change reason description')
+    experiment('when charge information is missing', () => {
+      experiment('such as the charge version not being found', () => {
+        beforeEach(async () => {
+          chargeVersions[0].id = 'notgonnafindme'
+
+          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        })
+
+        test("sets the 'Charge information reason' to empty", () => {
+          expect(csvData[0]['Charge information reason']).to.equal('')
+        })
+      })
+
+      experiment('such as the change reason being null', () => {
+        beforeEach(async () => {
+          chargeVersions[0].changeReason = null
+
+          csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+        })
+
+        test("sets the 'Charge information reason' to empty", () => {
+          expect(csvData[0]['Charge information reason']).to.equal('')
+        })
+      })
     })
 
     test('region is mapped to user friendly heading', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -250,6 +250,10 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['S130 agreement']).to.equal('S130W')
         expect(csvData[0]['S130 agreement value']).to.equal('')
       })
+
+      test('creates a line for each transaction', async () => {
+        expect(csvData.length).to.equal(invoice.billingInvoiceLicences[0].billingTransactions.length)
+      })
     })
 
     experiment('when the invoice is a credit', () => {
@@ -489,12 +493,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       test("sets 'S127 agreement value' to empty", () => {
         expect(csvData[0]['S127 agreement value']).to.equal('')
       })
-    })
-
-    test('creates a line for each transaction', async () => {
-      const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
-      expect(csvData[0]['Licence number']).to.equal(licenceRef)
-      expect(csvData[1]['Licence number']).to.equal(licenceRef)
     })
   })
 

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -338,6 +338,35 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when the transaction charge type is minimum charge', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+          transaction.chargeType = 'minimum_charge'
+        })
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test('drops a number of columns', () => {
+        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.be.undefined()
+        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.be.undefined()
+        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.be.undefined()
+        expect(csvData[0]['Billable annual quantity (megalitres)']).to.be.undefined()
+        expect(csvData[0]['Source type']).to.be.undefined()
+        expect(csvData[0]['Source factor']).to.be.undefined()
+        expect(csvData[0]['Adjusted source type']).to.be.undefined()
+        expect(csvData[0]['Adjusted source factor']).to.be.undefined()
+        expect(csvData[0].Season).to.be.undefined()
+        expect(csvData[0]['Season factor']).to.be.undefined()
+        expect(csvData[0].Loss).to.be.undefined()
+        expect(csvData[0]['Loss factor']).to.be.undefined()
+        expect(csvData[0]['Purpose code']).to.be.undefined()
+        expect(csvData[0]['Purpose name']).to.be.undefined()
+        expect(csvData[0]['Abstraction period start date']).to.be.undefined()
+        expect(csvData[0]['Abstraction period end date']).to.be.undefined()
+      })
+    })
+
     test('creates a line for each transaction', async () => {
       const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
       expect(csvData[0]['Licence number']).to.equal(licenceRef)
@@ -419,40 +448,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         billingVolume: []
       })
       expect(transactionData['Calculated quantity']).to.be.null()
-    })
-
-    test('handles minimum charge transactions', async () => {
-      const minChargeTransaction = {
-        value: 1468,
-        isCredit: false,
-        agreements: [],
-        section130Agreement: null,
-        section127Agreement: null,
-        status: 'candidate',
-        startDate: '2019-04-01',
-        endDate: '2020-03-31',
-        externalId: 'b97b7fe2-8704-4efa-9f39-277d8df997a0',
-        description:
-         'Minimum Charge Calculation - raised under Schedule 23 of the Environment Act 1995',
-        isCompensationCharge: true,
-        chargeType: 'minimum_charge',
-        isNewLicence: true,
-        chargePeriod: {
-          startDate: '2019-04-01',
-          endDate: '2020-03-31'
-        },
-        billingVolume: []
-      }
-
-      const transactionData = transactionsCSV._getTransactionData(minChargeTransaction)
-      expect(transactionData.description).to.equal(minChargeTransaction.description)
-      expect(transactionData['Compensation charge Y/N']).to.equal('Y')
-      expect(transactionData['S127 agreement (Y/N)']).to.equal('N')
-      expect(transactionData['S127 agreement value']).to.equal(null)
-      expect(transactionData['S130 agreement']).to.equal(null)
-      expect(transactionData['S130 agreement value']).to.equal(null)
-      expect(transactionData['Charge period start date']).to.equal(minChargeTransaction.chargePeriod.startDate)
-      expect(transactionData['Charge period end date']).to.equal(minChargeTransaction.chargePeriod.endDate)
     })
   })
 })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -229,6 +229,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
         expect(csvData[0]['Source type']).to.equal('unsupported')
         expect(csvData[0]['Source factor']).to.equal('0.5')
+        expect(csvData[0]['Adjusted source type']).to.equal('other')
       })
     })
 
@@ -268,6 +269,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
         expect(csvData[0]['Source type']).to.equal('unsupported')
         expect(csvData[0]['Source factor']).to.equal('0.5')
+        expect(csvData[0]['Adjusted source type']).to.equal('other')
       })
     })
 
@@ -379,6 +381,20 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when the transaction charge element source type is tidal', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+          transaction.chargeElement.source = 'tidal'
+        })
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'Adjusted source type' to 'tidal'", () => {
+        expect(csvData[0]['Adjusted source type']).to.equal('tidal')
+      })
+    })
+
     test('creates a line for each transaction', async () => {
       const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
       expect(csvData[0]['Licence number']).to.equal(licenceRef)
@@ -402,7 +418,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     })
 
     test('charge element data to user friendly headings', () => {
-      expect(transactionData['Adjusted source type']).to.equal(transaction.chargeElement.eiucSource)
       expect(transactionData['Adjusted source factor']).to.equal(transaction.calcEiucSourceFactor)
       expect(transactionData.Season).to.equal(transaction.chargeElement.season)
       expect(transactionData['Season factor']).to.equal(transaction.calcSeasonFactor)

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -221,6 +221,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
         expect(csvData[0]['Water company Y/N']).to.equal('N')
+        expect(csvData[0]['Historical area']).to.equal('AREA')
       })
     })
 
@@ -252,6 +253,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
         expect(csvData[0]['Water company Y/N']).to.equal('N')
+        expect(csvData[0]['Historical area']).to.equal('AREA')
       })
     })
 
@@ -318,10 +320,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       test("sets 'Water company Y/N' to 'Y'", () => {
         expect(csvData[0]['Water company Y/N']).to.equal('Y')
       })
-    })
-
-    test('historical area is mapped to user friendly heading', async () => {
-      expect(csvData[0]['Historical area']).to.equal('AREA')
     })
 
     test('creates a line for each transaction', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -223,6 +223,12 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Water company Y/N']).to.equal('N')
         expect(csvData[0]['Historical area']).to.equal('AREA')
         expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
+        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+        expect(csvData[0]['Source type']).to.equal('unsupported')
+        expect(csvData[0]['Source factor']).to.equal('0.5')
       })
     })
 
@@ -256,6 +262,12 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Water company Y/N']).to.equal('N')
         expect(csvData[0]['Historical area']).to.equal('AREA')
         expect(csvData[0]['Compensation charge Y/N']).to.equal('N')
+        expect(csvData[0]['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(csvData[0]['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal('1')
+        expect(csvData[0]['Authorised annual quantity (megalitres)']).to.equal('9.1')
+        expect(csvData[0]['Billable annual quantity (megalitres)']).to.equal('9.1')
+        expect(csvData[0]['Source type']).to.equal('unsupported')
+        expect(csvData[0]['Source factor']).to.equal('0.5')
       })
     })
 
@@ -390,12 +402,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     })
 
     test('charge element data to user friendly headings', () => {
-      expect(transactionData['Standard Unit Charge (SUC) (£/1000 cubic metres)']).to.equal(transaction.calcSucFactor)
-      expect(transactionData['Environmental Improvement Unit Charge (EIUC) (£/1000 cubic metres)']).to.equal(transaction.calcEiucFactor)
-      expect(transactionData['Authorised annual quantity (megalitres)']).to.equal(transaction.chargeElement.authorisedAnnualQuantity)
-      expect(transactionData['Billable annual quantity (megalitres)']).to.equal(transaction.chargeElement.billableAnnualQuantity)
-      expect(transactionData['Source type']).to.equal(transaction.chargeElement.source)
-      expect(transactionData['Source factor']).to.equal(transaction.calcSourceFactor)
       expect(transactionData['Adjusted source type']).to.equal(transaction.chargeElement.eiucSource)
       expect(transactionData['Adjusted source factor']).to.equal(transaction.calcEiucSourceFactor)
       expect(transactionData.Season).to.equal(transaction.chargeElement.season)

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -219,6 +219,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Charge information reason']).to.equal('change reason description')
         expect(csvData[0].Region).to.equal('Anglian')
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
+        expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
       })
     })
 
@@ -248,6 +249,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Charge information reason']).to.equal('change reason description')
         expect(csvData[0].Region).to.equal('Anglian')
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
+        expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
       })
     })
 
@@ -340,10 +342,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     beforeEach(() => {
       transaction = invoice.billingInvoiceLicences[0].billingTransactions[0]
       transactionData = transactionsCSV._getTransactionData(transaction)
-    })
-
-    test('description as is', () => {
-      expect(transactionData.description).to.equal(transaction.description)
     })
 
     test('compensation charge as Y/N to user friendly heading', () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -220,6 +220,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0].Region).to.equal('Anglian')
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
+        expect(csvData[0]['Water company Y/N']).to.equal('N')
       })
     })
 
@@ -250,6 +251,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0].Region).to.equal('Anglian')
         expect(csvData[0]['De minimis rule Y/N']).to.equal('N')
         expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
+        expect(csvData[0]['Water company Y/N']).to.equal('N')
       })
     })
 
@@ -296,10 +298,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
 
     test('description is mapped to user friendly heading', async () => {
       expect(csvData[0]['Transaction description']).to.equal('The description - with 007')
-    })
-
-    test('water company when false is mapped to user friendly heading', async () => {
-      expect(csvData[0]['Water company Y/N']).to.equal('N')
     })
 
     test('water company when true is mapped to user friendly heading', async () => {

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -246,6 +246,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
         expect(csvData[0].Quantity).to.equal('9.1')
         expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
+        expect(csvData[0]['S127 agreement value']).to.equal('0.5')
       })
     })
 
@@ -302,6 +303,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
         expect(csvData[0].Quantity).to.equal('9.1')
         expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
+        expect(csvData[0]['S127 agreement value']).to.equal('0.5')
       })
     })
 
@@ -471,6 +473,20 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when the calculated S127 value is null', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+          transaction.calcS127Factor = null
+        })
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'S127 agreement value' to empty", () => {
+        expect(csvData[0]['S127 agreement value']).to.equal('')
+      })
+    })
+
     test('creates a line for each transaction', async () => {
       const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
       expect(csvData[0]['Licence number']).to.equal(licenceRef)
@@ -503,7 +519,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         ...transaction,
         agreements: [{ code: 'S130W' }]
       })
-      expect(transactionData['S127 agreement value']).to.equal(0.5)
       expect(transactionData['S130 agreement']).to.equal('S130W')
       expect(transactionData['S130 agreement value']).to.equal(null)
     })

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -78,7 +78,7 @@ const invoice =
             calcS126Factor: 1.0,
             calcS127Factor: 0.5,
             section130Agreement: 'S130W',
-            section127Agreement: true
+            section127Agreement: false
           },
           {
             value: 4006,
@@ -245,6 +245,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Billable days']).to.equal('152')
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
         expect(csvData[0].Quantity).to.equal('9.1')
+        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
       })
     })
 
@@ -300,6 +301,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Billable days']).to.equal('152')
         expect(csvData[0]['Calculated quantity']).to.equal('10.3')
         expect(csvData[0].Quantity).to.equal('9.1')
+        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('N')
       })
     })
 
@@ -455,6 +457,20 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
       })
     })
 
+    experiment('when section 127 agreement is true', () => {
+      beforeEach(async () => {
+        invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
+          transaction.section127Agreement = true
+        })
+
+        csvData = await transactionsCSV.createCSV([invoice], chargeVersions)
+      })
+
+      test("sets 'S127 agreement (Y/N)' to 'Y'", () => {
+        expect(csvData[0]['S127 agreement (Y/N)']).to.equal('Y')
+      })
+    })
+
     test('creates a line for each transaction', async () => {
       const licenceRef = invoice.billingInvoiceLicences[0].licence.licenceRef
       expect(csvData[0]['Licence number']).to.equal(licenceRef)
@@ -487,7 +503,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         ...transaction,
         agreements: [{ code: 'S130W' }]
       })
-      expect(transactionData['S127 agreement (Y/N)']).to.equal('Y')
       expect(transactionData['S127 agreement value']).to.equal(0.5)
       expect(transactionData['S130 agreement']).to.equal('S130W')
       expect(transactionData['S130 agreement value']).to.equal(null)

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -239,6 +239,10 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
         expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
         expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
+        expect(csvData[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(csvData[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(csvData[0]['Authorised days']).to.equal('152')
+        expect(csvData[0]['Billable days']).to.equal('152')
       })
     })
 
@@ -288,6 +292,10 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(csvData[0]['Purpose name']).to.equal('Spray Irrigation - Storage')
         expect(csvData[0]['Abstraction period start date']).to.equal('1 Nov')
         expect(csvData[0]['Abstraction period end date']).to.equal('31 Mar')
+        expect(csvData[0]['Charge period start date']).to.equal('2019-04-01')
+        expect(csvData[0]['Charge period end date']).to.equal('2020-03-31')
+        expect(csvData[0]['Authorised days']).to.equal('152')
+        expect(csvData[0]['Billable days']).to.equal('152')
       })
     })
 
@@ -438,19 +446,6 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
     test('agreement to user friendly heading', () => {
       expect(transactionData['S130 agreement']).to.equal('S130W')
       expect(transactionData['S130 agreement value']).to.equal(null)
-    })
-
-    test('charge period to user friendly headings', () => {
-      expect(transactionData['Charge period start date']).to.equal(transaction.startDate)
-      expect(transactionData['Charge period end date']).to.equal(transaction.endDate)
-    })
-
-    test('authorised days to user friendly heading', () => {
-      expect(transactionData['Authorised days']).to.equal(transaction.authorisedDays)
-    })
-
-    test('billable days to user friendly heading', () => {
-      expect(transactionData['Billable days']).to.equal(transaction.billableDays)
     })
 
     test('quantities to user friendly heading', () => {

--- a/test/support/helpers/general.helper.js
+++ b/test/support/helpers/general.helper.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const Hoek = require('@hapi/hoek')
+
+/**
+ * Class of general test helper methods
+ *
+ * The methods here have a more general purpose and can be used across test types, features and domains.
+ */
+class GeneralHelper {
+  /**
+   * Deep clone an object
+   *
+   * In JavaScript assigning an object is by reference. We use 'fixtures' in our tests which are JSON objects read from
+   * files. They help us avoid duplication and noise in our tests. Often we need to amend a small part of the object for
+   * the purposes of a test. If we didn't clone the fixture before doing this, all subsequent tests would see the
+   * altered fixture.
+   *
+   * There are a number of ways to clone an object. Using the spread operator (`...`) or `Object.assign` however, will
+   * only do a shallow clone (copy the top level properties but still reference any sub-properties). Because our
+   * fixtures can be multidimensional we need to do a deep clone. Hapi brings in the dependency Hoek which contains a
+   * `clone()` method that does deep cloning so we use that.
+   *
+   * You can read more about cloning objects here https://www.samanthaming.com/tidbits/70-3-ways-to-clone-objects/
+   *
+   * @param {Object} thingToBeCloned Object you want to be cloned
+   * @returns {Object} a deep clone of the object
+   */
+  static cloneObject (thingToBeCloned) {
+    return Hoek.clone(thingToBeCloned)
+  }
+}
+
+module.exports = GeneralHelper


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3586

We came across transactions-csv.js as part of working on altering the bill run download to handle SROC bill runs.

To say it angered and upset the current dev team is a bit of an understatement. You _could_ argue calling a function to pull a couple of fields from an object has value (though in our opinion you'd be wrong!)

But there is no reason for making an _utter_ mess of known conventions around `private` and `public` methods. It is a [common practice](https://stackoverflow.com/a/4484449/6117745) in JavaScript to prefix private module methods with an underscore. This singles intent to other developers; these methods are only used internally by the module, and those without it are for use elsewhere in the code.

So, after another day of struggling through the code imagine our consternation when we come across this

```javascript
exports._getInvoiceData = getInvoiceData
exports._getInvoiceAccountData = getInvoiceAccountData
exports._getTransactionData = getTransactionData
exports._getTransactionAmounts = getTransactionAmounts
exports.createCSV = createCSV
exports.getCSVFileName = getCSVFileName
```

We are making `private` methods `public` but when we do so we are identifying them as `private`. Arrrrgh!!! 🤬😠

As far as we can see this was _solely_ for the purpose of testing the methods. _They are not referenced anywhere else!!!_ So, added to our convention-breaking we're also directly testing methods intended to be private and making them public purely to allow those tests to run. 🤯🤦

We have no words. Just know this change attempts to make things a little better 🥹