### PR TITLE
Fix export bill run csv for sroc

### DIFF
--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -117,8 +117,7 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Charge reference description': transaction.chargeCategoryDescription,
     Source: transaction.source,
     Loss: transaction.loss,
-    // In the UI, "Volume" is taken from authorisedAnnualQuantity
-    Volume: transaction.chargeElement.authorisedAnnualQuantity,
+    Volume: transaction.volume,
     'Water available Y/N': transaction.chargeElement.isRestrictedSource ? 'N' : 'Y',
     Modelling: transaction.chargeElement.waterModel,
     'Public water supply Y/N': transaction.isWaterCompanyCharge ? 'Y' : 'N',

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -127,7 +127,10 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Canal and Rivers trust agreement': transaction.calcS130Factor,
     'Aggregate factor': transaction.aggregateFactor,
     'Charge adjustment factor': transaction.adjustmentFactor,
-    'Abatement factor': transaction.calcS126Factor,
+    // Note that for sroc we do not receive back from the CM a value that can populate `calcS126Factor` (because the
+    // Rules Service only returns factors that it calculates, when in this case it uses the factor we provide). So
+    // unlike other factor fields, we use the value we sent `section126Factor` instead of the value we receive back.
+    'Abatement factor': transaction.section126Factor,
     'Two part tariff': transaction.calcS127Factor,
     'Transaction description': transaction.description,
     'Charge information reason': _changeReason(chargeVersions, transaction),

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -98,7 +98,8 @@ const invoiceData =
             calcS130Factor: null,
             aggregateFactor: 1,
             adjustmentFactor: 1,
-            isTwoPartSecondPartCharge: false
+            isTwoPartSecondPartCharge: false,
+            section126Factor: 0.9
           },
           {
             value: 4006,
@@ -175,7 +176,8 @@ const invoiceData =
             calcS130Factor: null,
             aggregateFactor: 1,
             adjustmentFactor: 1,
-            isTwoPartSecondPartCharge: false
+            isTwoPartSecondPartCharge: false,
+            section126Factor: 0.9
           }
         ],
         licence: {
@@ -568,7 +570,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0]['Canal and Rivers trust agreement']).to.equal('')
         expect(result[0]['Aggregate factor']).to.equal('1')
         expect(result[0]['Charge adjustment factor']).to.equal('1')
-        expect(result[0]['Abatement factor']).to.equal('1')
+        expect(result[0]['Abatement factor']).to.equal('0.9')
         expect(result[0]['Two part tariff']).to.equal('0.5')
         expect(result[0]['Transaction description']).to.equal('The description - with 007')
         expect(result[0]['Charge information reason']).to.equal('change reason description')

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -558,7 +558,7 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         expect(result[0]['Charge reference']).to.equal('4.5.55')
         expect(result[0].Source).to.equal('non-tidal')
         expect(result[0].Loss).to.equal('medium')
-        expect(result[0].Volume).to.equal('8.1')
+        expect(result[0].Volume).to.equal('9.1')
         expect(result[0]['Water available Y/N']).to.equal('Y')
         expect(result[0].Modelling).to.equal('no model')
         expect(result[0]['Public water supply Y/N']).to.equal('Y')


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/c/projects/WATER/boards/96?modal=detail&selectedIssue=WATER-3586

Volume, Winter adjustment factor & Abatement factor were not appearing in the CSV. We fix this here:

* Volume is the transaction's volume -- this is the same as Quantity but we accept that this is acceptable for now.
* Winter adjustment factor was not being persisted in the db -- we [update the service](https://github.com/DEFRA/water-abstraction-service/pull/1722) to save this.
* Abatement factor is not provided by the Charging Module as previously assumed -- long story short, the Rules Service only returns factors that it calculates and since it uses the factor we provide, it therefore doesn't return a value. So rather than use the `calc` value (which is the one returned by the CM, as is the case with certain other factors), we simply use the value originally provided.