### PR TITLE
Fix Compensation Charge field in CSV export

### DIFF
--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -135,7 +135,7 @@ function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
     'Transaction description': transaction.description,
     'Charge information reason': _changeReason(chargeVersions, transaction),
     'Is second part charge? Y/N': transaction.isTwoPartSecondPartCharge ? 'Y' : 'N',
-    'Compensation charge Y/N': transaction.isCompensationCharge ? 'Y' : 'N',
+    'Compensation charge Y/N': transaction.chargeType === 'compensation' ? 'Y' : 'N',
     'Compensation charge applicable Y/N': invoiceLicence.licence.isWaterUndertaker ? 'N' : 'Y',
     'De minimis rule Y/N': invoice.isDeMinimis ? 'Y' : 'N',
     Region: invoiceLicence.licence.region.displayName,

--- a/test/internal/modules/billing/services/transactions-csv.js
+++ b/test/internal/modules/billing/services/transactions-csv.js
@@ -750,10 +750,10 @@ experiment('internal/modules/billing/services/transactions-csv', () => {
         })
       })
 
-      experiment('when compensation charge is true', () => {
+      experiment('when charge type is compensation', () => {
         beforeEach(() => {
           invoice.billingInvoiceLicences[0].billingTransactions.forEach((transaction) => {
-            transaction.isCompensationCharge = true
+            transaction.chargeType = 'compensation'
           })
         })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3586

The Compensation Charge field is not correctly populated with `Y` for compensation charges. This is due to the expected `isCompensationCharge` flag not being present. We therefore replicate the logic of this flag in our CSV exporter.