### PR TITLE
Clamdscan failing - investigation

### DIFF
--- a/src/internal/modules/charge-information-upload/controller.js
+++ b/src/internal/modules/charge-information-upload/controller.js
@@ -72,13 +72,16 @@ async function postUploadChargeInformation (request, h) {
   let eventId, redirectPath
 
   const file = get(request.payload, 'file', {})
+  logger.info(file)
   const filename = get(file, 'hapi.filename')
+  logger.info(filename)
 
   if (!filename) {
     return h.redirect(uploadHelpers.getRedirectPath(NO_FILE))
   }
 
   const localPath = uploadHelpers.getFile()
+  logger.info(localPath)
 
   try {
     // Store file locally and run checks
@@ -106,7 +109,8 @@ async function postUploadChargeInformation (request, h) {
     throw error
   } finally {
     // Delete temporary file
-    await files.deleteFile(localPath)
+    // Temporarily disable deletion just to see if files eventually arrive
+    // await files.deleteFile(localPath)
   }
 
   return h.redirect(redirectPath)

--- a/src/shared/lib/upload-helpers.js
+++ b/src/shared/lib/upload-helpers.js
@@ -118,7 +118,8 @@ class UploadHelpers {
   async getUploadedFileStatus (file, type) {
     // Run virus check on temp file
     const { VIRUS, OK, INVALID_TYPE } = UploadHelpers.fileStatuses
-    const checkResult = this._testMode ? { isClean: true } : await fileCheck.virusCheck(file)
+    // const checkResult = this._testMode ? { isClean: true } : await fileCheck.virusCheck(file)
+    const checkResult = await fileCheck.virusCheck(file)
     // Set redirectUrl if virusCheck failed
     if (!checkResult.isClean) {
       this._logger.error('Uploaded file failed virus scan', checkResult.err)


### PR DESCRIPTION
Uploading charge information files to DEV currently fails with an error along the lines of:
```
3|ui-internal  | 2022-07-20T09:24:28.043Z - error: Error with charge information upload checks message=Command failed: clamdscan /srv/app/node/water-abstraction-ui/releases/20220719_115635/temp/cad85cbe-c689-4666-bc4b-3f7eaf5fcac8
3|ui-internal  | , stack=Error: Command failed: clamdscan /srv/app/node/water-abstraction-ui/releases/20220719_115635/temp/cad85cbe-c689-4666-bc4b-3f7eaf5fcac8
```

On investigation we have seen that the file `/srv/app/node/water-abstraction-ui/releases/20220719_115635/temp/cad85cbe-c689-4666-bc4b-3f7eaf5fcac8` is not present, so we need to figure out what's going on. We have created a new branch so we can deploy code.