### PR TITLE
Postal address issue - water abstraction alerts

### DIFF
--- a/src/internal/views/nunjucks/gauging-stations/confirm-sending-alerts.njk
+++ b/src/internal/views/nunjucks/gauging-stations/confirm-sending-alerts.njk
@@ -50,6 +50,19 @@
                 {% if notification.personalisation.address_line_4 %}
                     <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_4}}</p>
                 {% endif %}
+                {% if notification.personalisation.address_line_5 %}
+                    <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_5}}</p>
+                {% endif %}
+                {% if notification.personalisation.address_line_6 %}
+                    <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_6}}</p>
+                {% endif %}
+                {# We don't expect to see address_line_7, however it has been used elsewhere so we use it here just in case#}
+                {% if notification.personalisation.address_line_7 %}
+                    <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_7}}</p>
+                {% endif %}
+                {% if notification.personalisation.postcode %}
+                    <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.postcode}}</p>
+                {% endif %}
             {% endif %}
             </td>
             <td class="govuk-table__cell">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3717

When creating a water abstraction alert, the alert will be sent by letter to the licence holder if no water abstraction alert contact has been added and opted in to receive email alerts.

We update the `confirm-sending-alerts` template to display the full set of address lines that we expect to receive.

Note that we also display `address_line_7` even though elsewhere we see a comment that there can only be 6 address lines plus postcode. We do this because the notifications report is set to display an `address_line_7` so even though we don't expect to receive it, we use it anyway just in case.