### PR TITLE
Postal address issue - Remove separate postcode field from template

### DIFF
--- a/src/internal/views/nunjucks/gauging-stations/confirm-sending-alerts.njk
+++ b/src/internal/views/nunjucks/gauging-stations/confirm-sending-alerts.njk
@@ -56,12 +56,8 @@
                 {% if notification.personalisation.address_line_6 %}
                     <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_6}}</p>
                 {% endif %}
-                {# We don't expect to see address_line_7, however it has been used elsewhere so we use it here just in case#}
                 {% if notification.personalisation.address_line_7 %}
                     <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.address_line_7}}</p>
-                {% endif %}
-                {% if notification.personalisation.postcode %}
-                    <p class="govuk-body govuk-!-margin-0">{{notification.personalisation.postcode}}</p>
                 {% endif %}
             {% endif %}
             </td>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3717

When reviewing the UI changes for the postal address issue we realised that although we had added `notification.personalisation.postcode` to the template, this wouldn't actually be supplied by the service -- instead the postcode would come back as one of the numbered address lines. We therefore remove this from the template.