### PR TITLE
SRoC charge creation - additional characters required in charge reference description

### DIFF
--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -5,6 +5,7 @@ const { formFactory, fields } = require('shared/lib/forms/')
 const { ROUTING_CONFIG } = require('../../lib/charge-categories/constants')
 const { getChargeCategoryData, getChargeCategoryActionUrl } = require('../../lib/form-helpers')
 
+const INVALID_CHARS = ['“', '”', '?', '^', '£', '≥', '≤', '—']
 /**
  * Form to request the charge category description
  *
@@ -26,8 +27,11 @@ const form = request => {
       'any.required': {
         message: 'Enter a description for the charge reference'
       },
-      'string.pattern.base': {
-        message: 'You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters'
+      'any.invalid': {
+        message: 'You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes'
+      },
+      'string.max': {
+        message: 'The description for the charge reference must be 180 characters or less'
       }
     }
   }, data.description || ''))
@@ -38,10 +42,9 @@ const form = request => {
 }
 
 const schema = () => {
-  const descriptionRegex = /^[a-zA-Z/s 0-9-'.,()&*]{1,180}$/
   return Joi.object().keys({
     csrf_token: Joi.string().uuid().required(),
-    description: Joi.string().pattern(descriptionRegex).required()
+    description: Joi.string().invalid(...INVALID_CHARS).max(180).required()
   })
 }
 

--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -5,7 +5,6 @@ const { formFactory, fields } = require('shared/lib/forms/')
 const { ROUTING_CONFIG } = require('../../lib/charge-categories/constants')
 const { getChargeCategoryData, getChargeCategoryActionUrl } = require('../../lib/form-helpers')
 
-const INVALID_CHARS = ['“', '”', '?', '^', '£', '≥', '≤', '—']
 /**
  * Form to request the charge category description
  *
@@ -27,7 +26,7 @@ const form = request => {
       'any.required': {
         message: 'Enter a description for the charge reference'
       },
-      'any.invalid': {
+      'string.pattern.invert.base': {
         message: 'You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes'
       },
       'string.max': {
@@ -44,7 +43,7 @@ const form = request => {
 const schema = () => {
   return Joi.object().keys({
     csrf_token: Joi.string().uuid().required(),
-    description: Joi.string().invalid(...INVALID_CHARS).max(180).required()
+    description: Joi.string().pattern(/[“”?^£≥≤—]/, { invert: true }).max(180).required()
   })
 }
 

--- a/test/internal/modules/charge-information/forms/charge-categories/description.js
+++ b/test/internal/modules/charge-information/forms/charge-categories/description.js
@@ -51,7 +51,8 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice')
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference')
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference')
-      expect(descriptionField.options.errors['string.pattern.base'].message).to.equal('You can only include letters, numbers, hyphens, the and symbol (&) and brackets. The description must be less than 181 characters')
+      expect(descriptionField.options.errors['any.invalid'].message).to.equal('You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes')
+      expect(descriptionField.options.errors['string.max'].message).to.equal('The description for the charge reference must be 180 characters or less')
     })
 
     test('has a submit button', async () => {
@@ -94,13 +95,13 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
         expect(result.error).to.be.an.instanceof(Error)
         expect(result.error.message).to.equal('"description" is not allowed to be empty')
       })
-      test('validates for the descriptionRegex - includes nto allowed @', async () => {
+      test('validates for the descriptionRegex - ? not allowed', async () => {
         const result = schema(createRequest()).validate({
           csrf_token: 'c5afe238-fb77-4131-be80-384aaf245842',
-          description: '@'
+          description: '?'
         }, { allowUnknown: true })
         expect(result.error).to.be.an.instanceof(Error)
-        expect(result.error.message).to.equal('"description" with value "@" fails to match the required pattern: /^[a-zA-Z/s 0-9-\'.,()&*]{1,180}$/')
+        expect(result.error.message).to.equal('"description" contains an invalid value')
       })
       test('validates for the descriptionRegex - bigger than 180 chars', async () => {
         const stringBiggerThan180Chars = 'w5OyHN3NWsL9KTKU7afHDMlN1FUzzV3Fj30ci1sr9z1RK1jPxuOv6rFa9yb6tzGvZ6i5uaRF73V5FgwATfN08kdeYisXysk7gc90s1IVI2uyji04Tw8H1ij1o0tAh22r99C8aupphswIQt2I9CBNFhZr4rxaS413lFIb05BrQQ5OQPYVei3k4H6jEKfjCvW1iCMtReZYKE64C6EA9fGjUMrt2wNFKnoQoXo3A66yIS5iCJhV8g94fWEYzI8ZfozqWLR15Sg92HQQsT6Nr37uUFr3zIy79t0pDvcp75Ctq87Dx4eRLNHBTjzB'
@@ -109,7 +110,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
           description: stringBiggerThan180Chars
         }, { allowUnknown: true })
         expect(result.error).to.be.an.instanceof(Error)
-        expect(result.error.message).to.equal(`"description" with value "${stringBiggerThan180Chars}" fails to match the required pattern: /^[a-zA-Z/s 0-9-'.,()&*]{1,180}$/`)
+        expect(result.error.message).to.equal('"description" length must be less than or equal to 180 characters long')
       })
     })
   })

--- a/test/internal/modules/charge-information/forms/charge-categories/description.js
+++ b/test/internal/modules/charge-information/forms/charge-categories/description.js
@@ -98,10 +98,10 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       test('validates for the descriptionRegex - ? not allowed', async () => {
         const result = schema(createRequest()).validate({
           csrf_token: 'c5afe238-fb77-4131-be80-384aaf245842',
-          description: '?'
+          description: 'test?'
         }, { allowUnknown: true })
         expect(result.error).to.be.an.instanceof(Error)
-        expect(result.error.message).to.equal('"description" contains an invalid value')
+        expect(result.error.message).to.equal('"description" with value "test?" matches the inverted pattern: /[“”?^£≥≤—]/')
       })
       test('validates for the descriptionRegex - bigger than 180 chars', async () => {
         const stringBiggerThan180Chars = 'w5OyHN3NWsL9KTKU7afHDMlN1FUzzV3Fj30ci1sr9z1RK1jPxuOv6rFa9yb6tzGvZ6i5uaRF73V5FgwATfN08kdeYisXysk7gc90s1IVI2uyji04Tw8H1ij1o0tAh22r99C8aupphswIQt2I9CBNFhZr4rxaS413lFIb05BrQQ5OQPYVei3k4H6jEKfjCvW1iCMtReZYKE64C6EA9fGjUMrt2wNFKnoQoXo3A66yIS5iCJhV8g94fWEYzI8ZfozqWLR15Sg92HQQsT6Nr37uUFr3zIy79t0pDvcp75Ctq87Dx4eRLNHBTjzB'

--- a/test/internal/modules/charge-information/forms/charge-categories/description.js
+++ b/test/internal/modules/charge-information/forms/charge-categories/description.js
@@ -51,7 +51,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice')
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference')
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference')
-      expect(descriptionField.options.errors['any.invalid'].message).to.equal('You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes')
+      expect(descriptionField.options.errors['string.pattern.invert.base'].message).to.equal('You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes')
       expect(descriptionField.options.errors['string.max'].message).to.equal('The description for the charge reference must be 180 characters or less')
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3700

As part of the SRoC charge creation process, users need to enter a description for the charge reference. B&D want to be able to use ; (semi colon) and ' (apostrophe) in this description.

The list of allowed characters in WRLS is currently limited to letters (lower and upper case), hyphen (dash), numbers, forward slash, ampersand (&), asterisk , commas, brackets.

The following characters are not accepted by SOP “ ? ^ £ ≥ ≤ — (long dash).

We should allow ; and ' in WRLS, in addition to the currently accepted characters. We are amending to a 'not allowed' list instead, and only exclude those characters not accepted by SOP.