### PR TITLE
SROC charge creation - amend hint and error

### DIFF
--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -27,7 +27,7 @@ const form = request => {
         message: 'Enter a description for the charge reference'
       },
       'string.pattern.invert.base': {
-        message: 'You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes'
+        message: 'You can not use “ ” ? ^ £ ≥ ≤ — (long dash) in the charge reference description'
       },
       'string.max': {
         message: 'The description for the charge reference must be 180 characters or less'

--- a/src/internal/modules/charge-information/forms/charge-category/description.js
+++ b/src/internal/modules/charge-information/forms/charge-category/description.js
@@ -18,7 +18,7 @@ const form = request => {
 
   const f = formFactory(action, 'POST')
   f.fields.push(fields.text('description', {
-    hint: 'This is the description that will appear on the invoice',
+    hint: 'This is the description that will appear on the invoice. You can use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes.',
     errors: {
       'string.empty': {
         message: 'Enter a description for the charge reference'

--- a/test/internal/modules/charge-information/forms/charge-category/description.js
+++ b/test/internal/modules/charge-information/forms/charge-category/description.js
@@ -51,7 +51,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice. You can use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes.')
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference')
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference')
-      expect(descriptionField.options.errors['string.pattern.invert.base'].message).to.equal('You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes')
+      expect(descriptionField.options.errors['string.pattern.invert.base'].message).to.equal('You can not use “ ” ? ^ £ ≥ ≤ — (long dash) in the charge reference description')
       expect(descriptionField.options.errors['string.max'].message).to.equal('The description for the charge reference must be 180 characters or less')
     })
 

--- a/test/internal/modules/charge-information/forms/charge-category/description.js
+++ b/test/internal/modules/charge-information/forms/charge-category/description.js
@@ -48,7 +48,7 @@ experiment('internal/modules/charge-information/forms/charge-category/descriptio
       const descriptionField = findField(formResponse, 'description')
       expect(descriptionField.options.widget).to.equal('text')
       expect(descriptionField.options.type).to.equal('text')
-      expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice')
+      expect(descriptionField.options.hint).to.equal('This is the description that will appear on the invoice. You can use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes.')
       expect(descriptionField.options.errors['string.empty'].message).to.equal('Enter a description for the charge reference')
       expect(descriptionField.options.errors['any.required'].message).to.equal('Enter a description for the charge reference')
       expect(descriptionField.options.errors['string.pattern.invert.base'].message).to.equal('You can only use letters, numbers, hyphens, ampersands, brackets, semi colons and apostrophes')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3700

The hint was not specified originally in the acceptance criteria and has since been added.

Also after some debate the error message has ben updated.