### PR TITLE
Skip public water question page if licence holder isn't water undertaker

### DIFF
--- a/src/internal/modules/charge-information/controllers/charge-category.js
+++ b/src/internal/modules/charge-information/controllers/charge-category.js
@@ -96,12 +96,12 @@ const adjustementsHandler = async (request, draftChargeInformation) => {
   const chargeElement = draftChargeInformation.chargeElements.find(element => element.id === elementId)
   if (request.payload.isAdjustments === 'true') {
     return routing.getChargeCategoryStep(licenceId, elementId, ROUTING_CONFIG.isAdjustments.nextStep, { chargeVersionWorkflowId })
-  } else {
-    chargeElement.isAdjustments = false
-    chargeElement.adjustments = {}
-    request.setDraftChargeInformation(licenceId, chargeVersionWorkflowId, draftChargeInformation)
-    return getRedirectPath(request, 'adjustments')
   }
+
+  chargeElement.isAdjustments = false
+  chargeElement.adjustments = {}
+  request.setDraftChargeInformation(licenceId, chargeVersionWorkflowId, draftChargeInformation)
+  return getRedirectPath(request, 'adjustments')
 }
 
 const postChargeCategoryStep = async (request, h) => {
@@ -130,11 +130,9 @@ const postChargeCategoryStep = async (request, h) => {
     return h.redirect(getRedirectPath(request, stepKey))
   }
 
-  if (routeConfig === ROUTING_CONFIG.isSupportedSource) {
-    if (request.payload.isSupportedSource === 'false') {
-      delete chargeElement.supportedSourceName
-      request.setDraftChargeInformation(licenceId, chargeVersionWorkflowId, draftChargeInformation)
-    }
+  if (routeConfig === ROUTING_CONFIG.isSupportedSource && request.payload.isSupportedSource === 'false') {
+    delete chargeElement.supportedSourceName
+    request.setDraftChargeInformation(licenceId, chargeVersionWorkflowId, draftChargeInformation)
   }
 
   if (routeConfig === ROUTING_CONFIG.supportedSourceName) {
@@ -150,6 +148,8 @@ const postChargeCategoryStep = async (request, h) => {
   return h.redirect(redirectPath)
 }
 
-exports.getRedirectPath = getRedirectPath
-exports.getChargeCategoryStep = getChargeCategoryStep
-exports.postChargeCategoryStep = postChargeCategoryStep
+module.exports = {
+  getRedirectPath,
+  getChargeCategoryStep,
+  postChargeCategoryStep
+}

--- a/src/internal/modules/charge-information/controllers/charge-category.js
+++ b/src/internal/modules/charge-information/controllers/charge-category.js
@@ -120,6 +120,11 @@ const postChargeCategoryStep = async (request, h) => {
   const chargeElement = draftChargeInformation.chargeElements.find(element => element.id === elementId)
 
   if (routeConfig === ROUTING_CONFIG.isAdjustments) {
+    // If isSupplyPublicWater hasn't been set at this point we need to set it to false
+    if (chargeElement.isSupplyPublicWater === undefined) {
+      chargeElement.isSupplyPublicWater = false
+      request.setDraftChargeInformation(licenceId, chargeVersionWorkflowId, draftChargeInformation)
+    }
     const route = await adjustementsHandler(request, draftChargeInformation)
     return h.redirect(route)
   }

--- a/src/internal/modules/charge-information/controllers/charge-information.js
+++ b/src/internal/modules/charge-information/controllers/charge-information.js
@@ -230,6 +230,7 @@ const getCheckData = async (request, h) => {
     chargeVersionWorkflowId: request.query.chargeVersionWorkflowId,
     isChargeable,
     isEditable: true,
+    isWaterUndertaker: licence.isWaterUndertaker,
     isXlHeading: true,
     editChargeVersionWarning,
     isApprover,

--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -37,6 +37,7 @@ const getViewChargeInformation = async (request, h) => {
     pageTitle: `Charge information valid from ${formatDateForPageTitle(chargeVersion.dateRange.startDate)}`,
     chargeVersion,
     isEditable: false,
+    isWaterUndertaker: licence.isWaterUndertaker,
     chargeVersionWorkflowId,
     billingAccount,
     billingAccountAddress,
@@ -72,6 +73,7 @@ const getReviewChargeInformation = async (request, h) => {
     licenceHolder,
     licenceId: licence.id,
     isEditable: draftChargeInformation.status === 'changes_requested' || draftChargeInformation.status === 'review',
+    isWaterUndertaker: licence.isWaterUndertaker,
     isApprover,
     isChargeable,
     chargeVersionWorkflowId,
@@ -105,6 +107,7 @@ const postReviewChargeInformation = async (request, h) => {
       licenceId: licence.id,
       chargeVersionWorkflowId,
       isEditable: draftChargeInformation.status === 'changes_requested',
+      isWaterUndertaker: licence.isWaterUndertaker,
       isApprover,
       isChargeable,
       reviewForm: form

--- a/src/internal/modules/charge-information/lib/charge-categories/constants.js
+++ b/src/internal/modules/charge-information/lib/charge-categories/constants.js
@@ -134,6 +134,8 @@ const ROUTING_CONFIG = {
     errorMessage: 'Select the name of the supported source.',
     boolean: true
   },
+  // Note that this screen is skipped if the customer is not a water undertaker
+  // See src/internal/modules/charge-information/controllers/charge-category.js#getChargeCategoryStep
   isSupplyPublicWater: {
     step: 'supply-public-water',
     pageTitle: 'Is abstraction for the supply of public water?',

--- a/src/internal/views/nunjucks/charge-information/macros/charge-element-table-sroc.njk
+++ b/src/internal/views/nunjucks/charge-information/macros/charge-element-table-sroc.njk
@@ -185,7 +185,7 @@ formErrorSummary %}
 
 {% endmacro %}
 
-{% macro chargeElementTableSroc(chargeElements, isEditable, licenceId, chargeVersionWorkflowId) %}
+{% macro chargeElementTableSroc(chargeElements, isEditable, licenceId, chargeVersionWorkflowId, isWaterUndertaker) %}
   {% if chargeElements.length > 0 %}
     {% for chargeElement in chargeElements %}
       <h2 class="govuk-heading-l govuk-!-margin-bottom-4">
@@ -213,7 +213,7 @@ formErrorSummary %}
           {% if chargeElement.supportedSourceName %}
             {{ summaryListRow('Supported source name', chargeElement.supportedSourceName, changeLinkSroc('/supported-source-name', chargeElement.id, licenceId, chargeVersionWorkflowId), isEditable) }}
           {% endif %}
-          {{ summaryListRow('Supply public water', getBooleanText(chargeElement.isSupplyPublicWater) | title, changeLinkSroc('/supply-public-water', chargeElement.id, licenceId, chargeVersionWorkflowId), isEditable) }}
+          {{ summaryListRow('Supply public water', getBooleanText(chargeElement.isSupplyPublicWater) | title, changeLinkSroc('/supply-public-water', chargeElement.id, licenceId, chargeVersionWorkflowId), isEditable and isWaterUndertaker) }}
         </dl>
       {% endif %}
       {% if chargeElement.isAdjustments %}

--- a/src/internal/views/nunjucks/charge-information/view.njk
+++ b/src/internal/views/nunjucks/charge-information/view.njk
@@ -128,7 +128,7 @@ formErrorSummary %}
     <form method="post"  action="{{action}}" novalidate="novalidate">
       <input type="hidden" name="csrf_token" value="{{ csrfToken }}"/>
       {% if chargeVersion.scheme == 'sroc' and isSrocChargeInfoEnabled  %}
-        {{ chargeElementTableSroc(chargeVersion.chargeElements | arrayFilter('scheme', 'sroc'), isEditable, licenceId, chargeVersionWorkflowId)}}
+        {{ chargeElementTableSroc(chargeVersion.chargeElements | arrayFilter('scheme', 'sroc'), isEditable, licenceId, chargeVersionWorkflowId, isWaterUndertaker)}}
         {{ chargeElementTableAlcs(chargeVersion.chargeElements | arrayFilter('scheme','alcs'), isEditable, licenceId, 'sroc', chargeVersionWorkflowId, chargeVersion.chargeElements.length)}}
       {% else %}
         {{ chargeElementTableAlcs(chargeVersion.chargeElements, isEditable, licenceId, 'alcs', chargeVersionWorkflowId, chargeVersion.chargeElements.length ) }}

--- a/test/internal/modules/charge-information/controllers/charge-category.js
+++ b/test/internal/modules/charge-information/controllers/charge-category.js
@@ -42,7 +42,8 @@ const createRequest = ({ step }, payload = undefined) => ({
       id: 'test-licence-id',
       licenceNumber: '01/123',
       regionalChargeArea: { name: 'Test Region' },
-      startDate: moment().subtract(2, 'years').format('YYYY-MM-DD')
+      startDate: moment().subtract(2, 'years').format('YYYY-MM-DD'),
+      isWaterUndertaker: true
     },
     draftChargeInformation: {
       dateRange: { startDate: '2022-04-01' },
@@ -166,6 +167,19 @@ experiment('internal/modules/charge-information/controllers/charge-category', ()
       test('the back link is the supported source name page', async () => {
         const { back } = h.view.lastCall.args[1]
         expect(back).to.equal(`${prefixUrl}/charge-category/${elementId}/${ROUTING_CONFIG.supportedSourceName.step}`)
+      })
+    })
+
+    experiment('when the step is isSupplyPublicWater and isWaterUndertaker is false', () => {
+      beforeEach(async () => {
+        request = createRequest(ROUTING_CONFIG.isSupplyPublicWater)
+        request.pre.licence.isWaterUndertaker = false
+        await controller.getChargeCategoryStep(request, h)
+      })
+
+      test('we are redirected', async () => {
+        const [result] = h.redirect.lastCall.args
+        expect(result).to.equal(`${prefixUrl}/charge-category/${elementId}/${ROUTING_CONFIG.isAdjustments.step}`)
       })
     })
 

--- a/test/internal/modules/charge-information/controllers/charge-category.js
+++ b/test/internal/modules/charge-information/controllers/charge-category.js
@@ -276,6 +276,11 @@ experiment('internal/modules/charge-information/controllers/charge-category', ()
             `${prefixUrl}/check`
           )).to.be.true()
         })
+
+        test('the draft charge information is updated with the adjustments data', async () => {
+          const args = request.setDraftChargeInformation.lastCall.args
+          expect(args[2].chargeElements[0].isSupplyPublicWater).to.equal(false)
+        })
       })
 
       experiment('when the step is whichElement', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3702

When creating SRoC charge information, we want to skip the 'is abstraction for the supply of public water' question page if the licence holder is not a water undertaker. If we do skip this page then we ensure that `isSupplyPublicWater` is defaulted to `false`, by checking if it's been set by the time we get to the adjustments page at the end of the flow.