### PR TITLE
The charge ref is incorrect in the transaction detail

### DIFF
--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -52,7 +52,7 @@ const getSortKey = trans => `${get(trans, 'chargeElement.id')}_${trans.isCompens
 const getAdditionalCharges = transaction => {
   const additionalCharges = []
   if (transaction.supportedSourceName) {
-    additionalCharges.push(`Supported source ${transaction.supportedSourceName} (${numberFormatter.penceToPound(transaction.grossValuesCalculated.supportedSourceCharge, transaction.isCredit, true)})`)
+    additionalCharges.push(`Supported source ${transaction.supportedSourceName} (${numberFormatter.formatCurrency(transaction.grossValuesCalculated.supportedSourceCharge, transaction.isCredit, true)})`)
   }
   if (transaction.isWaterCompanyCharge) {
     additionalCharges.push('Public Water Supply')

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -173,7 +173,7 @@ function _creditLineValue (isCredit, value) {
     return null
   }
 
-  return numberFormatter.penceToPound(value, true)
+  return numberFormatter.formatCurrency(value, true)
 }
 
 function _debitLineValue (isCredit, value) {
@@ -181,7 +181,7 @@ function _debitLineValue (isCredit, value) {
     return null
   }
 
-  return numberFormatter.penceToPound(value, true)
+  return numberFormatter.formatCurrency(value, true)
 }
 
 function _rowToStrings (row) {

--- a/src/internal/views/nunjucks/billing/macros/transactions-table-sroc.njk
+++ b/src/internal/views/nunjucks/billing/macros/transactions-table-sroc.njk
@@ -49,9 +49,9 @@
 
 {% macro transactionDescription(transaction) %}
   {% if transaction.isCompensationCharge %}
-    Compensation charge 
+    Compensation charge
   {% elif transaction.isMinimumCharge %}
-    Minimum charge 
+    Minimum charge
   {% else %}
     {{ transaction.description }}
   {% endif %}
@@ -68,7 +68,7 @@
 {% macro transactionChargePeriod(transaction) %}
   <p class="govuk-body-s">
     <br><strong>Charge period:</strong> {{ transaction.chargePeriod.startDate | date }} to {{ transaction.chargePeriod.endDate | date }}
-    <br><strong>Charge reference:</strong> {{ transaction.chargeElement.chargeCategory.reference }} ({{ transaction.grossValuesCalculated.baselineCharge | charge(true) }})
+    <br><strong>Charge reference:</strong> {{ transaction.chargeElement.chargeCategory.reference }} ({{ transaction.grossValuesCalculated.baselineCharge | charge(true, false) }})
     <br><strong>Charge description:</strong> {{ transaction.chargeElement.chargeCategory.shortDescription }}<br>
     {% if transaction.additionalCharges %}
       <br><strong>Additional charges: </strong>{{ transaction.additionalCharges }}

--- a/src/shared/lib/number-formatter.js
+++ b/src/shared/lib/number-formatter.js
@@ -25,25 +25,26 @@ const maxPrecision = (number, decimalPlaces) => {
 }
 
 /**
- * Moves the decimal 2 spaces left for a number and
+ * Optionally moves the decimal 2 spaces left for a number and
  * adds an optional currency symbol
  * @param {Number|String} number
- * @param {Boolean} isSigned
- * @param {Boolean} showCurrency
+ * @param {Boolean} [showSign]
+ * @param {Boolean} [showCurrency]
+ * @param {Boolean} [poundsToPence]
  * @return {String}
  */
-const penceToPound = (number, isSigned = false, showCurrency = false) => {
+const formatCurrency = (number, showSign = false, showCurrency = false, poundsToPence = true) => {
   const parsedNumber = parseFloat(number)
 
-  if (!isFinite(parsedNumber)) {
+  if (isNaN(parsedNumber)) {
     return number
   }
 
-  const sign = parsedNumber < 0 && isSigned ? '-' : ''
-  const value = (Math.abs(number) / 100).toFixed(2)
+  const sign = showSign && parsedNumber < 0 ? '-' : ''
+  const value = poundsToPence ? (Math.abs(number) / 100) : number
   const currencySymbol = showCurrency ? '£' : ''
-  return `${sign}${currencySymbol}${commaNumber(value)}`
+  return `${sign}${currencySymbol}${commaNumber(value.toFixed(2))}`
 }
 
-exports.penceToPound = penceToPound
+exports.formatCurrency = formatCurrency
 exports.maxPrecision = maxPrecision

--- a/src/shared/lib/number-formatter.js
+++ b/src/shared/lib/number-formatter.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { isFinite } = require('lodash')
 const commaNumber = require('comma-number')
 
 /**

--- a/src/shared/lib/number-formatter.js
+++ b/src/shared/lib/number-formatter.js
@@ -29,10 +29,10 @@ const maxPrecision = (number, decimalPlaces) => {
  * @param {Number|String} number
  * @param {Boolean} [showSign]
  * @param {Boolean} [showCurrency]
- * @param {Boolean} [poundsToPence]
+ * @param {Boolean} [penceToPounds]
  * @return {String}
  */
-const formatCurrency = (number, showSign = false, showCurrency = false, poundsToPence = true) => {
+const formatCurrency = (number, showSign = false, showCurrency = false, penceToPounds = true) => {
   const parsedNumber = parseFloat(number)
 
   if (isNaN(parsedNumber)) {
@@ -40,7 +40,7 @@ const formatCurrency = (number, showSign = false, showCurrency = false, poundsTo
   }
 
   const sign = showSign && parsedNumber < 0 ? '-' : ''
-  const value = poundsToPence ? (Math.abs(number) / 100) : number
+  const value = penceToPounds ? (Math.abs(number) / 100) : number
   const currencySymbol = showCurrency ? '£' : ''
   return `${sign}${currencySymbol}${commaNumber(value.toFixed(2))}`
 }

--- a/src/shared/lib/number-formatter.js
+++ b/src/shared/lib/number-formatter.js
@@ -40,9 +40,12 @@ const formatCurrency = (number, showSign = false, showCurrency = false, penceToP
   }
 
   const sign = showSign && parsedNumber < 0 ? '-' : ''
-  const value = penceToPounds ? (Math.abs(number) / 100) : number
   const currencySymbol = showCurrency ? '£' : ''
-  return `${sign}${currencySymbol}${commaNumber(value.toFixed(2))}`
+  const conversionFactor = penceToPounds ? 100 : 1
+
+  const value = (Math.abs(parsedNumber) / conversionFactor).toFixed(2)
+
+  return `${sign}${currencySymbol}${commaNumber(value)}`
 }
 
 exports.formatCurrency = formatCurrency

--- a/src/shared/view/nunjucks/filters/charge.js
+++ b/src/shared/view/nunjucks/filters/charge.js
@@ -1,19 +1,19 @@
 const numberFormatter = require('../../../lib/number-formatter')
-const { isNil } = require('lodash')
+
 /**
- * Formats an integer charge value in pence
+ * Formats a charge value
  * The sign is discarded as credits either appear in their own column or
  * with "Credit note"
- * @param {Number} value - charge as an integer in pence
- * @param {Boolean} [isSigned] - if true, the sign is displayed
+ * @param {Number|String} value - charge value
+ * @param {Boolean} [showSign] - if true, the sign is displayed
  * @param {Boolean} [isPence] - if true, the value is divided by 100
  * @return {String} formatted number with £ prefix
  */
-const charge = (value, isSigned = false, isPence = true) => {
-  if (isNil(value)) {
+const charge = (value, showSign = false, isPence = true) => {
+  if (value === null || value === undefined) {
     return
   }
-  return `${numberFormatter.formatCurrency(value, isSigned, true, isPence)}`
+  return `${numberFormatter.formatCurrency(value, showSign, true, isPence)}`
 }
 
 exports.charge = charge

--- a/src/shared/view/nunjucks/filters/charge.js
+++ b/src/shared/view/nunjucks/filters/charge.js
@@ -6,13 +6,14 @@ const { isNil } = require('lodash')
  * with "Credit note"
  * @param {Number} value - charge as an integer in pence
  * @param {Boolean} [isSigned] - if true, the sign is displayed
+ * @param {Boolean} [isPence] - if true, the value is divided by 100
  * @return {String} formatted number with £ prefix
  */
-const charge = (value, isSigned = false) => {
+const charge = (value, isSigned = false, isPence = true) => {
   if (isNil(value)) {
     return
   }
-  return `${numberFormatter.penceToPound(value, isSigned, true)}`
+  return `${numberFormatter.formatCurrency(value, isSigned, true, isPence)}`
 }
 
 exports.charge = charge

--- a/test/shared/lib/number-formatter.js
+++ b/test/shared/lib/number-formatter.js
@@ -1,7 +1,7 @@
 const { experiment, test } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-const { maxPrecision, penceToPound } = require('shared/lib/number-formatter')
+const { maxPrecision, formatCurrency } = require('shared/lib/number-formatter')
 
 experiment('Test number formatter helpers', () => {
   experiment('.maxPrecision', () => {
@@ -26,38 +26,38 @@ experiment('Test number formatter helpers', () => {
     })
   })
 
-  experiment('.penceToPound', () => {
+  experiment('.formatCurrency', () => {
     test('should return a value with 2 decimal places', async () => {
-      expect(penceToPound(6678)).to.equal('66.78')
+      expect(formatCurrency(6678)).to.equal('66.78')
     })
 
     test('should not have the currency symbol if not provided', async () => {
-      expect(penceToPound(6678, false)).to.equal('66.78')
+      expect(formatCurrency(6678, false)).to.equal('66.78')
     })
 
     test('should add the currency symbol if provided', async () => {
-      expect(penceToPound(6678, false, '£')).to.equal('£66.78')
+      expect(formatCurrency(6678, false, '£')).to.equal('£66.78')
     })
 
     test('should still return a zero with 2 decimal places', async () => {
-      expect(penceToPound(0)).to.equal('0.00')
+      expect(formatCurrency(0)).to.equal('0.00')
     })
 
     test('should handle negative numbers', async () => {
-      expect(penceToPound(-462, true)).to.equal('-4.62')
+      expect(formatCurrency(-462, true)).to.equal('-4.62')
     })
 
     test('should add the currency symbol after the negative sign but before numbers', async () => {
-      expect(penceToPound(-462, true, '£')).to.equal('-£4.62')
+      expect(formatCurrency(-462, true, '£')).to.equal('-£4.62')
     })
 
     test('tolerates a string representation of a number', async () => {
-      expect(penceToPound('-462', true, '£')).to.equal('-£4.62')
-      expect(penceToPound('6678', false)).to.equal('66.78')
+      expect(formatCurrency('-462', true, '£')).to.equal('-£4.62')
+      expect(formatCurrency('6678', false)).to.equal('66.78')
     })
 
     test('returns a bad numeric if passed', async () => {
-      expect(penceToPound('potatoes')).to.equal('potatoes')
+      expect(formatCurrency('potatoes')).to.equal('potatoes')
     })
   })
 })

--- a/test/shared/lib/number-formatter.js
+++ b/test/shared/lib/number-formatter.js
@@ -5,59 +5,73 @@ const { maxPrecision, formatCurrency } = require('shared/lib/number-formatter')
 
 experiment('Test number formatter helpers', () => {
   experiment('.maxPrecision', () => {
-    test('should reduce precision of number to fixed decimal places', async () => {
+    test('should reduce precision of number to fixed decimal places', () => {
       expect(maxPrecision(24.56678, 3)).to.equal('24.567')
     })
 
-    test('should use reduced fixed precision if not required', async () => {
+    test('should use reduced fixed precision if not required', () => {
       expect(maxPrecision(123.42000, 4)).to.equal('123.42')
     })
 
-    test('should use integer if fractional not required', async () => {
+    test('should use integer if fractional not required', () => {
       expect(maxPrecision(12.00000, 7)).to.equal('12')
     })
 
-    test('should handle zero', async () => {
+    test('should handle zero', () => {
       expect(maxPrecision(0.00000, 2)).to.equal('0')
     })
 
-    test('should handle negative numbers', async () => {
+    test('should handle negative numbers', () => {
       expect(maxPrecision(-46.243525, 4)).to.equal('-46.2435')
     })
   })
 
   experiment('.formatCurrency', () => {
-    test('should return a value with 2 decimal places', async () => {
+    experiment('when the value is negative', () => {
+      test('should not be signed if showSign not specified', () => {
+        expect(formatCurrency(-6678)).to.equal('66.78')
+      })
+
+      test('should be signed if showSign is specified', () => {
+        expect(formatCurrency(-6678, true)).to.equal('-66.78')
+      })
+    })
+
+    test('should return a value with 2 decimal places', () => {
       expect(formatCurrency(6678)).to.equal('66.78')
     })
 
-    test('should not have the currency symbol if not provided', async () => {
+    test('should not have the currency symbol if showCurrency not specified', () => {
       expect(formatCurrency(6678, false)).to.equal('66.78')
     })
 
-    test('should add the currency symbol if provided', async () => {
-      expect(formatCurrency(6678, false, '£')).to.equal('£66.78')
+    test('should add the currency symbol if showCurrency is true', () => {
+      expect(formatCurrency(6678, false, true)).to.equal('£66.78')
     })
 
-    test('should still return a zero with 2 decimal places', async () => {
+    test('should still return a zero with 2 decimal places', () => {
       expect(formatCurrency(0)).to.equal('0.00')
     })
 
-    test('should handle negative numbers', async () => {
-      expect(formatCurrency(-462, true)).to.equal('-4.62')
-    })
-
-    test('should add the currency symbol after the negative sign but before numbers', async () => {
+    test('should add the currency symbol after the negative sign but before numbers', () => {
       expect(formatCurrency(-462, true, '£')).to.equal('-£4.62')
     })
 
-    test('tolerates a string representation of a number', async () => {
+    test('tolerates a string representation of a number', () => {
       expect(formatCurrency('-462', true, '£')).to.equal('-£4.62')
       expect(formatCurrency('6678', false)).to.equal('66.78')
     })
 
-    test('returns a bad numeric if passed', async () => {
+    test('returns a bad numeric if passed', () => {
       expect(formatCurrency('potatoes')).to.equal('potatoes')
+    })
+
+    test('does convert pounds to pence if penceToPounds is not specified', () => {
+      expect(formatCurrency('12345')).to.equal('123.45')
+    })
+
+    test('does NOT convert pounds to pence if penceToPounds is false', () => {
+      expect(formatCurrency('12345', false, false, false)).to.equal('12,345.00')
     })
   })
 })

--- a/test/shared/view/nunjucks/filters/charge.js
+++ b/test/shared/view/nunjucks/filters/charge.js
@@ -26,7 +26,11 @@ experiment('charge Nunjucks filter', () => {
     expect(charge(null)).to.equal(undefined)
   })
 
-  test('When the second argument is true, keeps the sign for negative charges', async () => {
+  test('When isSigned is true, keeps the sign for negative charges', async () => {
     expect(charge(-353, true)).to.equal('-£3.53')
+  })
+
+  test('When isPence is false does NOT convert pounds to pence', async () => {
+    expect(charge(353, false, false)).to.equal('£353.00')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3733

When viewing the transactions as part of an annual bill run for SRoC, there is a section for each transaction showing charge period, charge reference etc.

The value of the charge reference, shown in brackets after the charge reference is displaying incorrectly. The conversion of the value from pence to pounds looks to be incorrect.