### PR TITLE
Fix Notify callback exception

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,19 @@
+# This file contains a list of commits with mass changes for exclusion by `git blame`.
+#
+# Passing `--ignore-revs-file .git-blame-ignore-revs` as a flag will tell git to "ignore changes made by the revision
+# when assigning blame, as if the change never happened".
+#
+# For example:
+#   git blame --ignore-revs-file .git-blame-ignore-revs ...
+#
+# You can make this the default for your local repo using:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Doing this will allow the GitLens VS Code extension (and other tools which use the output of `git blame`) to make use
+# of the file for the repo.
+#
+# Note that `git blame` does not use any file by default, and  the filename `.git-blame-ignore-revs` is just a
+# convention.
+
+# Replace ESLint with Standard (#2118)
+14ccc1ec5e3234b06f9d211ba0640c1d82e4b76f

--- a/src/external/modules/notify/controller.js
+++ b/src/external/modules/notify/controller.js
@@ -7,7 +7,12 @@ const callback = async (request, h) => {
     return h.response('Unauthorized').code(403)
   }
 
-  services.water.notify.postNotifyCallback(request.payload)
+  try {
+    await services.water.notify.postNotifyCallback(request.payload)
+  } catch (error) {
+    return h.response(null).code(error.statusCode)
+  }
+
   return h.response(null).code(204)
 }
 

--- a/test/external/modules/notify/controller.js
+++ b/test/external/modules/notify/controller.js
@@ -66,7 +66,7 @@ experiment('notify callback', () => {
       expect(responseStub.code.calledWith(204)).to.be.true()
     })
 
-    experiment.only('but the request results in an error', () => {
+    experiment('but the request results in an error', () => {
       test('passes the error back in the response', async () => {
         // We replace the stub within the test as doing it in `before` would occur prior to the initial `beforeEach`
         sandbox.restore()

--- a/test/external/modules/notify/controller.js
+++ b/test/external/modules/notify/controller.js
@@ -6,7 +6,7 @@ const { experiment, test, beforeEach, afterEach, before } = exports.lab = requir
 const services = require('external/lib/connectors/services')
 const controller = require('external/modules/notify/controller')
 
-experiment('callback', () => {
+experiment('notify callback', () => {
   const request = {
     method: 'POST',
     url: '/notify/callback',
@@ -64,6 +64,17 @@ experiment('callback', () => {
     test('returns 204 with blank body', async () => {
       await controller.callback(request, h)
       expect(responseStub.code.calledWith(204)).to.be.true()
+    })
+
+    experiment.only('but the request results in an error', () => {
+      test('passes the error back in the response', async () => {
+        // We replace the stub within the test as doing it in `before` would occur prior to the initial `beforeEach`
+        sandbox.restore()
+        sandbox.stub(services.water.notify, 'postNotifyCallback').rejects({ statusCode: 404 })
+
+        await controller.callback(request, h)
+        expect(responseStub.code.calledWith(404)).to.be.true()
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3746

When a Notify request is generated, Notify hits a callback endpoint to update the request status. The callback endpoint is on the production server which means that any non-prod requests (ie. a password reset on `pre`) will still result in the callback endpoint being hit. This should be fine, as the request id won't exist in prod and therefore nothing would be changed. Unfortunately, our callback endpoint was written without any error handling for such errors and therefore these requests from Notify would cause a small interruption while the server restarts after the unhandled error!

We therefore add simple error handling to ensure that such errors are caught without bringing down the production server for a few seconds.