### PR TITLE
Add logging to failed Notify callback

### DIFF
--- a/src/external/modules/notify/controller.js
+++ b/src/external/modules/notify/controller.js
@@ -10,6 +10,7 @@ const callback = async (request, h) => {
   try {
     await services.water.notify.postNotifyCallback(request.payload)
   } catch (error) {
+    logger.info(`A Notify callback request was declined due to HTTP error code ${error.statusCode}`)
     return h.response(null).code(error.statusCode)
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3746

After [fixing the issue of failed Notify callbacks bringing down prod](https://github.com/DEFRA/water-abstraction-ui/pull/2176), we update our code to log these failed callbacks.