### PR TITLE
Make charge version max upload consistent

### DIFF
--- a/src/external/modules/returns/routes/upload.js
+++ b/src/external/modules/returns/routes/upload.js
@@ -35,7 +35,7 @@ module.exports = {
       payload: {
         output: 'stream',
         allow: 'multipart/form-data',
-        maxBytes: 5e+7,
+        maxBytes: 1000 * 1000 * 50,
         multipart: true
       }
     }

--- a/src/internal/modules/charge-information-upload/routes.js
+++ b/src/internal/modules/charge-information-upload/routes.js
@@ -44,7 +44,7 @@ if (config.featureToggles.allowChargeVersionUploads) {
         payload: {
           output: 'stream',
           allow: 'multipart/form-data',
-          maxBytes: 2e+7,
+          maxBytes: 1000 * 1000 * 20,
           multipart: true
         }
       }

--- a/src/internal/modules/charge-information-upload/routes.js
+++ b/src/internal/modules/charge-information-upload/routes.js
@@ -44,7 +44,7 @@ if (config.featureToggles.allowChargeVersionUploads) {
         payload: {
           output: 'stream',
           allow: 'multipart/form-data',
-          maxBytes: 5e+7,
+          maxBytes: 2e+7,
           multipart: true
         }
       }


### PR DESCRIPTION
We've spotted that the charge version upload endpoint route specifies `5e+7` for `maxBytes`. Quick conversion means this is 50MB. However, the UI page says the max upload is 20MB.

We don't like inconsistency! So, this updates the info in the route config to match what we are stating on the upload page.