### PR TITLE
Hide big tech debt change with git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -17,3 +17,5 @@
 
 # Replace ESLint with Standard (#2118)
 14ccc1ec5e3234b06f9d211ba0640c1d82e4b76f
+# Tech-Debt: Remove and update dependencies (#2017)
+72b6c03c5b67d56954084e8a52dbcab5ed3528da


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-ui/pull/2174

We found [another change](https://github.com/DEFRA/water-abstraction-ui/pull/2017) in the commit history where masses of files were updated due to linting fixes. It's another thing that gets in the way when trying to see meaningful changes. So, we add it to our new `.git-blame-ignore-revs` file.