### PR TITLE
TPT adjustment not being displayed in transaction detail

### DIFF
--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -71,6 +71,9 @@ const getAdjustments = transaction => {
   if (transaction.chargeElement?.adjustments?.s126) {
     adjustments.push(`Abatement factor (${transaction.chargeElement.adjustments.s126})`)
   }
+  if (transaction.chargeElement?.adjustments?.s127) {
+    adjustments.push('Two-part tariff (0.5)')
+  }
   if (transaction.chargeElement?.adjustments?.s130) {
     adjustments.push('Canal and River Trust (0.5)')
   }

--- a/test/internal/modules/billing/lib/mappers.js
+++ b/test/internal/modules/billing/lib/mappers.js
@@ -64,7 +64,15 @@ const invoice = {
           endDate: '2020-03-31'
         },
         chargeElement: {
-          id: 'charge_element_licence_1'
+          id: 'charge_element_licence_1',
+          adjustments: {
+            aggregate: 0.25,
+            charge: 0.35,
+            s126: 0.45,
+            s127: true,
+            s130: true,
+            winter: true
+          }
         },
         volume: 12.35,
         billingVolume: {
@@ -362,6 +370,32 @@ experiment('modules/billing/lib/mappers', () => {
 
       test('the link to delete the invoice licence is null', async () => {
         expect(result.links.delete).to.be.null()
+      })
+    })
+
+    experiment('when adjustments are present', () => {
+      const invoiceLicence = invoice.invoiceLicences[0]
+
+      beforeEach(async () => {
+        result = mappers.mapInvoiceLicence(batch, invoice, invoiceLicence)
+      })
+
+      test('the adjustments are displayed', async () => {
+        expect(result.transactions[0].adjustments).to.equal(
+          'Aggregate factor (0.25), Adjustment factor (0.35), Abatement factor (0.45), Two-part tariff (0.5), Canal and River Trust (0.5), Winter discount (0.5)'
+          )
+      })
+    })
+
+    experiment('when adjustments are not present', () => {
+      const invoiceLicence = invoice.invoiceLicences[1]
+
+      beforeEach(async () => {
+        result = mappers.mapInvoiceLicence(batch, invoice, invoiceLicence)
+      })
+
+      test('the adjustments are not displayed', async () => {
+        expect(result.transactions[0].adjustments).to.equal('')
       })
     })
   })

--- a/test/internal/modules/billing/lib/mappers.js
+++ b/test/internal/modules/billing/lib/mappers.js
@@ -383,7 +383,7 @@ experiment('modules/billing/lib/mappers', () => {
       test('the adjustments are displayed', async () => {
         expect(result.transactions[0].adjustments).to.equal(
           'Aggregate factor (0.25), Adjustment factor (0.35), Abatement factor (0.45), Two-part tariff (0.5), Canal and River Trust (0.5), Winter discount (0.5)'
-          )
+        )
       })
     })
 

--- a/test/internal/modules/billing/lib/mappers.js
+++ b/test/internal/modules/billing/lib/mappers.js
@@ -265,7 +265,7 @@ experiment('modules/billing/lib/mappers', () => {
 
   experiment('.mapInvoiceLicence', () => {
     experiment('for the first invoice licence', () => {
-      const [invoiceLicence] = invoice.invoiceLicences
+      const invoiceLicence = invoice.invoiceLicences[0]
 
       beforeEach(async () => {
         result = mappers.mapInvoiceLicence(batch, invoice, invoiceLicence)
@@ -298,13 +298,13 @@ experiment('modules/billing/lib/mappers', () => {
       })
 
       test('the first transaction is mapped correctly', async () => {
-        const [transaction] = result.transactions
+        const transaction = result.transactions[0]
         const keys = ['value', 'chargePeriod', 'chargeElement', 'volume', 'billingVolume', 'isMinimumCharge']
         expect(pick(transaction, keys)).to.equal(pick(invoiceLicence.transactions[0], keys))
       })
 
       test('the first transaction agreements are mapped correctly', async () => {
-        const [{ agreements }] = result.transactions
+        const { agreements } = result.transactions[0]
         expect(agreements).to.equal([
           {
             code: 'S127',
@@ -314,19 +314,19 @@ experiment('modules/billing/lib/mappers', () => {
       })
 
       test('the second transaction is mapped correctly', async () => {
-        const [, transaction] = result.transactions
+        const transaction = result.transactions[1]
         const keys = ['value', 'chargePeriod', 'chargeElement', 'volume', 'billingVolume', 'isMinimumCharge']
         expect(pick(transaction, keys)).to.equal(pick(invoiceLicence.transactions[1], keys))
       })
 
       test('the second transaction agreements are an empty array', async () => {
-        const [, { agreements }] = result.transactions
+        const { agreements } = result.transactions[1]
         expect(agreements).to.equal([])
       })
     })
 
     experiment('when the invoice is a rebilling invoice', () => {
-      const [invoiceLicence] = invoice.invoiceLicences
+      const invoiceLicence = invoice.invoiceLicences[0]
 
       beforeEach(async () => {
         result = mappers.mapInvoiceLicence(batch, {
@@ -341,7 +341,7 @@ experiment('modules/billing/lib/mappers', () => {
     })
 
     experiment('when the batch is not ready', () => {
-      const [invoiceLicence] = invoice.invoiceLicences
+      const invoiceLicence = invoice.invoiceLicences[0]
 
       beforeEach(async () => {
         result = mappers.mapInvoiceLicence({
@@ -356,7 +356,7 @@ experiment('modules/billing/lib/mappers', () => {
     })
 
     experiment('when the invoice has only 1 licence', () => {
-      const [invoiceLicence] = invoice.invoiceLicences
+      const invoiceLicence = invoice.invoiceLicences[0]
 
       beforeEach(async () => {
         const invoiceWithSingleLicence = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3753

When viewing the transactions as part of an annual bill run for SRoC, there is a section for each transaction showing charge period, charge reference etc.

If there is a TPT agreement, this should be shown in the Adjustments section. But it is not being displayed.