### PR TITLE
Correctly set NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,13 +24,20 @@ TEST_MODE=
 
 BASE_URL=
 GOOGLE_ANALYTICS_PROPERTY_ID=
-NODE_ENV=local
 
 REDIS_HOST=
 REDIS_PORT=
 REDIS_PASSWORD=
 
 ALLOW_CHARGE_VERSION_UPLOADS=
+
+# TODO: When NODE_ENV is 'test' the previous team would often set `lazyConnect` in the ioRedis connection config to
+# 'true'. It's not always the case though and things seem fine?? So, see if we can go without it (less complexity) else
+# try and figure out why its needed when testing (nothing so far when Googling)
+# From the docs
+# By default, When a new Redis instance is created, it will connect to Redis server automatically. If you want to keep
+# disconnected until a command is called, you can pass the lazyConnect option to the constructor
+LAZY_REDIS=true
 
 ENABLE_DELETE_ALL_BILLING_DATA_FEATURE=
 

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ REDIS_PASSWORD=
 
 ALLOW_CHARGE_VERSION_UPLOADS=
 
+NODE_ENV=production
+ENVIRONMENT=pre
+
 # TODO: When NODE_ENV is 'test' the previous team would often set `lazyConnect` in the ioRedis connection config to
 # 'true'. It's not always the case though and things seem fine?? So, see if we can go without it (less complexity) else
 # try and figure out why its needed when testing (nothing so far when Googling)

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const testMode = parseInt(process.env.TEST_MODE) === 1
 const isLocal = process.env.NODE_ENV === 'local'
 

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -6,6 +6,7 @@ const testMode = parseInt(process.env.TEST_MODE) === 1
 
 const environment = process.env.ENVIRONMENT
 const isLocal = environment === 'local'
+const isProduction = environment === 'prd'
 
 const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
@@ -67,7 +68,7 @@ module.exports = {
     application: 'water_vml'
   },
 
-  isLocal,
+
 
   jwt: {
     token: process.env.JWT_TOKEN,
@@ -107,6 +108,9 @@ module.exports = {
   },
 
   testMode,
+  environment,
+  isLocal,
+  isProduction,
 
   // Configured to last for 5 days but will be reset on sign in and
   // sign out meaning that the session lasts for as long as the user's

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const testMode = parseInt(process.env.TEST_MODE) === 1
 const isLocal = process.env.NODE_ENV === 'local'
 const isTest = process.env.NODE_ENV === 'test'

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -68,8 +68,6 @@ module.exports = {
     application: 'water_vml'
   },
 
-
-
   jwt: {
     token: process.env.JWT_TOKEN,
     key: process.env.JWT_SECRET,

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -1,12 +1,14 @@
 'use strict'
 
+const { withQueryStringSubset } = require('./lib/url')
+
 const testMode = parseInt(process.env.TEST_MODE) === 1
-const isLocal = process.env.NODE_ENV === 'local'
+
+const environment = process.env.ENVIRONMENT
+const isLocal = environment === 'local'
 
 const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
-
-const { withQueryStringSubset } = require('./lib/url')
 
 module.exports = {
 

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -1,6 +1,9 @@
 const testMode = parseInt(process.env.TEST_MODE) === 1
 const isLocal = process.env.NODE_ENV === 'local'
-const isTest = process.env.NODE_ENV === 'test'
+
+const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
+const isRedisLazy = !!process.env.LAZY_REDIS
+
 const { withQueryStringSubset } = require('./lib/url')
 
 module.exports = {
@@ -123,8 +126,8 @@ module.exports = {
     host: process.env.REDIS_HOST || '127.0.0.1',
     port: process.env.REDIS_PORT || 6379,
     password: process.env.REDIS_PASSWORD || '',
-    ...!isLocal && { tls: {} },
-    db: 0,
-    lazyConnect: isTest
+    ...(isTlsConnection) && { tls: {} },
+    db: process.env.NODE_ENV === 'test' ? 5 : 0,
+    lazyConnect: isRedisLazy
   }
 }

--- a/src/external/lib/view-engine/index.js
+++ b/src/external/lib/view-engine/index.js
@@ -1,4 +1,6 @@
 const nunjucksEngine = require('./nunjucks')
+
+const config = require('../../config')
 const defaultContext = require('shared/view/default-context')
 
 module.exports = {
@@ -7,6 +9,6 @@ module.exports = {
   },
   path: './src/external/views',
   context: defaultContext,
-  isCached: process.env.NODE_ENV === 'production',
+  isCached: config.isProduction,
   defaultExtension: 'njk'
 }

--- a/src/external/lib/view.js
+++ b/src/external/lib/view.js
@@ -73,7 +73,7 @@ function viewContextDefaults (request) {
 
   viewContext.tracking = getTracking(request.defra)
 
-  viewContext.env = process.env.NODE_ENV
+  viewContext.env = config.environment
   viewContext.crownCopyrightMessage = '© Crown copyright'
   viewContext.surveyType = getSurveyType(viewContext.isAuthenticated)
 

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -4,8 +4,10 @@ const { get } = require('lodash')
 const testMode = parseInt(process.env.TEST_MODE) === 1
 
 const isLocal = process.env.NODE_ENV === 'local'
-const isTest = process.env.NODE_ENV === 'test'
 const isProduction = process.env.NODE_ENV === 'production'
+
+const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
+const isRedisLazy = !!process.env.LAZY_REDIS
 
 const crmUri = process.env.CRM_URI || 'http://127.0.0.1:8002/crm/1.0'
 const srocStartDate = new Date('2022-04-01')
@@ -140,9 +142,9 @@ module.exports = {
     host: process.env.REDIS_HOST || '127.0.0.1',
     port: process.env.REDIS_PORT || 6379,
     password: process.env.REDIS_PASSWORD || '',
-    ...!isLocal && { tls: {} },
-    db: 1,
-    lazyConnect: isTest
+    ...(isTlsConnection) && { tls: {} },
+    db: process.env.NODE_ENV === 'test' ? 6 : 1,
+    lazyConnect: isRedisLazy
   },
   isSrocLive,
   srocStartDate,

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -75,8 +75,6 @@ module.exports = {
     application: 'water_admin'
   },
 
-  isLocal,
-
   jwt: {
     key: process.env.JWT_SECRET,
     verifyOptions: { algorithms: ['HS256'] },
@@ -116,6 +114,9 @@ module.exports = {
   },
 
   testMode,
+  environment,
+  isLocal,
+  isProduction,
 
   // Configured to last 5 days but will be reset on sign in and
   // sign out meaning that the session lasts for as long as the user's

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -1,20 +1,22 @@
 'use strict'
 
 const { get } = require('lodash')
+
 const testMode = parseInt(process.env.TEST_MODE) === 1
 
-const isLocal = process.env.NODE_ENV === 'local'
-const isProduction = process.env.NODE_ENV === 'production'
+const environment = process.env.ENVIRONMENT
+const isLocal = environment === 'local'
+const isProduction = environment === 'prd'
 
 const isTlsConnection = (process.env.REDIS_HOST || '').includes('aws')
 const isRedisLazy = !!process.env.LAZY_REDIS
 
 const crmUri = process.env.CRM_URI || 'http://127.0.0.1:8002/crm/1.0'
+
 const srocStartDate = new Date('2022-04-01')
+const isSrocLive = new Date() >= srocStartDate || !isProduction
 
 const { internal } = require('./lib/constants').scope
-const isSrocLive = new Date() >= srocStartDate ||
-  ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
 
 module.exports = {
 

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -1,6 +1,5 @@
 'use strict'
 
-require('dotenv').config()
 const { get } = require('lodash')
 const testMode = parseInt(process.env.TEST_MODE) === 1
 

--- a/src/internal/lib/view-engine/index.js
+++ b/src/internal/lib/view-engine/index.js
@@ -1,4 +1,6 @@
 const nunjucksEngine = require('./nunjucks')
+
+const config = require('../../config')
 const defaultContext = require('shared/view/default-context')
 
 module.exports = {
@@ -7,6 +9,6 @@ module.exports = {
   },
   path: './src/internal/views',
   context: defaultContext,
-  isCached: process.env.NODE_ENV === 'production',
+  isCached: config.isProduction,
   defaultExtension: 'njk'
 }

--- a/src/internal/lib/view.js
+++ b/src/internal/lib/view.js
@@ -69,7 +69,7 @@ function viewContextDefaults (request) {
 
   viewContext.tracking = getTracking(request.defra)
 
-  viewContext.env = process.env.NODE_ENV
+  viewContext.env = config.environment
   viewContext.crownCopyrightMessage = '© Crown copyright'
   viewContext.surveyType = getSurveyType(viewContext.isAuthenticated)
 

--- a/src/shared/plugins/acceptance-tests-proxy/routes.js
+++ b/src/shared/plugins/acceptance-tests-proxy/routes.js
@@ -1,10 +1,10 @@
-const controller = require('./controller')
+'use strict'
 
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
+const controller = require('./controller')
 
 const routes = []
 
-if (isAcceptanceTestTarget) {
+if (process.env.ENVIRONMENT !== 'prd') {
   routes.push({
     method: 'POST',
     path: '/acceptance-tests/{tail*}',

--- a/src/shared/plugins/cookie-message/index.js
+++ b/src/shared/plugins/cookie-message/index.js
@@ -125,7 +125,7 @@ function setCookiePreferences (isAnalyticsAccepted) {
  * @returns {Object}
  */
 const getCookieOptions = () => ({
-  isSecure: process.env.NODE_ENV !== 'local',
+  isSecure: process.env.ENVIRONMENT !== 'local',
   isHttpOnly: true,
   ttl: 365 * 24 * 60 * 60 * 1000,
   isSameSite: 'Lax'

--- a/test/shared/plugins/cookie-message/index.js
+++ b/test/shared/plugins/cookie-message/index.js
@@ -38,7 +38,7 @@ experiment('plugins/cookie-message/index', () => {
       state: {}
     }
 
-    sandbox.stub(process.env, 'ENVIRONMENT').value('dev')
+    sandbox.stub(process, 'env').value({ ENVIRONMENT: 'dev' })
   })
   afterEach(async () => {
     sandbox.restore()

--- a/test/shared/plugins/cookie-message/index.js
+++ b/test/shared/plugins/cookie-message/index.js
@@ -38,7 +38,7 @@ experiment('plugins/cookie-message/index', () => {
       state: {}
     }
 
-    sandbox.stub(process.env, 'NODE_ENV').value('dev')
+    sandbox.stub(process.env, 'ENVIRONMENT').value('dev')
   })
   afterEach(async () => {
     sandbox.restore()


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/43

We are currently using `NODE_ENV` incorrectly; we set it to be the name of the specific environment (eg. `local`, `qa` etc.) when it should be more like the _type_ of environment (e.g. is it a dev environment, a production environment, etc.)

This means that tools like pm2 aren't correctly picking up that we are running in a dev-like or prod-like environment and configuring accordingly.

We, therefore, change how we use `NODE_ENV` to be the type of environment, with a separate `ENVIRONMENT` env var to set the actual environment (eg. `tst`, `pre` etc.)