### PR TITLE
Fix licence returns pagination

### DIFF
--- a/src/external/views/nunjucks/returns/licence.njk
+++ b/src/external/views/nunjucks/returns/licence.njk
@@ -25,7 +25,7 @@
   {% else %}
     <p>No returns found.</p>
   {% endif %}
-  {{ paginate(pagination, 'paginationUrl') }}
+  {{ paginate(pagination, paginationUrl) }}
 </div>
 
 {% endblock %}

--- a/src/internal/views/nunjucks/returns/licence.njk
+++ b/src/internal/views/nunjucks/returns/licence.njk
@@ -14,7 +14,7 @@
   {% else %}
     <p>No returns found.</p>
   {% endif %}
-  {{ paginate(pagination, 'paginationUrl') }}
+  {{ paginate(pagination, paginationUrl) }}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3408

Here we have fixed a bug where the licence returns page was throwing an error when it got to the second page. This was caused by the next page and previous page link being passed a string rather then a varaible. We noticed the external returns page has the same bug (but unreported) so we have fixed this as well, as it was the same issue.