### PR TITLE
Stop passing err to logger.error

### DIFF
--- a/server-external.js
+++ b/server-external.js
@@ -88,14 +88,14 @@ async function start () {
 
     server.log(['info'], `Server started on ${server.info.uri} port ${server.info.port}`)
   } catch (err) {
-    logger.error('Failed to start server', err)
+    logger.error('Failed to start server', err.stack)
   }
 
   return server
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/server-internal.js
+++ b/server-internal.js
@@ -109,14 +109,14 @@ async function start () {
 
     server.log(['info'], `Server started on ${server.info.uri} port ${server.info.port}`)
   } catch (err) {
-    logger.error('Failed to start server', err)
+    logger.error('Failed to start server', err.stack)
   }
 
   return server
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/src/external/lib/connectors/services/water/NotificationsApiClient.js
+++ b/src/external/lib/connectors/services/water/NotificationsApiClient.js
@@ -42,7 +42,7 @@ class NotificationsApiClient extends SharedNotificationsApiClient {
     try {
       await this.sendNotifyMessage(messageRef, email, personalisation)
     } catch (err) {
-      this.logger.error('Error sending access notification', err)
+      this.logger.error('Error sending access notification', err.stack)
       return err
     };
   }

--- a/src/external/modules/manage-licences/controller.js
+++ b/src/external/modules/manage-licences/controller.js
@@ -160,7 +160,7 @@ async function postAddAccess (request, h) {
 
     return h.view('nunjucks/manage-licences/add-access-success', viewContext)
   } catch (err) {
-    logger.errorWithJourney('Post add access error', err, request)
+    logger.errorWithJourney('Post add access error', err.stack, request)
     throw err
   }
 }

--- a/src/internal/modules/abstraction-reform/lib/map-condition.js
+++ b/src/internal/modules/abstraction-reform/lib/map-condition.js
@@ -18,7 +18,7 @@ const mapConditionText = (condition) => {
   if (!conditionTitle) {
     const message = 'Could not find condition title'
     const error = new Error(message)
-    logger.error(message, error, condition)
+    logger.error(message, error.stack, condition)
     throw error
   }
 

--- a/src/internal/modules/abstraction-reform/lib/map-condition.js
+++ b/src/internal/modules/abstraction-reform/lib/map-condition.js
@@ -18,7 +18,7 @@ const mapConditionText = (condition) => {
   if (!conditionTitle) {
     const message = 'Could not find condition title'
     const error = new Error(message)
-    logger.error(message, error.stack, condition)
+    logger.error(message, error, condition)
     throw error
   }
 

--- a/src/internal/modules/billing-accounts/controllers/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/controllers/select-billing-account.js
@@ -273,7 +273,7 @@ const postCheckAnswers = async (request, h) => {
     const { redirectPath } = session.merge(request, key, { data })
     return h.redirect(redirectPath)
   } catch (err) {
-    logger.error('Error saving billing account', err)
+    logger.error('Error saving billing account', err.stack)
     throw err
   }
 }

--- a/src/internal/modules/service-status/controller.js
+++ b/src/internal/modules/service-status/controller.js
@@ -24,7 +24,7 @@ const getRedisCacheStatus = async (redisConfig, logger) => {
       result = 'Connected'
     }
   } catch (err) {
-    logger.error('Cache not connected', err)
+    logger.error('Cache not connected', err.stack)
   }
 
   return result

--- a/src/internal/modules/waiting/controller.js
+++ b/src/internal/modules/waiting/controller.js
@@ -52,7 +52,7 @@ const getWaiting = async (request, h) => {
 
   if (error) {
     const message = 'Unknown event type'
-    logger.error(message, error, { params: event })
+    logger.error(message, error.stack, { params: event })
     throw new Error('Unknown event type')
   }
   throwIfError(error)

--- a/src/shared/lib/connectors/services/water/NotificationsApiClient.js
+++ b/src/shared/lib/connectors/services/water/NotificationsApiClient.js
@@ -42,7 +42,7 @@ class NotificationsApiClient extends APIClient {
       const response = await serviceRequest.post(url, { body })
       return response.body
     } catch (err) {
-      this.logger.error('Error sending notify message', { error: err })
+      this.logger.error('Error sending notify message', { error: err.stack })
       return err
     };
   }

--- a/src/shared/lib/logger-factory.js
+++ b/src/shared/lib/logger-factory.js
@@ -13,7 +13,7 @@ const create = config => {
 
     const paramsToLog = Object.assign(params, userJourney, { requestDetails })
 
-    logger.error(msg, error, paramsToLog)
+    logger.error(msg, error.stack, paramsToLog)
   }
 
   return logger

--- a/test/external/lib/connectors/services/water/NotificationsApiClient.test.js
+++ b/test/external/lib/connectors/services/water/NotificationsApiClient.test.js
@@ -244,9 +244,10 @@ experiment('external/NotificationsApiClient', () => {
 
     experiment('when there is an error', () => {
       let result
+      const error = new Error('oops')
 
       beforeEach(async () => {
-        client.sendNotifyMessage.rejects({ error: 'some-error' })
+        client.sendNotifyMessage.rejects(error)
         result = await client.sendAccessNotification({
           email: 'recipient@example.com',
           sender: 'sender@example.com'
@@ -256,11 +257,11 @@ experiment('external/NotificationsApiClient', () => {
       test('the error is logged', async () => {
         const [msg, err] = logger.error.lastCall.args
         expect(msg).to.equal('Error sending access notification')
-        expect(err).to.equal({ error: 'some-error' })
+        expect(err).to.equal(error.stack)
       })
 
       test('the error is returned', async () => {
-        expect(result).to.equal({ error: 'some-error' })
+        expect(result).to.equal(error)
       })
     })
   })

--- a/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
+++ b/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
@@ -796,7 +796,7 @@ experiment('internal/modules/billing-accounts/controllers/select-billing-account
     })
 
     experiment('when there is an error', () => {
-      const ERROR = new Error('oops')
+      const error = new Error('oops')
 
       beforeEach(async () => {
         request = createPostRequest({
@@ -804,14 +804,14 @@ experiment('internal/modules/billing-accounts/controllers/select-billing-account
             csrf_token: CSRF_TOKEN
           }
         })
-        services.water.companies.postInvoiceAccount.rejects(ERROR)
+        services.water.companies.postInvoiceAccount.rejects(error)
       })
 
       test('the error is logged and rethrown', async () => {
         const func = () => controller.postCheckAnswers(request, h)
         await expect(func()).to.reject()
         expect(logger.error.calledWith(
-          'Error saving billing account', ERROR
+          'Error saving billing account', error.stack
         )).to.be.true()
       })
     })

--- a/test/shared/lib/logger-factory.test.js
+++ b/test/shared/lib/logger-factory.test.js
@@ -57,7 +57,7 @@ experiment('shared/lib/logger-factory', () => {
       const [msg, error] = logger.error.lastCall.args
 
       expect(msg).to.equal('message')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
     })
 
     test('errorWithJourney adds journey data when no extra error params are included', async () => {
@@ -67,7 +67,7 @@ experiment('shared/lib/logger-factory', () => {
       const [msg, error, params] = logger.error.lastCall.args
 
       expect(msg).to.equal('message')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
       expect(params.userJourney).to.equal({
         'user-agent': 'safari'
       })
@@ -85,7 +85,7 @@ experiment('shared/lib/logger-factory', () => {
       const [msg, error, parameters] = logger.error.lastCall.args
 
       expect(msg).to.equal('message')
-      expect(error).to.equal(err)
+      expect(error).to.equal(err.stack)
       expect(parameters).to.equal({
         userJourney: { 'user-agent': 'safari' },
         numbers: { one: 1 },


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.