### PR TITLE
Add new /health/info endpoint

### DIFF
--- a/src/external/modules/routes.js
+++ b/src/external/modules/routes.js
@@ -1,3 +1,6 @@
+'use strict'
+
+// Internal only routes
 const addLicencesRoutes = require('./add-licences/routes')
 const coreRoutes = require('./core/routes')
 const contentRoutes = require('./content/routes')
@@ -10,6 +13,9 @@ const accountRoutes = require('./account/routes')
 const notificationRoutes = require('./notifications/routes')
 const notifyRoutes = require('./notify/routes')
 
+// Shared routes
+const healthRoutes = require('../../shared/modules/health/routes')
+
 module.exports = [
   ...Object.values(addLicencesRoutes),
   ...Object.values(coreRoutes),
@@ -21,5 +27,6 @@ module.exports = [
   ...Object.values(companySelector),
   ...Object.values(notificationRoutes),
   ...Object.values(accountRoutes),
-  ...Object.values(notifyRoutes)
+  ...Object.values(notifyRoutes),
+  ...Object.values(healthRoutes)
 ]

--- a/src/internal/modules/routes.js
+++ b/src/internal/modules/routes.js
@@ -1,3 +1,6 @@
+'use strict'
+
+// External only routes
 const coreRoutes = require('./core/routes')
 const contentRoutes = require('./content/routes')
 const notificationsRoutes = require('./notifications/routes')
@@ -18,11 +21,14 @@ const chargeInformationRoutes = require('./charge-information/routes')
 const chargeInformationUploadRoutes = require('./charge-information-upload/routes')
 const agreementsRoutes = require('./agreements/routes')
 const reportingRoutes = require('./reporting/routes')
-const kpiReporting = require('../../internal/modules/kpi-reporting/routes')
 const viewLicences = require('./view-licences/routes')
 const gaugingStations = require('./gauging-stations/routes')
 const customers = require('./customers/routes')
 const notes = require('./notes/routes')
+
+// Shared routes
+const healthRoutes = require('../../shared/modules/health/routes')
+const kpiReporting = require('../../internal/modules/kpi-reporting/routes')
 
 module.exports = [
   ...Object.values(coreRoutes),
@@ -50,5 +56,6 @@ module.exports = [
   ...Object.values(viewLicences),
   ...Object.values(gaugingStations),
   ...Object.values(customers),
-  ...Object.values(notes)
+  ...Object.values(notes),
+  ...Object.values(healthRoutes)
 ]

--- a/src/shared/modules/health/controller.js
+++ b/src/shared/modules/health/controller.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
+const util = require('util')
+const exec = util.promisify(require('child_process').exec)
+
+const pkg = require('../../../../package.json')
+
+const _getCommitHash = async () => {
+  try {
+    const { stdout, stderr } = await exec('git rev-parse HEAD')
+    return stderr ? `ERROR: ${stderr}` : stdout.replace('\n', '')
+  } catch (error) {
+    return `ERROR: ${error.message}`
+  }
+}
+
+const getInfo = async () => {
+  return {
+    version: pkg.version,
+    commit: await _getCommitHash()
+  }
+}
+
+exports.getInfo = getInfo

--- a/src/shared/modules/health/routes.js
+++ b/src/shared/modules/health/routes.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const controller = require('./controller')
+
+module.exports = {
+  getInfo: {
+    method: 'GET',
+    path: '/health/info',
+    handler: controller.getInfo,
+    config: {
+      auth: false
+    }
+  }
+}

--- a/test/shared/modules/health/controller.test.js
+++ b/test/shared/modules/health/controller.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+// Test framework dependencies
+const { test, experiment, before } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+
+// Test helpers
+const pkg = require('../../../../package.json')
+
+// Thing under test
+const controller = require('../../../../src/shared/modules/health/controller')
+
+experiment('modules/health/controller', () => {
+  experiment('.getInfo', () => {
+    let info
+
+    before(async () => {
+      info = await controller.getInfo()
+    })
+
+    test('contains the expected water service version', async () => {
+      expect(info.version).to.equal(pkg.version)
+    })
+
+    test('contains the git commit hash', async () => {
+      expect(info.commit).to.exist()
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/54

This supports the new service-status page we're building in the [water-abstraction-system repo](https://github.com/DEFRA/water-abstraction-system).

We want to be able to show both the version and commit hash for each service on that page. The existing `/status` page does include the `package.json` version. But that endpoint is also used for the AWS load balancer health check so is heavily hit. We don't want to make it do more work getting the commit hash.

Instead, we add a new `/health/` path and a new `/info` endpoint to return both the version and commit hash.