### PR TITLE
Add feature flag to fix verification code appearing in production environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,9 @@ ENVIRONMENT=pre
 # disconnected until a command is called, you can pass the lazyConnect option to the constructor
 LAZY_REDIS=true
 
+# Feature toggles
 ENABLE_DELETE_ALL_BILLING_DATA_FEATURE=
+SHOW_VERIFICATION_CODE_FEATURE=
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/src/external/config.js
+++ b/src/external/config.js
@@ -135,5 +135,9 @@ module.exports = {
     ...(isTlsConnection) && { tls: {} },
     db: process.env.NODE_ENV === 'test' ? 5 : 0,
     lazyConnect: isRedisLazy
+  },
+
+  featureToggles: {
+    showVerificationCode: process.env.SHOW_VERIFICATION_CODE_FEATURE === 'true' && !isProduction
   }
 }

--- a/src/external/lib/view.js
+++ b/src/external/lib/view.js
@@ -80,6 +80,8 @@ function viewContextDefaults (request) {
   viewContext.hasMultipleCompanies = hasMultipleCompanies(request)
   viewContext.companyName = get(request, 'defra.companyName')
 
+  viewContext.showVerificationCode = config.featureToggles.showVerificationCode
+
   return viewContext
 }
 

--- a/src/external/views/nunjucks/add-licences/verification-sent.njk
+++ b/src/external/views/nunjucks/add-licences/verification-sent.njk
@@ -32,7 +32,7 @@
         <a href="/signout">Sign out</a>
       </p>
 
-      {%if isTestMode%}
+      {%if showVerificationCode%}
       <p>
         Your code is <code><b>{{ verification.verification_code }}</b></code>
       </p>

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -161,6 +161,7 @@ module.exports = {
     waterAbstractionAlerts: true,
     recalculateBills: true,
     allowChargeVersionUploads: (get(process.env, 'ALLOW_CHARGE_VERSION_UPLOADS') || '').toLowerCase() === 'true',
-    acceptanceTestsProxy: !isProduction
+    acceptanceTestsProxy: !isProduction,
+    showVerificationCode: process.env.SHOW_VERIFICATION_CODE_FEATURE === 'true' && !isProduction
   }
 }

--- a/src/internal/lib/view.js
+++ b/src/internal/lib/view.js
@@ -73,6 +73,8 @@ function viewContextDefaults (request) {
   viewContext.crownCopyrightMessage = '© Crown copyright'
   viewContext.surveyType = getSurveyType(viewContext.isAuthenticated)
 
+  viewContext.showVerificationCode = config.featureToggles.showVerificationCode
+
   return viewContext
 }
 

--- a/src/internal/views/nunjucks/add-licences/verification-sent.njk
+++ b/src/internal/views/nunjucks/add-licences/verification-sent.njk
@@ -32,7 +32,7 @@
         <a href="/signout">Sign out</a>
       </p>
 
-      {%if isTestMode%}
+      {%if showVerificationCode%}
       <p>
         Your code is <code><b>{{ verification.verification_code }}</b></code>
       </p>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3816

When registering a new account, the end of the process triggers a verification code being sent to the customer's postal address. In our test environments, we display this code on the page so the user can continue without needing to receive the code by post. However it's been reported that this code recently appeared to a user in the production environment. We therefore fix this defect.

We do this by creating a new feature flag, defined in `.env` as `SHOW_VERIFICATION_CODE_FEATURE`, which displays the code when set to `true` but with an additional check so it is only displayed in non-prod environments. We then swap out the previous use of the `TEST_MODE` env var for our new feature flag.