### PR TITLE
Fix request.logout() is undefined error

### DIFF
--- a/src/shared/plugins/auth/index.js
+++ b/src/shared/plugins/auth/index.js
@@ -25,7 +25,7 @@ const authPlugin = {
 
     // Attach methods to request
     server.ext({
-      type: 'onPreHandler',
+      type: 'onPreAuth',
       method: async (request, h) => {
         request.logIn = async (user) => {
           await options.signIn(request, user)

--- a/test/shared/lib/plugins/auth/index.test.js
+++ b/test/shared/lib/plugins/auth/index.test.js
@@ -50,7 +50,7 @@ experiment('Auth plugin', () => {
     test('a pre handler is registered on the server', async () => {
       expect(server.ext.callCount).to.equal(1)
       const [ext] = server.ext.lastCall.args
-      expect(ext.type).to.equal('onPreHandler')
+      expect(ext.type).to.equal('onPreAuth')
       expect(ext.method).to.be.a.function()
     })
 

--- a/test/shared/plugins/auth/index.test.js
+++ b/test/shared/plugins/auth/index.test.js
@@ -51,10 +51,10 @@ experiment('auth pluging', () => {
       expect(plugin.version).to.be.a.string()
     })
 
-    test('defines a register function with a preHandler', async () => {
+    test('defines a register function with a preAuth', async () => {
       plugin.register(server)
       const [{ type, method }] = server.ext.lastCall.args
-      expect(type).to.equal('onPreHandler')
+      expect(type).to.equal('onPreAuth')
       expect(method).to.be.a.function()
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3815

An external user reported seeing our SilverLine WAF error page. web-ops tracked this down to `Illegal HTTP status in response`. Basically, the service threw an unhandled error which caused it to return a http 500 response code. Responses like this are blocked because they typically leak information about the site.

We tracked down the issue being that the app was rejecting the request due to an invalid CSRF token (why, we'll never know!) That was then causing the error plugin to fire. In the event of a CRSF issue the error plugin will immediately log the user out using `request.logOut()`.

The problem is that function is attached to the Hapi request object in the auth plugin. It is also attached to the Hapi `onPreHandler` extension point, but registered _after_ the CSRF plugin. Hapi runs plugins in the order they are registered, which is why we get a situation where the CRSF logic and subsequent error handling is running before the auth plugin has had a chance to decorate the request object.

This change fixes the issue.