### PR TITLE
Remove pm2 watch config from ecosystem file

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -2,46 +2,16 @@
   "apps": [
     {
       "name": "ui",
-      "ignore_watch": [
-        "coverage",
-        "data",
-        "govuk_modules",
-        "node_modules",
-        "src/internal",
-        "test",
-        "temp",
-        "cypress",
-        ".git"
-      ],
       "script": "server-external.js",
-      "env": {
-        "watch": false
-      },
       "env_production": {
-        "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"
       }
     },
     {
       "name": "ui-internal",
-      "ignore_watch": [
-        "coverage",
-        "data",
-        "govuk_modules",
-        "node_modules",
-        "src/external",
-        "test",
-        "temp",
-        "cypress",
-        ".git"
-      ],
       "script": "server-internal.js",
-      "env": {
-        "watch": false
-      },
       "env_production": {
-        "watch": false,
         "instances" : "max",
         "exec_mode" : "cluster"
       }


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/10

Here we have removed the watch config for pm2. This is due to using nodemon instead. Having both in the application is causing too many files to be registered, making it problematic to watch.