### PR TITLE
Autobuild assets after npm ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint:fix": "standard --fix",
     "sass": "gulp sass",
     "sass:watch": "gulp sass:watch",
-    "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"
+    "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md",
+    "postinstall": "gulp build"
   },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/64

To help simplify things in our new Docker-based build environment and to take advantage of something we learned on [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) this change adds a post-install step.

If we're running `npm ci` you can be sure we also want to build our assets (we certainly should be!)

So, with this change that will happen automatically. We've left the old script command there for now whilst we update our various environments. But once that's done we'll drop `"install-assets": "gulp build",` from `package.json`.