### PR TITLE
Fix server-common plugins

### DIFF
--- a/server-external.js
+++ b/server-external.js
@@ -14,7 +14,7 @@ const viewEngine = require('./src/external/lib/view-engine/')
 const { logger } = require('./src/external/logger')
 const connectors = require('./src/external/lib/connectors/services')
 
-const common = createPlugins(config, logger, connectors)
+const common = createPlugins(config, connectors)
 
 // Configure auth plugin
 const AuthConfig = require('external/lib/AuthConfig')


### PR DESCRIPTION
Spotted by our QA when some of the Cypress tests were no longer passing.

After lots of digging we tracked down the issue to a recent change where we [Removed hapi good - added hapi-pino](https://github.com/DEFRA/water-abstraction-ui/pull/2252).

The change caused a different argument order which we never spotted elsewhere and the existing tests didn't pick it up.

This change resolves the issue.