### PR TITLE
Trigger SROC supplementary bill run in parallel

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -1,4 +1,4 @@
-const config = require('../../../config')
+'use strict'
 
 /**
  * Gets the correct route for the specified batch depending on its
@@ -12,12 +12,12 @@ const config = require('../../../config')
  * @return {String} the link
  */
 const getBillingBatchRoute = (batch, opts = {}) => {
-  const { id, type, scheme, region } = batch
+  const { id } = batch
 
   const routeMap = new Map()
     .set('processing', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
     .set('sending', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
-    .set('ready', _determineReadyUrl(opts, id, type, scheme, region))
+    .set('ready', opts.invoiceId ? `/billing/batch/${id}/invoice/${opts.invoiceId}` : `/billing/batch/${id}/summary`)
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
 
@@ -28,18 +28,6 @@ const getBillingBatchRoute = (batch, opts = {}) => {
   }
 
   return routeMap.get(batch.status)
-}
-
-function _determineReadyUrl (opts, id, type, scheme, region) {
-  if (opts.invoiceId) {
-    return `/billing/batch/${id}/invoice/${opts.invoiceId}`
-  }
-
-  if (config.featureToggles.triggerSrocSupplementary && type === 'supplementary' && scheme === 'alcs') {
-    return `/billing/batch/sroc/${region.id}`
-  }
-
-  return `/billing/batch/${id}/summary`
 }
 
 const getTwoPartTariffLicenceReviewRoute = (batch, invoiceLicenceId) =>

--- a/src/internal/modules/billing/routes/create-bill-run.js
+++ b/src/internal/modules/billing/routes/create-bill-run.js
@@ -83,21 +83,6 @@ module.exports = {
     }
   },
 
-  getBillingBatchSroc: {
-    method: 'GET',
-    path: '/billing/batch/sroc/{region}',
-    handler: controller.getBillingBatchSroc,
-    config: {
-      auth: { scope: allowedScopes },
-      description: 'get handler for creating an sroc billing batch',
-      validate: {
-        params: Joi.object().keys({
-          region: Joi.string().uuid()
-        })
-      }
-    }
-  },
-
   getBillingBatchExists: {
     method: 'GET',
     path: '/billing/batch/{batchId}/exists',

--- a/test/internal/modules/billing/controllers/create-bill-run.test.js
+++ b/test/internal/modules/billing/controllers/create-bill-run.test.js
@@ -101,14 +101,6 @@ const batchInvoicesResult = [
     isWaterUndertaker: true
   }]
 
-const createdBillRun = {
-  id: 'f561990b-b29a-42f4-b71a-398c52339f78',
-  region: '07ae7f3a-2677-4102-b352-cc006828948c',
-  scheme: 'sroc',
-  batchType: 'supplementary',
-  status: 'ready'
-}
-
 const secondHeader = sandbox.stub()
 const header = sandbox.stub().returns({ header: secondHeader })
 
@@ -161,8 +153,6 @@ experiment('internal/modules/billing/controllers/create-bill-run', () => {
 
     sandbox.stub(services.water.billingBatches, 'cancelBatch').resolves()
     sandbox.stub(services.water.billingBatches, 'approveBatch').resolves()
-
-    sandbox.stub(services.system.billRuns, 'createBillRun').resolves(createdBillRun)
 
     sandbox.stub(batchService, 'getBatchList')
     sandbox.stub(batchService, 'getBatchInvoice').resolves({ id: 'invoice-account-id', accountNumber: 'A12345678A' })
@@ -762,15 +752,6 @@ experiment('internal/modules/billing/controllers/create-bill-run', () => {
         const [url] = h.redirect.lastCall.args
         expect(url).to.equal(`/billing/batch/financial-year/${request.params.billingType}/${request.params.season}/${request.params.region}`)
       })
-    })
-  })
-
-  experiment('.getBillingBatchSroc', () => {
-    test('it redirects to the summary page', async () => {
-      await controller.getBillingBatchSroc(request, h)
-
-      const [url] = h.redirect.lastCall.args
-      expect(url).to.equal('/billing/batch/f561990b-b29a-42f4-b71a-398c52339f78/summary')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3828

Prior to this change, we were triggering the SROC supplementary bill run when the PRESROC reported back that it was finished. The mechanism for doing this is a spinner page that polls the bill run status. When it gets out of `processing`, we're go for SROC!

But we've quickly found relying on this existing feature is flaky at best and introduces a whole bunch of other issues. Also, it doesn't work with the view bill runs screen. There is nothing to stop a user from quitting the spinner page and coming back to view bill runs. They'll see PRESROC there, but not the SROC. The existing functionality treats creation and processing separately so we should do the same for SROC.

So, this change updates the UI to trigger the creation of the SROC bill run at the same time it triggers the creation of the PRESROC. Processing the SROC bill run will still happen after the PRESROC one has been completed but those changes will happen in [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) and [water-abstraction-system](http://github.com/DEFRA/water-abstraction-system).