### PR TITLE
Label empty bill runs as `EMPTY`

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -20,11 +20,11 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     .set('ready', opts.invoiceId ? `/billing/batch/${id}/invoice/${opts.invoiceId}` : `/billing/batch/${id}/summary`)
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
+    .set('empty', `/billing/batch/${id}/empty`)
 
   if (opts.isErrorRoutesIncluded) {
     routeMap
       .set('error', `/billing/batch/${id}/processing`)
-      .set('empty', `/billing/batch/${id}/empty`)
   }
 
   return routeMap.get(batch.status)

--- a/src/shared/view/nunjucks/filters/batch-badge.js
+++ b/src/shared/view/nunjucks/filters/batch-badge.js
@@ -7,7 +7,7 @@ const badge = {
   sent: { status: 'success', text: 'Sent' },
   review: { status: 'todo', text: 'Review' },
   error: { status: 'error', text: 'Error' },
-  empty: { status: 'error', text: 'Error' }
+  empty: { status: 'inactive', text: 'Empty' }
 }
 
 exports.batchBadge = (batch, isLarge) => ({

--- a/test/shared/view/nunjucks/filters/batch-badge.test.js
+++ b/test/shared/view/nunjucks/filters/batch-badge.test.js
@@ -102,12 +102,12 @@ experiment('batchBadge Nunjucks filter', () => {
       badge = batchBadge({ status: 'empty' })
     })
 
-    test('badge text is "Error"', async () => {
-      expect(badge.text).to.equal('Error')
+    test('badge text is "Empty"', async () => {
+      expect(badge.text).to.equal('Empty')
     })
 
-    test('badge status is error', async () => {
-      expect(badge.status).to.equal('error')
+    test('badge status is inactive', async () => {
+      expect(badge.status).to.equal('inactive')
     })
 
     test('badge is not large', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3874

When you run a bill run for a region and the service finds no applicable licences that need billing it directs you to an error page. The page tells you the reason is that the bill run is empty, so this fact is in the data somewhere!

What we and the users would ideally like to see is the bill run labelled as `EMPTY` in the view bill runs screen. As we'll have 2 distinct supplementary bill runs being generated each time it's important we can start distinguishing between those that have truly errored, and those where there was nothing to do.

<details>
<summary>Screenshot</summary>

<img width="976" alt="Screenshot 2023-01-19 at 09 52 42" src="https://user-images.githubusercontent.com/1789650/213414571-98747237-10e7-4a93-8f7b-26fc3cd3beac.png">

</details>
