### PR TITLE
Support new queued bill run status

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -21,6 +21,7 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
     .set('empty', `/billing/batch/${id}/empty`)
+    .set('queued', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
 
   if (opts.isErrorRoutesIncluded) {
     routeMap

--- a/src/internal/modules/billing/pre-handlers.js
+++ b/src/internal/modules/billing/pre-handlers.js
@@ -91,7 +91,7 @@ const checkBatchStatusIsReview = partialRight(checkBatchStatus, 'review')
 const checkBatchStatusIsReady = partialRight(checkBatchStatus, 'ready')
 
 const validBatchStatusSchema = Joi.array().min(1).required().items(
-  Joi.string().valid('processing', 'review', 'ready', 'error', 'empty', 'sent', 'sending')
+  Joi.string().valid('queued', 'processing', 'review', 'ready', 'error', 'empty', 'sent', 'sending')
 )
 
 /**

--- a/src/internal/modules/billing/routes/bill-run.js
+++ b/src/internal/modules/billing/routes/bill-run.js
@@ -293,7 +293,7 @@ const routes = {
     handler: controller.getBillingBatchProcessing,
     config: {
       app: {
-        validBatchStatuses: ['processing', 'error', 'sending']
+        validBatchStatuses: ['queued', 'processing', 'error', 'sending']
       },
       auth: { scope: allowedScopes },
       plugins: {

--- a/src/internal/views/nunjucks/billing/macros/batch-buttons.njk
+++ b/src/internal/views/nunjucks/billing/macros/batch-buttons.njk
@@ -23,7 +23,7 @@
 {% endmacro %}
 
 {% macro cancelStatusBatchButton(batch) %}
-  {% if batch.status in['processing'] %}
+  {% if batch.status in['queued', 'processing'] %}
     {{
     govukButton({
       text: "Cancel bill run",

--- a/src/shared/view/nunjucks/filters/batch-badge.js
+++ b/src/shared/view/nunjucks/filters/batch-badge.js
@@ -7,7 +7,8 @@ const badge = {
   sent: { status: 'success', text: 'Sent' },
   review: { status: 'todo', text: 'Review' },
   error: { status: 'error', text: 'Error' },
-  empty: { status: 'inactive', text: 'Empty' }
+  empty: { status: 'inactive', text: 'Empty' },
+  queued: { status: 'warning', text: 'Queued' }
 }
 
 exports.batchBadge = (batch, isLarge) => ({

--- a/test/internal/modules/billing/routes/bill-run.test.js
+++ b/test/internal/modules/billing/routes/bill-run.test.js
@@ -98,7 +98,7 @@ experiment('internal/modules/billing/routes', () => {
 
     test('redirects unless batch status is "processing" or "error"', async () => {
       const { validBatchStatuses } = routes.getBillingBatchProcessing.config.app
-      expect(validBatchStatuses).to.equal(['processing', 'error', 'sending'])
+      expect(validBatchStatuses).to.equal(['queued', 'processing', 'error', 'sending'])
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3877

When a supplementary bill run is started, we'll be creating both a PRESROC and SROC one at the same time.

The PRESROC one will then begin `processing` (labelled as BUILDING in the UI) whilst the SROC one is `queued` waiting to be processed.

At the moment though, all we can do is initialise the SROC bill run with a status of `processing` as that is all that is available to us. In the UI this will give the impression both are building when they're not.

We've added a new `queued` status to [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/pull/1965). This change updates the UI to add a new **QUEUED** badge and supports it.

<details>
<summary>Screenshot</summary>

<img width="984" alt="Screenshot 2023-01-23 at 11 30 01" src="https://user-images.githubusercontent.com/1789650/214029201-13b5c7d2-de33-427e-8996-d431b852b17c.png">

</details>