### PR TITLE
Add charge scheme annotation to bill runs page

### DIFF
--- a/src/internal/views/nunjucks/billing/batch-list.njk
+++ b/src/internal/views/nunjucks/billing/batch-list.njk
@@ -45,6 +45,10 @@
                   {% else %}
                     {{ batch.dateCreated | date }}
                   {% endif %}
+                  {% if batch.scheme === 'alcs' %}
+                    <br />
+                    <span class="govuk-body-s">Old charge scheme</span>
+                  {% endif %}
                 </td>
                 <td class="govuk-table__cell">{{ batch.region.displayName }}</td>
                 <td class="govuk-table__cell">{{ batch.batchType }}</td>

--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -473,7 +473,8 @@ experiment('internal/modules/billing/controller', () => {
             creditNoteCount: 2,
             invoiceCount: 12,
             netTotal: 4005,
-            externalId: 1234
+            externalId: 1234,
+            scheme: 'alcs'
           },
           {
             invoices: [],
@@ -499,7 +500,8 @@ experiment('internal/modules/billing/controller', () => {
             creditNoteCount: 5,
             invoiceCount: 3,
             netTotal: 4005,
-            externalId: 244
+            externalId: 244,
+            scheme: 'sroc'
           }
         ],
         pagination: {
@@ -524,11 +526,13 @@ experiment('internal/modules/billing/controller', () => {
       expect(batches[0].status).to.equal('processing')
       expect(batches[0].billCount).to.equal(14)
       expect(batches[0].link).to.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e1/processing?back=1')
+      expect(batches[0].scheme).to.equal('alcs')
       expect(batches[1].type).to.equal('Two-part tariff')
       expect(batches[1].region.name).to.equal('Midlands')
       expect(batches[1].status).to.equal('review')
       expect(batches[1].billCount).to.equal(8)
       expect(batches[1].link).to.be.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e2/two-part-tariff-review')
+      expect(batches[1].scheme).to.equal('sroc')
     })
 
     test('configures the expected view template', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3664

With the introduction of SRoC, when running a supplementary bill run, it's possible that the bill run could pick up pre-SRoC and SRoC transactions. SOP has a constraint where they can’t deal with pre and post SRoC charges on the same bill run. Therefore supplementary billing will be split across two bill runs if there are a mixture of pre and post SRoC transactions.

To help B&D distinguish between the two charging schemes, we will add an annotation to pre-SRoC bill runs on the bill runs page - the annotation will be 'old charge scheme'.