### PR TITLE
Add charge scheme to bill run view metadata

### DIFF
--- a/src/internal/views/nunjucks/billing/macros/batch-metadata.njk
+++ b/src/internal/views/nunjucks/billing/macros/batch-metadata.njk
@@ -18,6 +18,16 @@
       {% endif %}
       </dd>
     </div>
+    <div class="meta__row">
+      <dt class="meta__key">Charge scheme</dt>
+      <dd class="meta__value">
+      {% if batch.scheme == 'sroc' %}
+        Current
+      {% else %}
+        Old
+      {% endif %}
+      </dd>
+    </div>
     {% if invoice %}
     <div class="meta__row">
       <dt class="meta__key">Financial year</dt>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3869

B&D need to be able to identify if a bill run is pre-SRoC or SRoC. We do this by adding a `Charge scheme` field to the `batch-metadata.njk` template, which shows `Current` if the bill run scheme is `sroc` and `Old` if it's `alcs`.

Note that this template is a macro used by other templates and therefore will be displayed in other screens:
- `batch-creation-error.njk`
- `batch-invoice.njk`
- `batch-summary.njk`
- `batch-header.njk`

The calling controllers use `request.pre.batch` which is added by a prehandler calling `water-abstraction-service`; we therefore don't write any additional unit tests since we would be mocking the data returned by this anyway.