### PR TITLE
Add new error page for errored bill runs

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -3,7 +3,6 @@
 const { titleCase } = require('shared/lib/string-formatter')
 const { pluralize } = require('shared/lib/pluralize')
 const moment = require('moment')
-const Boom = require('@hapi/boom')
 const { get } = require('lodash')
 
 const { cancelOrConfirmBatchForm } = require('../forms/cancel-or-confirm-batch')

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -300,26 +300,22 @@ const postDeleteAllBillingData = async (request, h) => {
   return h.redirect(BATCH_LIST_ROUTE)
 }
 
-exports.getBillingBatchList = getBillingBatchList
-exports.getBillingBatchSummary = getBillingBatchSummary
-exports.getBillingBatchInvoice = getBillingBatchInvoice
-
-exports.getBillingBatchCancel = getBillingBatchCancel
-exports.postBillingBatchCancel = postBillingBatchCancel
-
-exports.getBillingBatchConfirm = getBillingBatchConfirm
-exports.postBillingBatchConfirm = postBillingBatchConfirm
-exports.getBillingBatchConfirmSuccess = getBillingBatchConfirmSuccess
-
-exports.getBillingBatchDeleteInvoice = getBillingBatchDeleteInvoice
-exports.postBillingBatchDeleteInvoice = postBillingBatchDeleteInvoice
-
-exports.getTransactionsCSV = getTransactionsCSV
-
-exports.getBillingBatchProcessing = getBillingBatchProcessing
-exports.getBillingBatchEmpty = getBillingBatchEmpty
-exports.getBillingBatchError = getBillingBatchError
-
-exports.postDeleteAllBillingData = postDeleteAllBillingData
-exports.getBillingBatchStatusToCancel = getBillingBatchStatusToCancel
-exports.postBillingBatchStatusToCancel = postBillingBatchStatusToCancel
+module.exports = {
+  getBillingBatchList,
+  getBillingBatchSummary,
+  getBillingBatchInvoice,
+  getBillingBatchCancel,
+  postBillingBatchCancel,
+  getBillingBatchConfirm,
+  postBillingBatchConfirm,
+  getBillingBatchConfirmSuccess,
+  getBillingBatchDeleteInvoice,
+  postBillingBatchDeleteInvoice,
+  getTransactionsCSV,
+  getBillingBatchProcessing,
+  getBillingBatchEmpty,
+  getBillingBatchError,
+  postDeleteAllBillingData,
+  getBillingBatchStatusToCancel,
+  postBillingBatchStatusToCancel
+}

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -218,20 +218,16 @@ const postBillingBatchDeleteInvoice = async (request, h) => {
 
 /**
  * Renders a 'waiting' page while the batch is processing.
- * If the batch is in error, responds with a 500 error page.
+ *
  * The redirectOnBatchStatus pre handler will have already redirected to the appropriate page
  * if the batch is processed.
+ *
  * @param {Object} request.pre.batch - billing batch loaded by pre handler
  * @param {Number} request.query.back - whether to render back button
  */
 const getBillingBatchProcessing = async (request, h) => {
   const { batch } = request.pre
   const back = !!request.query.back
-
-  // Render error page if batch has errored
-  if (batch.status === 'error') {
-    return Boom.badImplementation('Billing batch error')
-  }
 
   return h.view('nunjucks/billing/batch-processing', {
     batch,
@@ -268,8 +264,45 @@ const getBillingBatchError = async (request, h) => {
     ...request.view,
     pageTitle: getBillRunPageTitle(batch),
     batch,
-    back: BATCH_LIST_ROUTE
+    back: BATCH_LIST_ROUTE,
+    errorList: _errorList(batch.errorCode)
   })
+}
+
+const _errorList = (errorCode) => {
+  const error = { text: 'No error code was assigned. We have no further information at this time.' }
+
+  switch (errorCode) {
+    case 10:
+      error.text = 'Error when populating the charge versions.'
+      break
+    case 20:
+      error.text = 'Error when processing the charge versions.'
+      break
+    case 30:
+      error.text = 'Error when preparing the transactions.'
+      break
+    case 40:
+      error.text = 'Error when creating a charge.'
+      break
+    case 50:
+      error.text = 'Error when creating the Charging Module bill run.'
+      break
+    case 60:
+      error.text = 'Error when deleting an invoice.'
+      break
+    case 70:
+      error.text = 'Error when processing two-part tariff.'
+      break
+    case 80:
+      error.text = 'Error when getting the Charging Module bill run summary.'
+      break
+    case 90:
+      error.text = 'Error when re-billing a bill run.'
+      break
+  }
+
+  return [error]
 }
 
 /**

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -258,6 +258,21 @@ const getBillingBatchEmpty = async (request, h) => {
 }
 
 /**
+ * Renders an error page if the batch is errored - i.e. no transactions
+ * @param {Object} request.pre.batch - billing batch loaded by pre handler
+ */
+const getBillingBatchError = async (request, h) => {
+  const { batch } = request.pre
+
+  return h.view('nunjucks/billing/batch-error', {
+    ...request.view,
+    pageTitle: getBillRunPageTitle(batch),
+    batch,
+    back: BATCH_LIST_ROUTE
+  })
+}
+
+/**
  * Deletes all billing data
  */
 const postDeleteAllBillingData = async (request, h) => {
@@ -283,6 +298,7 @@ exports.getTransactionsCSV = getTransactionsCSV
 
 exports.getBillingBatchProcessing = getBillingBatchProcessing
 exports.getBillingBatchEmpty = getBillingBatchEmpty
+exports.getBillingBatchError = getBillingBatchError
 
 exports.postDeleteAllBillingData = postDeleteAllBillingData
 exports.getBillingBatchStatusToCancel = getBillingBatchStatusToCancel

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -269,39 +269,30 @@ const getBillingBatchError = async (request, h) => {
 }
 
 const _errorList = (errorCode) => {
-  const error = { text: 'No error code was assigned. We have no further information at this time.' }
-
-  switch (errorCode) {
-    case 10:
-      error.text = 'Error when populating the charge versions.'
-      break
-    case 20:
-      error.text = 'Error when processing the charge versions.'
-      break
-    case 30:
-      error.text = 'Error when preparing the transactions.'
-      break
-    case 40:
-      error.text = 'Error when requesting or processing a transaction charge.'
-      break
-    case 50:
-      error.text = 'Error when creating the Charging Module bill run.'
-      break
-    case 60:
-      error.text = 'Error when deleting an invoice.'
-      break
-    case 70:
-      error.text = 'Error when processing two-part tariff.'
-      break
-    case 80:
-      error.text = 'Error when getting the Charging Module bill run summary.'
-      break
-    case 90:
-      error.text = 'Error when re-billing a bill run.'
-      break
+  if (!errorCode) {
+    return [{ text: 'No error code was assigned. We have no further information at this time.' }]
   }
 
-  return [error]
+  const errors = [
+    { code: 10, text: 'Error when populating the charge versions.' },
+    { code: 20, text: 'Error when processing the charge versions.' },
+    { code: 30, text: 'Error when preparing the transactions.' },
+    { code: 40, text: 'Error when requesting or processing a transaction charge.' },
+    { code: 50, text: 'Error when creating the Charging Module bill run.' },
+    { code: 60, text: 'Error when deleting an invoice.' },
+    { code: 70, text: 'Error when processing two-part tariff.' },
+    { code: 80, text: 'Error when getting the Charging Module bill run summary.' },
+    { code: 90, text: 'Error when re-billing a bill run.' }
+  ]
+
+  const error = errors.find((error) => {
+    if (error.code === errorCode) {
+      return true
+    }
+    return false
+  })
+
+  return [{ text: error.text }]
 }
 
 /**

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -286,10 +286,7 @@ const _errorList = (errorCode) => {
   ]
 
   const error = errors.find((error) => {
-    if (error.code === errorCode) {
-      return true
-    }
-    return false
+    return error.code === errorCode
   })
 
   return [{ text: error.text }]

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -253,7 +253,7 @@ const getBillingBatchEmpty = async (request, h) => {
 }
 
 /**
- * Renders an error page if the batch is errored - i.e. no transactions
+ * Renders an error page if the batch is errored - i.e. the charging module is down
  * @param {Object} request.pre.batch - billing batch loaded by pre handler
  */
 const getBillingBatchError = async (request, h) => {

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -282,7 +282,7 @@ const _errorList = (errorCode) => {
       error.text = 'Error when preparing the transactions.'
       break
     case 40:
-      error.text = 'Error when creating a charge.'
+      error.text = 'Error when requesting or processing a transaction charge.'
       break
     case 50:
       error.text = 'Error when creating the Charging Module bill run.'

--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -21,6 +21,7 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
     .set('empty', `/billing/batch/${id}/empty`)
+    .set('error', `/billing/batch/${id}/error`)
     .set('queued', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
 
   if (opts.isErrorRoutesIncluded) {

--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -6,7 +6,6 @@
  * @param {Object} batch - the batch object from water service
  * @param {Object} options - whether back should be enabled on processing page
  *          {Boolean} isBackEnabled - whether back should be enabled on processing page
- *          {Boolean} isErrorRoutesIncluded - whether to include error/empty batch routes
  *          {Boolean} showSuccessPage - whether to show success or summary page for sent batch
  *          {String} invoiceId - set if user should be redirected to invoice page when batch ready
  * @return {String} the link
@@ -20,14 +19,9 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     .set('ready', opts.invoiceId ? `/billing/batch/${id}/invoice/${opts.invoiceId}` : `/billing/batch/${id}/summary`)
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
-    .set('empty', `/billing/batch/${id}/empty`)
-    .set('error', `/billing/batch/${id}/error`)
+    .set('empty', `/billing/batch/${id}/empty?back=${opts.isBackEnabled ? 1 : 0}`)
+    .set('error', `/billing/batch/${id}/error?back=${opts.isBackEnabled ? 1 : 0}`)
     .set('queued', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
-
-  if (opts.isErrorRoutesIncluded) {
-    routeMap
-      .set('error', `/billing/batch/${id}/processing`)
-  }
 
   return routeMap.get(batch.status)
 }

--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -19,8 +19,8 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     .set('ready', opts.invoiceId ? `/billing/batch/${id}/invoice/${opts.invoiceId}` : `/billing/batch/${id}/summary`)
     .set('sent', opts.showSuccessPage ? `/billing/batch/${id}/confirm/success` : `/billing/batch/${id}/summary`)
     .set('review', `/billing/batch/${id}/two-part-tariff-review`)
-    .set('empty', `/billing/batch/${id}/empty?back=${opts.isBackEnabled ? 1 : 0}`)
-    .set('error', `/billing/batch/${id}/error?back=${opts.isBackEnabled ? 1 : 0}`)
+    .set('empty', `/billing/batch/${id}/empty`)
+    .set('error', `/billing/batch/${id}/error`)
     .set('queued', `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`)
 
   return routeMap.get(batch.status)

--- a/src/internal/modules/billing/pre-handlers.js
+++ b/src/internal/modules/billing/pre-handlers.js
@@ -111,7 +111,7 @@ const redirectOnBatchStatus = async (request, h) => {
   }
 
   // Redirect to the correct page for this batch
-  const path = routing.getBillingBatchRoute(batch, { isBackEnabled: true, isErrorRoutesIncluded: true, showSuccessPage: true, invoiceId })
+  const path = routing.getBillingBatchRoute(batch, { isBackEnabled: true, showSuccessPage: true, invoiceId })
   return h.redirect(path).takeover()
 }
 

--- a/src/internal/modules/billing/routes/bill-run.js
+++ b/src/internal/modules/billing/routes/bill-run.js
@@ -293,7 +293,7 @@ const routes = {
     handler: controller.getBillingBatchProcessing,
     config: {
       app: {
-        validBatchStatuses: ['queued', 'processing', 'error', 'sending']
+        validBatchStatuses: ['queued', 'processing', 'sending']
       },
       auth: { scope: allowedScopes },
       plugins: {

--- a/src/internal/modules/billing/routes/bill-run.js
+++ b/src/internal/modules/billing/routes/bill-run.js
@@ -341,6 +341,32 @@ const routes = {
         { method: preHandlers.redirectOnBatchStatus }
       ]
     }
+  },
+
+  getBillingBatchError: {
+    method: 'GET',
+    path: '/billing/batch/{batchId}/error',
+    handler: controller.getBillingBatchError,
+    config: {
+      app: {
+        validBatchStatuses: ['error']
+      },
+      auth: { scope: allowedScopes },
+      plugins: {
+        viewContext: {
+          activeNavLink: 'bill-runs'
+        }
+      },
+      validate: {
+        params: Joi.object().keys({
+          batchId: Joi.string().uuid()
+        })
+      },
+      pre: [
+        { method: preHandlers.loadBatch, assign: 'batch' },
+        { method: preHandlers.redirectOnBatchStatus }
+      ]
+    }
   }
 }
 

--- a/src/internal/modules/billing/routes/bill-run.js
+++ b/src/internal/modules/billing/routes/bill-run.js
@@ -233,6 +233,7 @@ const routes = {
       pre: [{ method: preHandlers.loadBatch, assign: 'batch' }]
     }
   },
+
   getBillingBatchDeleteInvoice: {
     method: 'GET',
     path: '/billing/batch/{batchId}/delete-invoice/{invoiceId}',
@@ -262,6 +263,7 @@ const routes = {
       ]
     }
   },
+
   postBillingBatchDeleteInvoice: {
     method: 'POST',
     path: '/billing/batch/{batchId}/delete-invoice/{invoiceId}',

--- a/src/internal/views/nunjucks/billing/batch-error.njk
+++ b/src/internal/views/nunjucks/billing/batch-error.njk
@@ -12,7 +12,7 @@
 
   {{ batchHeader(pageTitle, batch) }}
 
-  <p>
+  <p class="govuk-body">
     <a href="{{ back }}">Return to bill runs</a>
   </p>
 

--- a/src/internal/views/nunjucks/billing/batch-error.njk
+++ b/src/internal/views/nunjucks/billing/batch-error.njk
@@ -1,0 +1,23 @@
+{% extends "./nunjucks/layout.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "./nunjucks/billing/macros/batch-header.njk" import batchHeader %}
+
+{% block content %}
+
+  {{ govukErrorSummary({
+    titleText: "There is a problem with this bill run",
+    errorList: [
+      {
+        text: "Computer said no."
+      }
+    ]
+  }) }}
+
+  {{ batchHeader(pageTitle, batch) }}
+
+  <p>
+    <a href="{{ back }}">Return to bill runs</a>
+  </p>
+
+{% endblock %}

--- a/src/internal/views/nunjucks/billing/batch-error.njk
+++ b/src/internal/views/nunjucks/billing/batch-error.njk
@@ -7,11 +7,7 @@
 
   {{ govukErrorSummary({
     titleText: "There is a problem with this bill run",
-    errorList: [
-      {
-        text: "Computer said no."
-      }
-    ]
+    errorList: errorList
   }) }}
 
   {{ batchHeader(pageTitle, batch) }}

--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -770,7 +770,7 @@ experiment('internal/modules/billing/controller', () => {
   experiment('.getBillingBatchProcessing', () => {
     let request
 
-    const createRequest = (status, back = 1) => ({
+    const createRequest = (back = 1) => ({
       query: {
         back
       },
@@ -778,7 +778,7 @@ experiment('internal/modules/billing/controller', () => {
         batch: {
           id: 'test-batch-id',
           type: 'two_part_tariff',
-          status,
+          status: 'processing',
           createdAt: '2020-02-01',
           region: {
             displayName: 'Anglian'
@@ -788,7 +788,7 @@ experiment('internal/modules/billing/controller', () => {
     })
 
     beforeEach(async () => {
-      request = createRequest('processing')
+      request = createRequest()
       await controller.getBillingBatchProcessing(request, h)
     })
 
@@ -821,7 +821,7 @@ experiment('internal/modules/billing/controller', () => {
 
     experiment('when the back query param is 0', () => {
       beforeEach(async () => {
-        const request = createRequest('processing', 0)
+        request = createRequest(0)
         await controller.getBillingBatchProcessing(request, h)
       })
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -131,23 +131,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the empty batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/empty?back=0`)
-      })
-
-      experiment('and the back option is not set', () => {
-        test('defaults the back query param to 0', () => {
-          const result = getBillingBatchRoute(batch)
-
-          expect(result).to.endWith('?back=0')
-        })
-      })
-
-      experiment('and the back option is set', () => {
-        test('sets the back query param to 1', () => {
-          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
-
-          expect(result).to.endWith('?back=1')
-        })
+        expect(result).to.equal(`/billing/batch/${batch.id}/empty`)
       })
     })
 
@@ -159,23 +143,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the error batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/error?back=0`)
-      })
-
-      experiment('and the back option is not set', () => {
-        test('defaults the back query param to 0', () => {
-          const result = getBillingBatchRoute(batch)
-
-          expect(result).to.endWith('?back=0')
-        })
-      })
-
-      experiment('and the back option is set', () => {
-        test('sets the back query param to 1', () => {
-          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
-
-          expect(result).to.endWith('?back=1')
-        })
+        expect(result).to.equal(`/billing/batch/${batch.id}/error`)
       })
     })
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -41,19 +41,23 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         batch.status = 'ready'
       })
 
-      test('returns the batch summary url if no invoice ID is supplied', () => {
-        const result = getBillingBatchRoute(batch)
+      experiment('and an invoice Id is not set', () => {
+        test('returns the summary batch page url', () => {
+          const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
+          expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
+        })
       })
 
-      test('returns the invoice page if an invoice ID is supplied', () => {
-        const options = {
-          invoiceId: '9683aba6-39ab-4b2d-885c-542ff864dbe9'
-        }
-        const result = getBillingBatchRoute(batch, options)
+      experiment('and an invoice Id is set', () => {
+        test('returns the invoice batch page url', () => {
+          const options = {
+            invoiceId: '9683aba6-39ab-4b2d-885c-542ff864dbe9'
+          }
+          const result = getBillingBatchRoute(batch, options)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
+          expect(result).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
+        })
       })
     })
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -16,7 +16,7 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       test('returns the processing batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.startWith(`/billing/batch/${batch.id}/processing`)
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
       })
 
       experiment('and the back option is not set', () => {
@@ -103,7 +103,7 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       test('returns the empty batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.startWith(`/billing/batch/${batch.id}/empty`)
+        expect(result).to.equal(`/billing/batch/${batch.id}/empty?back=0`)
       })
 
       experiment('and the back option is not set', () => {
@@ -131,7 +131,7 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       test('returns the error batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.startWith(`/billing/batch/${batch.id}/error`)
+        expect(result).to.equal(`/billing/batch/${batch.id}/error?back=0`)
       })
 
       experiment('and the back option is not set', () => {

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -13,7 +13,7 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         batch.status = 'processing'
       })
 
-      test('returns the expected url', () => {
+      test('returns the processing batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
         expect(result).to.startWith(`/billing/batch/${batch.id}/processing`)
@@ -74,7 +74,7 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         batch.status = 'review'
       })
 
-      test('returns the summary url by default', () => {
+      test('returns the two part tariff review url', () => {
         const result = getBillingBatchRoute(batch)
 
         expect(result).to.equal(`/billing/batch/${batch.id}/two-part-tariff-review`)

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -4,16 +4,17 @@ const { expect } = require('@hapi/code')
 const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
 const { getBillingBatchRoute } = require('internal/modules/billing/lib/routing')
 
-experiment('internal/modules/billing/lib/routing', () => {
+experiment.only('internal/modules/billing/lib/routing', () => {
   experiment('.getBillingBatchRoute', () => {
-    const batch = { id: 'test-batch-id' }
+    const batch = { id: '59203fa0-41d5-44c3-994e-032dc0985ea1' }
+
     experiment('when batch status is "processing"', () => {
       beforeEach(() => {
         batch.status = 'processing'
       })
 
       test('returns the expected url', () => {
-        expect(getBillingBatchRoute(batch)).to.startWith('/billing/batch/test-batch-id/processing')
+        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/processing`)
       })
 
       test('sets back query param to 0 by default', () => {
@@ -28,15 +29,15 @@ experiment('internal/modules/billing/lib/routing', () => {
     experiment('when batch status is "ready"', () => {
       test('returns the batch summary url if no invoice ID is supplied', () => {
         batch.status = 'ready'
-        expect(getBillingBatchRoute(batch)).to.equal('/billing/batch/test-batch-id/summary')
+        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/summary`)
       })
 
       test('returns the invoice page if an invoice ID is supplied', () => {
         batch.status = 'ready'
         const options = {
-          invoiceId: 'test-invoice-id'
+          invoiceId: '9683aba6-39ab-4b2d-885c-542ff864dbe9'
         }
-        expect(getBillingBatchRoute(batch, options)).to.equal('/billing/batch/test-batch-id/invoice/test-invoice-id')
+        expect(getBillingBatchRoute(batch, options)).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
       })
     })
 
@@ -46,30 +47,38 @@ experiment('internal/modules/billing/lib/routing', () => {
       })
 
       test('returns the summary url by default', () => {
-        expect(getBillingBatchRoute(batch)).to.equal('/billing/batch/test-batch-id/summary')
+        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/summary`)
       })
 
       test('returns success page url when showSuccessPage flag is true', () => {
-        expect(getBillingBatchRoute(batch, { showSuccessPage: true })).to.equal('/billing/batch/test-batch-id/confirm/success')
+        expect(getBillingBatchRoute(batch, { showSuccessPage: true })).to.equal(`/billing/batch/${batch.id}/confirm/success`)
       })
     })
 
     experiment('when batch status is "review"', () => {
       test('returns the summary url by default', () => {
         batch.status = 'review'
-        expect(getBillingBatchRoute(batch)).to.equal('/billing/batch/test-batch-id/two-part-tariff-review')
+        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/two-part-tariff-review`)
       })
     })
 
-    experiment('when isErrorRoutesIncluded flag is true', () => {
-      test('and batch status is "error" returns the processing page url', () => {
-        batch.status = 'error'
-        expect(getBillingBatchRoute(batch, { isErrorRoutesIncluded: true })).to.equal('/billing/batch/test-batch-id/processing')
+    experiment('when batch status is "empty"', () => {
+      beforeEach(() => {
+        batch.status = 'empty'
       })
 
-      test('and batch status is "empty" returns the empty batch page url', () => {
-        batch.status = 'empty'
-        expect(getBillingBatchRoute(batch, { isErrorRoutesIncluded: true })).to.equal('/billing/batch/test-batch-id/empty')
+      test('returns the empty batch page url', () => {
+        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/empty`)
+      })
+    })
+
+    experiment('when batch status is "error"', () => {
+      beforeEach(() => {
+        batch.status = 'error'
+      })
+
+      test('returns the error batch page url', () => {
+        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/error`)
       })
     })
   })

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -4,7 +4,7 @@ const { expect } = require('@hapi/code')
 const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
 const { getBillingBatchRoute } = require('internal/modules/billing/lib/routing')
 
-experiment.only('internal/modules/billing/lib/routing', () => {
+experiment('internal/modules/billing/lib/routing', () => {
   experiment('.getBillingBatchRoute', () => {
     const batch = { id: '59203fa0-41d5-44c3-994e-032dc0985ea1' }
 
@@ -160,6 +160,34 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         const result = getBillingBatchRoute(batch)
 
         expect(result).to.equal(`/billing/batch/${batch.id}/error?back=0`)
+      })
+
+      experiment('and the back option is not set', () => {
+        test('defaults the back query param to 0', () => {
+          const result = getBillingBatchRoute(batch)
+
+          expect(result).to.endWith('?back=0')
+        })
+      })
+
+      experiment('and the back option is set', () => {
+        test('sets the back query param to 1', () => {
+          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+
+          expect(result).to.endWith('?back=1')
+        })
+      })
+    })
+
+    experiment('when batch status is "queued"', () => {
+      beforeEach(() => {
+        batch.status = 'queued'
+      })
+
+      test('returns the processing batch page url', () => {
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
       })
 
       experiment('and the back option is not set', () => {

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -66,14 +66,20 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         batch.status = 'sent'
       })
 
-      test('returns the summary url by default', () => {
-        const result = getBillingBatchRoute(batch)
+      experiment('and show success page is not set', () => {
+        test('returns the summary batch page url', () => {
+          const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
+          expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
+        })
       })
 
-      test('returns success page url when showSuccessPage flag is true', () => {
-        expect(getBillingBatchRoute(batch, { showSuccessPage: true })).to.equal(`/billing/batch/${batch.id}/confirm/success`)
+      experiment('and show success page is set', () => {
+        test('returns the success batch page url', () => {
+          const result = getBillingBatchRoute(batch, { showSuccessPage: true })
+
+          expect(result).to.equal(`/billing/batch/${batch.id}/confirm/success`)
+        })
       })
     })
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -14,30 +14,42 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       })
 
       test('returns the expected url', () => {
-        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/processing`)
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.startWith(`/billing/batch/${batch.id}/processing`)
       })
 
       test('sets back query param to 0 by default', () => {
-        expect(getBillingBatchRoute(batch)).to.endWith('?back=0')
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.endWith('?back=0')
       })
 
       test('sets back query param to 1 when isBackEnabled is true', () => {
-        expect(getBillingBatchRoute(batch, { isBackEnabled: true })).to.endWith('?back=1')
+        const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+
+        expect(result).to.endWith('?back=1')
       })
     })
 
     experiment('when batch status is "ready"', () => {
-      test('returns the batch summary url if no invoice ID is supplied', () => {
+      beforeEach(() => {
         batch.status = 'ready'
-        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/summary`)
+      })
+
+      test('returns the batch summary url if no invoice ID is supplied', () => {
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
       })
 
       test('returns the invoice page if an invoice ID is supplied', () => {
-        batch.status = 'ready'
         const options = {
           invoiceId: '9683aba6-39ab-4b2d-885c-542ff864dbe9'
         }
-        expect(getBillingBatchRoute(batch, options)).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
+        const result = getBillingBatchRoute(batch, options)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
       })
     })
 
@@ -47,7 +59,9 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       })
 
       test('returns the summary url by default', () => {
-        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/summary`)
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/summary`)
       })
 
       test('returns success page url when showSuccessPage flag is true', () => {
@@ -56,9 +70,14 @@ experiment.only('internal/modules/billing/lib/routing', () => {
     })
 
     experiment('when batch status is "review"', () => {
-      test('returns the summary url by default', () => {
+      beforeEach(() => {
         batch.status = 'review'
-        expect(getBillingBatchRoute(batch)).to.equal(`/billing/batch/${batch.id}/two-part-tariff-review`)
+      })
+
+      test('returns the summary url by default', () => {
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/two-part-tariff-review`)
       })
     })
 
@@ -68,7 +87,9 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       })
 
       test('returns the empty batch page url', () => {
-        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/empty`)
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.startWith(`/billing/batch/${batch.id}/empty`)
       })
     })
 
@@ -78,7 +99,9 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       })
 
       test('returns the error batch page url', () => {
-        expect(getBillingBatchRoute(batch)).to.startWith(`/billing/batch/${batch.id}/error`)
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.startWith(`/billing/batch/${batch.id}/error`)
       })
     })
   })

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -19,16 +19,20 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         expect(result).to.startWith(`/billing/batch/${batch.id}/processing`)
       })
 
-      test('sets back query param to 0 by default', () => {
-        const result = getBillingBatchRoute(batch)
+      experiment('and the back option is not set', () => {
+        test('defaults the back query param to 0', () => {
+          const result = getBillingBatchRoute(batch)
 
-        expect(result).to.endWith('?back=0')
+          expect(result).to.endWith('?back=0')
+        })
       })
 
-      test('sets back query param to 1 when isBackEnabled is true', () => {
-        const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+      experiment('and the back option is set', () => {
+        test('sets the back query param to 1', () => {
+          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
 
-        expect(result).to.endWith('?back=1')
+          expect(result).to.endWith('?back=1')
+        })
       })
     })
 
@@ -91,6 +95,22 @@ experiment.only('internal/modules/billing/lib/routing', () => {
 
         expect(result).to.startWith(`/billing/batch/${batch.id}/empty`)
       })
+
+      experiment('and the back option is not set', () => {
+        test('defaults the back query param to 0', () => {
+          const result = getBillingBatchRoute(batch)
+
+          expect(result).to.endWith('?back=0')
+        })
+      })
+
+      experiment('and the back option is set', () => {
+        test('sets the back query param to 1', () => {
+          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+
+          expect(result).to.endWith('?back=1')
+        })
+      })
     })
 
     experiment('when batch status is "error"', () => {
@@ -102,6 +122,22 @@ experiment.only('internal/modules/billing/lib/routing', () => {
         const result = getBillingBatchRoute(batch)
 
         expect(result).to.startWith(`/billing/batch/${batch.id}/error`)
+      })
+
+      experiment('and the back option is not set', () => {
+        test('defaults the back query param to 0', () => {
+          const result = getBillingBatchRoute(batch)
+
+          expect(result).to.endWith('?back=0')
+        })
+      })
+
+      experiment('and the back option is set', () => {
+        test('sets the back query param to 1', () => {
+          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+
+          expect(result).to.endWith('?back=1')
+        })
       })
     })
   })

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -36,6 +36,34 @@ experiment.only('internal/modules/billing/lib/routing', () => {
       })
     })
 
+    experiment('when batch status is "sending"', () => {
+      beforeEach(() => {
+        batch.status = 'sending'
+      })
+
+      test('returns the processing batch page url', () => {
+        const result = getBillingBatchRoute(batch)
+
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
+      })
+
+      experiment('and the back option is not set', () => {
+        test('defaults the back query param to 0', () => {
+          const result = getBillingBatchRoute(batch)
+
+          expect(result).to.endWith('?back=0')
+        })
+      })
+
+      experiment('and the back option is set', () => {
+        test('sets the back query param to 1', () => {
+          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
+
+          expect(result).to.endWith('?back=1')
+        })
+      })
+    })
+
     experiment('when batch status is "ready"', () => {
       beforeEach(() => {
         batch.status = 'ready'

--- a/test/internal/modules/billing/routes/bill-run.test.js
+++ b/test/internal/modules/billing/routes/bill-run.test.js
@@ -96,9 +96,9 @@ experiment('internal/modules/billing/routes', () => {
       expect(routePreHandlers[1]).to.equal({ method: preHandlers.redirectOnBatchStatus })
     })
 
-    test('redirects unless batch status is "processing" or "error"', async () => {
+    test('redirects unless batch status is "queued", "processing" or "sending"', async () => {
       const { validBatchStatuses } = routes.getBillingBatchProcessing.config.app
-      expect(validBatchStatuses).to.equal(['queued', 'processing', 'error', 'sending'])
+      expect(validBatchStatuses).to.equal(['queued', 'processing', 'sending'])
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3882

When working on WATER-3833 it was tested what would happen if an error occurred.

If this happens in the legacy code the `billing_batch` has its `status` changed to error. In the UI it still gets listed with an **ERROR** label. In our new SROC supplementary bill run code though we weren't creating the record.

To ensure parity between the legacy and new code, we did some testing of what the legacy code actually does. What we found was _if_ it manages to throw and handle an error, it does set the `status` to 'error' and in some cases, it also sets an `error_code` against the bill run. But though the team thought there was an error page to display this information what actually happens is the service forwards the errored bill runs to `/billing/batch/${id}/processing`, which then 'helpfully' throws an HTTP `500`

```javascript
  // src/internal/modules/billing/controllers/bill-run.js - getBillingBatchProcessing()
  // ...

  // Render error page if batch has errored
  if (batch.status === 'error') {
    return Boom.badImplementation('Billing batch error')
  }

  // ...
```

The error page the comment is referring to is the generic 'Something's gone wrong page'. But the user will never see this because it also returns an HTTP `500` code, which our WAF blocks for good reasons (never send a 500 to the user!)

Why is this an issue now? We're implementing a process where the PRESROC and SROC bill runs are created in parallel, but processed in sequence. If an error happens during the processing of the SROC bill run that's fine because it is at the forefront. But if an error happens during creation, the PRESROC is at the forefront. We can't redirect to an error page for something happening in the background. All the user will see is the SROC bill run listed as **ERROR** with no other details.

To improve their experience, avoid needless ☎️ to the team, and stop users from seeing the Firewall error page (at least in this context) we're adding an error page, that errored bill runs can link through to.

<details>
<summary>Example screen</summary>

![Screenshot 2023-01-26 at 09 40 35](https://user-images.githubusercontent.com/1789650/214859170-42a03f86-dca5-40cb-8799-8e44437fc8c4.png)

</details>