### PR TITLE
Add charge scheme message to bill run spinner page

### DIFF
--- a/src/internal/views/nunjucks/billing/batch-processing.njk
+++ b/src/internal/views/nunjucks/billing/batch-processing.njk
@@ -28,7 +28,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-!-text-align-centre">
-        <p class="govuk-body-m">Gathering transactions</p>
+        <p class="govuk-body-m">Gathering transactions for {{ 'current' if batch.scheme == 'sroc' else 'old' }} charge scheme</p>
       </div>
     </div>
 {% endblock %}

--- a/src/internal/views/nunjucks/billing/batch-processing.njk
+++ b/src/internal/views/nunjucks/billing/batch-processing.njk
@@ -25,4 +25,10 @@
     <meta http-equiv="refresh" content="10">
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <img class="spinner" src="/public/images/ajax-loader.gif" alt="spinner">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-!-text-align-centre">
+        <p class="govuk-body-m">Gathering transactions</p>
+      </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3870

When a bill run is processing the user sees the 'spinner page'. We now trigger the SROC bill run after the PRESROC has been completed. To the user though, this switch will be all but invisible (keen-eyed users will spot the batch ID change in the URL!)

The user needs some belief there has been progress, especially as running 2 bill runs will make the process longer. It will also help us to deal with issues, as they can identify which bill run is having a problem.

We therefore add a `Gathering transactions for old/current charge scheme` message to this page.

Note that as with previous UI changes, the `batch` object that's passed to the template is taken in its entirety from a call to `water-abstraction-service`; since we expect to get it fully populated and make no additional changes, we don't do any unit testing as we would simply be mocking the response from the service.