### PR TITLE
Remove unnecessary tear-downs in acceptance tests

### DIFF
--- a/cypress/integration/external/bulk-upload.spec.js
+++ b/cypress/integration/external/bulk-upload.spec.js
@@ -7,10 +7,6 @@ describe('Bulk upload returns test', () => {
     setUp('bulk-return')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('User bulk upload test', () => {
     //  cy.visit to visit the URL
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/external/licence-alias-naming.spec.js
+++ b/cypress/integration/external/licence-alias-naming.spec.js
@@ -5,10 +5,6 @@ describe('View Licences as external user', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create the alias name for the licences user is holding', () => {
     //  cy.visit to visit the URL
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/external/login.spec.js
+++ b/cypress/integration/external/login.spec.js
@@ -6,10 +6,6 @@ describe('User Login and Log out', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('User login and logout', () => {
     //  cy.visit to visit the URL
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/external/reset-password.spec.js
+++ b/cypress/integration/external/reset-password.spec.js
@@ -6,10 +6,6 @@ describe('Reset password', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Navigate to the signin page', () => {
     cy.visit(Cypress.env('USER_URI'))
     cy.get('a[href*="/signin"]').click()

--- a/cypress/integration/external/sharing-access-with-existing-user.spec.js
+++ b/cypress/integration/external/sharing-access-with-existing-user.spec.js
@@ -6,10 +6,6 @@ describe('External user sharing license access with another external user ', () 
     setUp('barebones')
   })
 
-  afterEach(() => {
-    tearDown()
-  })
-
   it('User login and assing the license to another external user', () => {
     //  User logs in
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/external/sharing-access-with-new-user.spec.js
+++ b/cypress/integration/external/sharing-access-with-new-user.spec.js
@@ -6,10 +6,6 @@ describe('External user sharing license access with new external user ', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('User assigning the license to a new user', () => {
     //  User logs in
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/external/user-registration.spec.js
+++ b/cypress/integration/external/user-registration.spec.js
@@ -6,10 +6,6 @@ describe('User registration', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('redirects to the welcome page', () => {
     cy.visit(Cypress.env('USER_URI'))
     cy.contains('Sign in or create an account').should('have.class', 'govuk-heading-l')

--- a/cypress/integration/external/user-returns-view.spec.js
+++ b/cypress/integration/external/user-returns-view.spec.js
@@ -7,10 +7,6 @@ describe('check for different return status as an external user', () => {
     setUp('barebones')
   })
 
-  afterEach(() => {
-    tearDown()
-  })
-
   it('sees the page title', () => {
     cy.visit(Cypress.env('USER_URI'))
 

--- a/cypress/integration/external/user-submitting-returns.spec.js
+++ b/cypress/integration/external/user-submitting-returns.spec.js
@@ -12,10 +12,6 @@ describe('submit a return metered readings return as an external user', () => {
     setUp('barebones')
   })
 
-  afterEach(() => {
-    tearDown()
-  })
-
   it('sees the page title', () => {
     cy.visit(Cypress.env('USER_URI'))
 

--- a/cypress/integration/external/view-licences.spec.js
+++ b/cypress/integration/external/view-licences.spec.js
@@ -5,10 +5,6 @@ describe('View Licences as external user', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('View licenses and verify them', () => {
     //  cy.visit to visit the URL
     cy.visit(Cypress.env('USER_URI'))

--- a/cypress/integration/internal/billing/billing-annual-bills-run.spec.js
+++ b/cypress/integration/internal/billing/billing-annual-bills-run.spec.js
@@ -9,10 +9,6 @@ describe('annual bill run', () => {
     setUp('billing-data')
   })
 
-  afterEach(() => {
-    tearDown()
-  })
-
   it('user logs in and generates annual bill', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/billing-cancel-bill-run.spec.js
+++ b/cypress/integration/internal/billing/billing-cancel-bill-run.spec.js
@@ -6,10 +6,6 @@ describe('Cancel bill run', () => {
     setUp('supplementary-billing')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in, creates and cancels a bill run [supplimentary, annual, 2PT]', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/billing-non-chargeable-licence-credits-back-historic-charges.spec.js
+++ b/cypress/integration/internal/billing/billing-non-chargeable-licence-credits-back-historic-charges.spec.js
@@ -13,10 +13,6 @@ describe('non-chargeable licence credits back historic charges', () => {
     setUp('five-year-two-part-tariff-bill-runs')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in', () => {
     login('billingAndData', 'DEFAULT_PASSWORD')
 

--- a/cypress/integration/internal/billing/billing-rebilling-supplementary.spec.js
+++ b/cypress/integration/internal/billing/billing-rebilling-supplementary.spec.js
@@ -6,10 +6,6 @@ describe('rebilling supplementary bill run', () => {
     setUp('supplementary-billing')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/billing-supplementary-2part-historic-recalculate-charges.spec.js
+++ b/cypress/integration/internal/billing/billing-supplementary-2part-historic-recalculate-charges.spec.js
@@ -55,11 +55,6 @@ describe('2part historic recalculating charges', () => {
     login('billingAndData', 'DEFAULT_PASSWORD')
   })
 
-  afterEach(() => {
-    cy.get('#signout').click()
-    tearDown()
-  })
-
   it('with no change to charge versions', () => {
     recalculateChargesTest()
   })

--- a/cypress/integration/internal/billing/billing-two-part-tariff-bill-run.spec.js
+++ b/cypress/integration/internal/billing/billing-two-part-tariff-bill-run.spec.js
@@ -6,10 +6,6 @@ describe('two-part-tariff bill run', () => {
     setUp('two-part-tariff-billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/bills-tab.spec.js
+++ b/cypress/integration/internal/billing/bills-tab.spec.js
@@ -8,10 +8,6 @@ describe('non-charging user unable to view bills tab', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('searches for licence by licence number and clicks on it', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/license-transfer-to-new-billing-account.spec.js
+++ b/cypress/integration/internal/billing/license-transfer-to-new-billing-account.spec.js
@@ -12,10 +12,6 @@ describe('License transfer to new billing account', () => {
     setUp('five-year-two-part-tariff-bill-runs')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('License transfer to new billing account', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/billing/mark-licence-for-supplementary-billing.spec.js
+++ b/cypress/integration/internal/billing/mark-licence-for-supplementary-billing.spec.js
@@ -6,10 +6,6 @@ describe('check for different status for a licence in returns tab as internal us
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('logs in and searches for a licence', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/billing/remove-individual-licence-from-bill.spec.js
+++ b/cypress/integration/internal/billing/remove-individual-licence-from-bill.spec.js
@@ -6,10 +6,6 @@ describe('remove individual licence from bill', () => {
     setUp('supplementary-billing')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/chargeinformation/change-user-permissions.spec.js
+++ b/cypress/integration/internal/chargeinformation/change-user-permissions.spec.js
@@ -6,10 +6,6 @@ describe('change internal user permissions as B&D user', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('searches for user by email address', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.fixture('users.json').then(users => {

--- a/cypress/integration/internal/chargeinformation/create-view-edit-delete-licence-agreements.spec.js
+++ b/cypress/integration/internal/chargeinformation/create-view-edit-delete-licence-agreements.spec.js
@@ -6,10 +6,6 @@ describe('Licence agreement - Set up, View, End and Delete', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in and sets up new License Agreement, Ends it and deletes the agreement', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.fixture('users.json').then(users => {

--- a/cypress/integration/internal/chargeinformation/remove-charge-info-workflow.spec.js
+++ b/cypress/integration/internal/chargeinformation/remove-charge-info-workflow.spec.js
@@ -7,11 +7,6 @@ describe('remove charge info workflow as B&D user', () => {
     setUp('charge-version-workflow')
   })
 
-  after(() => {
-    cy.get('#signout').click()
-    tearDown()
-  })
-
   it('navigates to charge info workflow page', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.fixture('users.json').then(users => {

--- a/cypress/integration/internal/chargeinformation/sroc-charge-version-adjustments-option-no.spec.js
+++ b/cypress/integration/internal/chargeinformation/sroc-charge-version-adjustments-option-no.spec.js
@@ -8,10 +8,6 @@ describe('Create SRoC Charge version workflow journey', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create SRoC Charge version workflow journey', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/chargeinformation/sroc-charge-version-adjustments-option-yes.spec.js
+++ b/cypress/integration/internal/chargeinformation/sroc-charge-version-adjustments-option-yes.spec.js
@@ -8,10 +8,6 @@ describe('Create SRoC Charge version workflow journey', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create SRoC Charge version workflow journey', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/chargeinformation/sroc-charge-version.spec.js
+++ b/cypress/integration/internal/chargeinformation/sroc-charge-version.spec.js
@@ -8,10 +8,6 @@ describe('Create SRoC Charge version workflow journey', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create SRoC Charge version workflow journey', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/chargeinformation/sroc-edit-submit-review-view-charge-version.spec.js
+++ b/cypress/integration/internal/chargeinformation/sroc-edit-submit-review-view-charge-version.spec.js
@@ -7,10 +7,6 @@ describe('Create SRoC Charge version workflow journey', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create SRoC Charge version workflow journey', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/chargeinformation/sroc-select-multiple-charge-version.spec.js
+++ b/cypress/integration/internal/chargeinformation/sroc-select-multiple-charge-version.spec.js
@@ -7,10 +7,6 @@ describe('Create SRoC Charge version workflow journey', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Create SRoC Charge version workflow journey', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
 

--- a/cypress/integration/internal/returns/invite-licence-holders-submit-returns.spec.js
+++ b/cypress/integration/internal/returns/invite-licence-holders-submit-returns.spec.js
@@ -6,10 +6,6 @@ describe('Inviting users to submit the returns', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Inviting users to submit the returns', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/returns/remind-licence-holders-submit-returns.spec.js
+++ b/cypress/integration/internal/returns/remind-licence-holders-submit-returns.spec.js
@@ -6,10 +6,6 @@ describe('Sending returns reminders to users ', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('sending reminder to users asking to submit the returns', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/returns/returns-status-view.spec.js
+++ b/cypress/integration/internal/returns/returns-status-view.spec.js
@@ -6,10 +6,6 @@ describe('check for different status for a licence in returns tab as internal us
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in and searches for a License', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/returns/update-view-returns-status-of-a-licence.spec.js
+++ b/cypress/integration/internal/returns/update-view-returns-status-of-a-licence.spec.js
@@ -6,10 +6,6 @@ describe('check and update different status for a licence in returns tab as inte
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in and searches for a License and updates retuns status', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.fixture('users.json').then(users => {

--- a/cypress/integration/internal/user/create-user.spec.js
+++ b/cypress/integration/internal/user/create-user.spec.js
@@ -7,10 +7,6 @@ describe('creating an internal user:', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('navigates to the new internal user form and creates an internal account', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.fixture('users.json').then(users => {

--- a/cypress/integration/internal/user/reset-password.spec.js
+++ b/cypress/integration/internal/user/reset-password.spec.js
@@ -6,10 +6,6 @@ describe('internal user resetting their password:', () => {
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('Navigate to the reset your password page', () => {
     cy.visit(Cypress.env('ADMIN_URI'))
     cy.get('a[href*="/reset_password').click()

--- a/cypress/integration/internal/user/search-for-licence.spec.js
+++ b/cypress/integration/internal/user/search-for-licence.spec.js
@@ -6,10 +6,6 @@ describe('search for licences as internal user', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs in and searches for a License', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/user/view-contacts.spec.js
+++ b/cypress/integration/internal/user/view-contacts.spec.js
@@ -7,10 +7,6 @@ describe('view contacts assigned to the licence ', () => {
     setUp('billing-data')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('searches for licence by licence number and clicks on it', () => {
     // cy.visit to visit the URL
     cy.visit(Cypress.env('ADMIN_URI'))

--- a/cypress/integration/internal/waa/gauging-stations-and-water-abstraction-alerts-mbod.spec.js
+++ b/cypress/integration/internal/waa/gauging-stations-and-water-abstraction-alerts-mbod.spec.js
@@ -6,10 +6,6 @@ describe('tag a licence to a gauging station, send a warning, and remove the tag
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs and searches for a gauging station, tags and untags the licences', () => {
     describe('User Tags the licence', () => {
       // cy.visit to visit the URL

--- a/cypress/integration/internal/waa/gauging-stations-and-water-abstraction-alerts.spec.js
+++ b/cypress/integration/internal/waa/gauging-stations-and-water-abstraction-alerts.spec.js
@@ -6,10 +6,6 @@ describe('tag a licence to a gauging station, send a warning, and remove the tag
     setUp('barebones')
   })
 
-  after(() => {
-    tearDown()
-  })
-
   it('user logs and searches for a gauging station, tags and untags the licences', () => {
     describe('User Tags the licence', () => {
       // cy.visit to visit the URL


### PR DESCRIPTION
In all of our acceptance tests, we use `before()` and `after()` [hooks](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Hooks) to set the state of the app.

In the `before()` hook we'll call the `/tear-down` endpoint to delete the existing test data. We'll then follow it up with a call to set up the test data we need, for example, `/barebones`.

It's _extremely_ slow. But it's all we've got at the moment.

For some reason though, all our tests also have an `after()` hook that calls `/tear-down` again. We always call it in our `before()` hook. So, it's not adding any value. Add to that [Cypress best practices](https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks) specifically state you should not do this!

On the basis it's pointless, against best practices, and slows the tests down this change removes the `after()` hooks.