### PR TITLE
Disable video in Cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -15,6 +15,7 @@
   },
   "env": {
   },
+  "video": false,
   "integrationFolder": "./cypress/integration",
   "videosFolder": "./cypress/videos",
   "screenshotsFolder": "./cypress/screenshots",


### PR DESCRIPTION
By default, for each test Cypress will record and then compress a video. These might be handy for sharing with those outside the team. But we never do! They can also help with debugging. But when we need to we just run the problem spec in the GUI.

So, it's another thing that is slowing the tests down and not adding any benefit.

This change disables videos by default.