### PR TITLE
Make default env vars for Cypress consistent

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,10 +1,11 @@
+'use strict'
 
 require('dotenv').config();
 
-module.exports = (on, config) => {
+module.exports = (_on, config) => {
   config.env.JWT_TOKEN = process.env.JWT_TOKEN;
   config.env.NOTIFY_CALLBACK_TOKEN = process.env.NOTIFY_CALLBACK_TOKEN;
-  config.env.WATER_URI = process.env.WATER_URI  || 'http://127.0.0.1:8001/water/1.0';
+  config.env.WATER_URI = process.env.WATER_URI  || 'http://localhost:8001/water/1.0';
   config.env.ADMIN_URI = process.env.ADMIN_URI  || 'http://localhost:8008/';
   config.env.USER_URI = process.env.USER_URI  || 'http://localhost:8000/';
   config.env.DEFAULT_PASSWORD = 'P@55word';


### PR DESCRIPTION
Spotted in our Cypress acceptance tests that one of the URIs is defined differently from the others. No need for this. So, this is a quick change to make them consistent.

---

Also, added a `use strict` and denoted the first param as unused. We touched the file so did a little tidying whilst in there.