### PR TITLE
Fix Cypress get email link commands

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -3,14 +3,14 @@ const querystring = require('querystring');
 const axios = require('axios');
 
 Cypress.Commands.add('getPasswordResetUrl', async (baseUrl, email) => {
-  const url = `${baseUrl}notifications/last?${querystring.encode({ email })}`;
+  const url = `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`;
   const req = await axios.get(url);
   const personalisation = get(req, `data.data[0].personalisation['reset_url']`, null);
   return personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl);
 });
 
 Cypress.Commands.add('getUserRegistrationUrl', async (baseUrl, email) => {
-  const url = `${baseUrl}notifications/last?${querystring.encode({ email })}`;
+  const url = `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`;
   const req = await axios.get(url);
   const personalisation = get(req, `data.data[0].personalisation['link']`, null);
   return personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl);


### PR DESCRIPTION
We hadn't spotted that when we made a change recently to [allow getting the last notification sent in our non-prod environments](https://github.com/DEFRA/water-abstraction-ui/pull/2267) that we broke the Cypress acceptance tests that depend on following these links, for example, password reset.

Simply put, the commands were premised on the endpoint being available in both the internal and external versions of the UI. Now it's only available in the internal version, we can tweak the commands and fix the issue.