### PR TITLE
Fix licence holder display bug in check charge info

### DIFF
--- a/src/internal/modules/charge-information/controllers/charge-information.js
+++ b/src/internal/modules/charge-information/controllers/charge-information.js
@@ -211,9 +211,6 @@ const getCheckData = async (request, h) => {
   const { licenceId } = request.params
   const isApprover = hasScope(request, chargeVersionWorkflowReviewer)
 
-  // const { data: documentRoles } = await services.crm.documentRoles.getDocumentRolesByDocumentRef(licence.licenceNumber)
-  // const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder')
-
   const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
   const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
     moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&

--- a/src/internal/modules/charge-information/controllers/charge-information.js
+++ b/src/internal/modules/charge-information/controllers/charge-information.js
@@ -211,8 +211,14 @@ const getCheckData = async (request, h) => {
   const { licenceId } = request.params
   const isApprover = hasScope(request, chargeVersionWorkflowReviewer)
 
-  const { data: documentRoles } = await services.crm.documentRoles.getDocumentRolesByDocumentRef(licence.licenceNumber)
-  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder')
+  // const { data: documentRoles } = await services.crm.documentRoles.getDocumentRolesByDocumentRef(licence.licenceNumber)
+  // const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder')
+
+  const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
+  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
+    moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&
+    (!role.endDate || moment(role.endDate).isAfter(draftChargeInformation.dateRange.startDate, 'd'))
+  )
 
   const billingAccountAddress = getCurrentBillingAccountAddress(billingAccount)
   const editChargeVersionWarning = await isOverridingChargeVersion(request, draftChargeInformation.dateRange.startDate)

--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -61,8 +61,14 @@ const getReviewChargeInformation = async (request, h) => {
   const billingAccountAddress = getCurrentBillingAccountAddress(billingAccount)
 
   const validatedDraftChargeVersion = chargeInformationValidator.addValidation(draftChargeInformation)
-  const { data: documentRoles } = await services.crm.documentRoles.getDocumentRolesByDocumentRef(licence.licenceNumber)
-  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder')
+  // const { data: documentRoles } = await services.crm.documentRoles.getDocumentRolesByDocumentRef(licence.licenceNumber)
+  // const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder')
+
+  const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
+  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
+    moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&
+    (!role.endDate || moment(role.endDate).isAfter(draftChargeInformation.dateRange.startDate, 'd'))
+  )
 
   return h.view('nunjucks/charge-information/view', {
     ...getDefaultView(request, backLink),

--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -24,12 +24,7 @@ const getViewChargeInformation = async (request, h) => {
   const backLink = await getLicencePageUrl(licence, true)
   const billingAccountAddress = getCurrentBillingAccountAddress(billingAccount)
 
-  const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
-
-  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
-    moment(role.startDate).isSameOrBefore(chargeVersion.dateRange.startDate, 'd') &&
-    (!role.endDate || moment(role.endDate).isAfter(chargeVersion.dateRange.startDate, 'd'))
-  )
+  const licenceHolder = await _licenceHolder(chargeVersion, licence.licenceNumber)
 
   return h.view('nunjucks/charge-information/view', {
     ...getDefaultView(request, backLink),
@@ -61,12 +56,7 @@ const getReviewChargeInformation = async (request, h) => {
 
   const validatedDraftChargeVersion = chargeInformationValidator.addValidation(draftChargeInformation)
 
-  const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
-
-  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
-    moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&
-    (!role.endDate || moment(role.endDate).isAfter(draftChargeInformation.dateRange.startDate, 'd'))
-  )
+  const licenceHolder = await _licenceHolder(draftChargeInformation, licence.licenceNumber)
 
   return h.view('nunjucks/charge-information/view', {
     ...getDefaultView(request, backLink),
@@ -99,11 +89,7 @@ const postReviewChargeInformation = async (request, h) => {
     reviewFormSchema(request)
   )
   if (!form.isValid) {
-    const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
-    const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
-      moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&
-      (!role.endDate || moment(role.endDate).isAfter(draftChargeInformation.dateRange.startDate, 'd'))
-    )
+    const licenceHolder = await _licenceHolder(draftChargeInformation, licence.licenceNumber)
 
     return h.view('nunjucks/charge-information/view', {
       ...getDefaultView(request, backLink),
@@ -139,6 +125,16 @@ const postReviewChargeInformation = async (request, h) => {
 
     return h.redirect(`/licences/${licence.id}#charge`)
   }
+}
+
+const _licenceHolder = async (chargeInformation, licenceNumber) => {
+  const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licenceNumber)
+  const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
+    moment(role.startDate).isSameOrBefore(chargeInformation.dateRange.startDate, 'd') &&
+    (!role.endDate || moment(role.endDate).isAfter(chargeInformation.dateRange.startDate, 'd'))
+  )
+
+  return licenceHolder
 }
 
 exports.getViewChargeInformation = getViewChargeInformation

--- a/test/internal/modules/charge-information/controllers/view-charge-information.test.js
+++ b/test/internal/modules/charge-information/controllers/view-charge-information.test.js
@@ -115,7 +115,6 @@ experiment('internal/modules/charge-information/controllers/view-charge-informat
     sandbox.stub(services.crm.documents, 'getWaterLicence').returns({
       document_id: 'test-document-id'
     })
-    sandbox.stub(services.crm.documentRoles, 'getDocumentRolesByDocumentRef').resolves({ data: [] })
     sandbox.stub(services.crm.documentRoles, 'getFullHistoryOfDocumentRolesByDocumentRef').resolves({ data: [] })
 
     h = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3905

The business has raised an issue with the 'Check charge information' view. The scenario they outlined was

- Licence **AN/030/0008/006** was originally issued to _Cemex Materials Ltd_ with effect from 14/03/2022
- It was then transferred to _Breedon Trading Limited_ with effect from 27/06/2022
- Within the period 14/03/2022 - 26/06/2022 they would expect to see _Cemex Materials Ltd_ as the licence holder
- From 27/06/2022 we would expect to see _Breedon Trading Limited_ as the licence holder

This reminded someone that we'd had a similar issue previously. They found WATER-3348 which is linked to [Bugfix/water 3348](https://github.com/DEFRA/water-abstraction-ui/pull/1943). It seems that fixed the bug for the charge info view page (`/licences/{licenceId}/charge-in
formation/{chargeVersionId}/view`). But though the controller for `/licences/{licenceId}/charge-information/{chargeVersionWorkflowId}/review` is directly below it, it didn't get fixed at the same time. 🙁

Whilst digging into this we also found the same issue with the `/licences/{licenceId}/charge-information/check` screen.

So, this fix applies what was done to `getViewChargeInformation()` to `getReviewChargeInformation()` and `getCheckData()` in `src/internal/modules/charge-information/controllers/charge-information.js`.

<details>
<summary>Before fix (review)</summary>

![review_charge_info_error](https://user-images.githubusercontent.com/1789650/221236133-bf0c0cb7-0004-4fdc-8b4d-325022507683.png)

</details>

<details>
<summary>After fix (review)</summary>

<img width="1005" alt="review_charge_info_fix" src="https://user-images.githubusercontent.com/1789650/221236843-a4665def-7ab4-4226-a4c6-991ecd287bcd.png">

</details>