### PR TITLE
Fix licence holder display bug 4 date of transfer

### DIFF
--- a/src/internal/modules/charge-information/controllers/charge-information.js
+++ b/src/internal/modules/charge-information/controllers/charge-information.js
@@ -214,7 +214,7 @@ const getCheckData = async (request, h) => {
   const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licence.licenceNumber)
   const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
     moment(role.startDate).isSameOrBefore(draftChargeInformation.dateRange.startDate, 'd') &&
-    (!role.endDate || moment(role.endDate).isAfter(draftChargeInformation.dateRange.startDate, 'd'))
+    (!role.endDate || moment(role.endDate).isSameOrAfter(draftChargeInformation.dateRange.startDate, 'd'))
   )
 
   const billingAccountAddress = getCurrentBillingAccountAddress(billingAccount)

--- a/src/internal/modules/charge-information/controllers/view-charge-information.js
+++ b/src/internal/modules/charge-information/controllers/view-charge-information.js
@@ -131,7 +131,7 @@ const _licenceHolder = async (chargeInformation, licenceNumber) => {
   const { data: documentRoles } = await services.crm.documentRoles.getFullHistoryOfDocumentRolesByDocumentRef(licenceNumber)
   const licenceHolder = documentRoles.find(role => role.roleName === 'licenceHolder' &&
     moment(role.startDate).isSameOrBefore(chargeInformation.dateRange.startDate, 'd') &&
-    (!role.endDate || moment(role.endDate).isAfter(chargeInformation.dateRange.startDate, 'd'))
+    (!role.endDate || moment(role.endDate).isSameOrAfter(chargeInformation.dateRange.startDate, 'd'))
   )
 
   return licenceHolder


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3905

We had a first stab at solving how the licence holder is displayed in the charge version review and check screens in [Fix licence holder display bug in check charge info](https://github.com/DEFRA/water-abstraction-ui/pull/2300).

That basically involved applying a fix implemented by the previous team to the charge version view screen to these screens. But our meticulous QA spotted that if you created a new charge version that starts on the day of an existing transfer you don't get the wrong holder, you get nothing!

This change fixes the issue for that edge case.