### PR TITLE
Make request logging configurable & change default

### DIFF
--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -81,13 +81,14 @@ module.exports = {
     // Credit to https://stackoverflow.com/a/323546/6117745 for how to handle
     // converting the env var to a boolean
     logAssetRequests: (String(process.env.LOG_ASSET_REQUESTS) === 'true') || false,
-    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false
+    logInTest: (String(process.env.LOG_IN_TEST) === 'true') || false,
+    level: process.env.WRLS_LOG_LEVEL || 'warn'
   },
 
   // This config is used by water-abstraction-helpers and its use of Winston and Airbrake. Any use of `logger.info()`,
   // for example, is built on this config.
   logger: {
-    level: process.env.WRLS_LOG_LEVEL || 'info',
+    level: process.env.WRLS_LOG_LEVEL || 'warn',
     airbrakeKey: process.env.ERRBIT_KEY,
     airbrakeHost: process.env.ERRBIT_SERVER,
     airbrakeLevel: 'error'

--- a/src/shared/plugins/hapi-pino.plugin.js
+++ b/src/shared/plugins/hapi-pino.plugin.js
@@ -28,8 +28,12 @@ const HapiPinoIgnoreRequestService = require('../lib/services/hapi-pino-ignore-r
  * the returned value will allow it to be incorporated with our default hapi-pino options.
  */
 const testOptions = logInTest => {
+  const level = process.env.WRLS_LOG_LEVEL || 'warn'
+
   if (process.env.NODE_ENV !== 'test' || logInTest) {
-    return {}
+    return {
+      level
+    }
   }
 
   return {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/79

We have an ongoing problem where the log files for our apps very quickly become massive. In the space of a week, we can see a repo like [water-abstraction-returns](https://github.com/DEFRA/water-abstraction-returns) generate a log file almost 10Gb in size!

Fortunately, we have a solution in place for `production` that truncates them on a regular basis. But because we switch off our non-prod environments that process is often blocked there, meaning the logs get out of hand and use up all available disk space. It also means our local environments can be extremely noisy and if we don't switch them off, they too can run into the same issue.

So, for our background web services, we are changing the [hapi-pino](https://github.com/pinojs/hapi-pino) config to be based on the existing `WRLS_LOG_LEVEL` env var.

We're also defaulting it to 'warn' in our non-prod and local environment so we'll only log request errors. This will also have an effect on the existing logging in the app. Now, only when it's logging an error will we see something.

---

We have to refer to the env var directly in our plugin, unlike the other repos because of the whole issue of having shared, internal and external folders but no proper implementation for shared config.