### PR TITLE
Remove axios from acceptance tests

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,17 +1,29 @@
-const { get } = require('lodash');
+'use strict'
+
 const querystring = require('querystring');
-const axios = require('axios');
 
-Cypress.Commands.add('getPasswordResetUrl', async (baseUrl, email) => {
-  const url = `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`;
-  const req = await axios.get(url);
-  const personalisation = get(req, `data.data[0].personalisation['reset_url']`, null);
-  return personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl);
-});
+Cypress.Commands.add('getPasswordResetUrl', (baseUrl, email) => {
+  cy.request({
+    url: `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`,
+    log: false,
+    method: 'GET'
+  }).then((response) => {
+    const personalisation = response.body.data[0].personalisation['reset_url']
+    const cleansedPersonalisation = personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl)
 
-Cypress.Commands.add('getUserRegistrationUrl', async (baseUrl, email) => {
-  const url = `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`;
-  const req = await axios.get(url);
-  const personalisation = get(req, `data.data[0].personalisation['link']`, null);
-  return personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl);
-});
+    return cy.wrap(cleansedPersonalisation)
+  })
+})
+
+Cypress.Commands.add('getUserRegistrationUrl', (baseUrl, email) => {
+  cy.request({
+    url: `${Cypress.env('ADMIN_URI')}notifications/last?${querystring.encode({ email })}`,
+    log: false,
+    method: 'GET'
+  }).then((response) => {
+    const personalisation = response.body.data[0].personalisation['link']
+    const cleansedPersonalisation = personalisation.replace((/^https?:\/\/[^/]+\//g).exec(personalisation), baseUrl)
+
+    return cy.wrap(cleansedPersonalisation)
+  })
+})

--- a/cypress/support/notifications.js
+++ b/cypress/support/notifications.js
@@ -1,30 +1,35 @@
-const { get } = require('lodash');
-const querystring = require('querystring');
-const axios = require('axios');
+'use strict'
 
-Cypress.Commands.add('simulateNotifyCallback', async (notificationId) => {
-  const requestBody = {
-    id: notificationId,
-    reference: notificationId,
-    status: 'delivered',
-    notification_type: 'email',
-    to: 'irrelevant',
-    created_at: new Date().toISOString(),
-    completed_at: new Date().toISOString(),
-    sent_at: new Date().toISOString()
-  };
+const querystring = require('querystring')
 
-  const url = `${Cypress.env('USER_URI')}notify/callback`;
-  await axios.post(url, requestBody, {
+Cypress.Commands.add('simulateNotifyCallback', (notificationId) => {
+  cy.request({
+    url: `${Cypress.env('USER_URI')}notify/callback`,
+    log: false,
+    method: 'POST',
     headers: {
       authorization: `Bearer ${Cypress.env('NOTIFY_CALLBACK_TOKEN')}`
-    }
-  });
-  return 'OK';
+    },
+    body: {
+      id: notificationId,
+      reference: notificationId,
+      status: 'delivered',
+      notification_type: 'email',
+      to: 'irrelevant',
+      created_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+      sent_at: new Date().toISOString()
+    },
+    timeout: 60000
+  })
 });
 
-Cypress.Commands.add('getLastNotifications', async (baseUrl, email) => {
-  const url = `${baseUrl}notifications/last?${querystring.encode({ email })}`;
-  const response = await axios.get(url);
-  return get((response), `data.data[0]`, {});
-});
+Cypress.Commands.add('getLastNotifications', (baseUrl, email) => {
+  cy.request({
+    url: `${baseUrl}notifications/last?${querystring.encode({ email })}`,
+    log: false,
+    method: 'GET'
+  }).then((response) => {
+    return cy.wrap(response.body.data[0])
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "@babel/preset-env": "^7.20.2",
         "@hapi/code": "^9.0.3",
         "@hapi/lab": "^25.1.2",
-        "axios": "^1.3.4",
         "cypress": "^8.7.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-multi-reporters": "^1.6.2",
@@ -3555,31 +3554,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
-    "node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
@@ -6947,26 +6921,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/for-in": {
@@ -12275,12 +12229,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -18007,30 +17955,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
-    "axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
@@ -20682,12 +20606,6 @@
           }
         }
       }
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -24789,12 +24707,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@babel/preset-env": "^7.20.2",
     "@hapi/code": "^9.0.3",
     "@hapi/lab": "^25.1.2",
-    "axios": "^1.3.4",
     "cypress": "^8.7.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.2",


### PR DESCRIPTION
We'd already spotted that for some reason _another_ HTTP request package had been added to the repo just for use in Cypress. This was even more confusing because Cypress is itself a framework for sending HTTP requests!

Ideally, we'd like to run the current acceptance tests from the same repo we download as part of our Docker base local dev environment. You have to run the tests outside of the environment though because of the dependence on browsers being available. But because of the inclusion of [axios](https://github.com/axios/axios) as part of the dependencies any tests that rely on the custom commands that use **axios** fail.

So, this change removes **axios** and replaces what it was doing with native Cypress commands. It helps us remove a redundant package (that is also out of date) and allows us to avoid having to maintain 2 copies of this repo on our machines.