### PR TITLE
Fix no address selected 500 error

### DIFF
--- a/src/internal/modules/address-entry/controller.js
+++ b/src/internal/modules/address-entry/controller.js
@@ -9,6 +9,7 @@ const routing = require('./lib/routing')
 const { NEW_ADDRESS } = require('./lib/constants')
 const addressForms = require('./forms')
 const { handleFormRequest } = require('shared/lib/form-handler')
+const preHandlers = require('./pre-handlers')
 
 const getDefaultView = request => {
   const { sessionData: { caption, back } } = request.pre
@@ -60,7 +61,7 @@ const postSelectAddress = (request, h) => {
   }
 
   const { key } = request.params
-  const { addressSearchResults } = request.pre
+  const { addressSearchResults } = preHandlers.searchForAddressesByPostcode(request)
   const { uprn } = forms.getValues(form)
 
   const selectedAddress = addressSearchResults.find(address => address.uprn === parseInt(uprn))

--- a/src/internal/modules/address-entry/controller.js
+++ b/src/internal/modules/address-entry/controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit, add } = require('lodash')
+const { omit } = require('lodash')
 
 const forms = require('shared/lib/forms')
 const { addressSources } = require('shared/lib/constants')

--- a/src/internal/modules/address-entry/controller.js
+++ b/src/internal/modules/address-entry/controller.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit } = require('lodash')
+const { omit, add } = require('lodash')
 
 const forms = require('shared/lib/forms')
 const { addressSources } = require('shared/lib/constants')
@@ -28,6 +28,28 @@ const getPostcode = async (request, h) => {
   const postcodeForm = handleFormRequest(request, addressForms.ukPostcode)
   const selectAddressForm = handleFormRequest(request, addressForms.selectAddress)
 
+  // NOTE: This is a solution for an edge case, and necessary because of the inflexibility of the custom form engine
+  // that has been built into the app. The scenario is
+  //
+  // - user submits a postcode
+  // - we return the results in the select address page
+  // - user hits submit without selecting an address
+  //
+  // When this happens postSelectAddress() will add the error to the form object then stash the whole form in the
+  // session (this is how the engine works!! Check out src/shared/lib/session-forms.js). Prior to PR #2062 they would
+  // have also used the pre-handler searchForAddressesByPostcode() to find matching addresses whether the user had
+  // selected one or not. The results would then have been stashed with the form in the session as well. But we had to
+  // stop this because the redirect to getPostcode() within a few milliseconds was hitting the Address facades rate
+  // limit causing an error. So, now the stashed form has no addresses.
+  //
+  // This controller still uses the pre-handler searchForAddressesByPostcode() because it always needs them.
+  // So, to handle this edge case we now do a check to see if the form we get back from handleFormRequest() is the
+  // stashed one with an error. If it is we apply the address results we have to it, so the lookup is re-populated.
+  const addresses = request.pre.addressSearchResults || []
+  if (selectAddressForm.errors.length > 0) {
+    selectAddressForm.fields[0].options.choices = addressForms.selectAddress.getAddressChoices(addresses)
+  }
+
   // If valid postcode, select available addresses
   const isPostcodeSelected = [postcodeForm.isValid, selectAddressForm.isSubmitted].includes(true)
   if (isPostcodeSelected) {
@@ -53,7 +75,7 @@ const getPostcode = async (request, h) => {
 /**
  * Post handler for selecting address
  */
-const postSelectAddress = (request, h) => {
+const postSelectAddress = async (request, h) => {
   const form = handleFormRequest(request, addressForms.selectAddress)
 
   if (!form.isValid) {
@@ -61,11 +83,16 @@ const postSelectAddress = (request, h) => {
   }
 
   const { key } = request.params
-  const { addressSearchResults } = preHandlers.searchForAddressesByPostcode(request)
+
+  // NOTE: It _is_ odd to call the pre-handler here. But this is all to stop thrashing the Address facade, especially
+  // if there is an issue with what the user submitted as this would cause an immediate redirect back to getPostcode()
+  // which also uses the pre-handler.
+  const addressSearchResults = await preHandlers.searchForAddressesByPostcode(request)
   const { uprn } = forms.getValues(form)
 
   const selectedAddress = addressSearchResults.find(address => address.uprn === parseInt(uprn))
   const { redirectPath } = session.merge(request, key, { data: selectedAddress })
+
   return h.redirect(redirectPath)
 }
 

--- a/src/internal/modules/address-entry/forms/select-address.js
+++ b/src/internal/modules/address-entry/forms/select-address.js
@@ -89,5 +89,8 @@ const schema = request => {
   })
 }
 
-exports.form = form
-exports.schema = schema
+module.exports = {
+  form,
+  getAddressChoices,
+  schema
+}

--- a/src/internal/modules/address-entry/forms/select-address.js
+++ b/src/internal/modules/address-entry/forms/select-address.js
@@ -56,6 +56,9 @@ const form = request => {
     errors: {
       'any.only': {
         message: 'Select an address from the list'
+      },
+      'number.base': {
+        message: 'Select an address from the list'
       }
     },
     label: 'Select an address',

--- a/src/internal/modules/address-entry/forms/select-address.js
+++ b/src/internal/modules/address-entry/forms/select-address.js
@@ -77,7 +77,7 @@ const form = request => {
 const getUprn = address => address.uprn
 
 const schema = request => {
-  const { addressSearchResults } = request.pre
+  const addressSearchResults = request.pre.addressSearchResults || []
   const validUprns = addressSearchResults.map(getUprn)
   return Joi.object().keys({
     csrf_token: Joi.string().uuid().required(),

--- a/src/internal/modules/address-entry/routes.js
+++ b/src/internal/modules/address-entry/routes.js
@@ -46,8 +46,6 @@ module.exports = {
       },
       pre: [{
         method: preHandlers.getSessionData, assign: 'sessionData'
-      }, {
-        method: preHandlers.searchForAddressesByPostcode, assign: 'addressSearchResults'
       }]
     }
   },

--- a/src/shared/lib/form-handler.js
+++ b/src/shared/lib/form-handler.js
@@ -15,23 +15,34 @@ const isGet = method => isEqualCaseInsensitive(method, 'get')
  * @return {Object}
  */
 const handleFormRequest = (request, formContainer) => {
-  let form = formContainer.form(request)
+  // The default form is based on whatever the underlying form container, for example
+  // src/internal/modules/address-entry/forms/select-address.js generates plus what it extracts from the request object.
+  const defaultForm = formContainer.form(request)
 
-  // Use session forms for post forms
-  if (isPost(form.method) && isGet(request.method)) {
-    form = sessionForms.get(request, formContainer.form(request))
+  let processedForm
+
+  // Some forms, like the select-address form, are designated as 'post' forms. The user is expected to submit a value
+  // and the form will be POSTed to the UI. What this is checking for is we have a GET request for a 'post' form based
+  // page. If we do, there are 2 possible scenarios
+  //
+  // - this is the first GET request to the page so sessionForms() will pull nothing out of the session and default to
+  //   defaultForm. This will then be used to build the page
+  // - this is a result of a POST request being rejected because of a validation error. This means the form will have
+  //   been saved in the session and sessionForms() will retrieve it along with the error details. defaultForm will be
+  //   ignored
+  if (isPost(defaultForm.method) && isGet(request.method)) {
+    processedForm = sessionForms.get(request, defaultForm)
   }
 
-  // Handle request
-  if (isEqualCaseInsensitive(request.method, form.method)) {
-    form = forms.handleRequest(
-      formContainer.form(request),
-      request,
-      formContainer.schema(request)
-    )
+  // If we didn't fall into the previous block we next check if the type of form matches the request type. This is
+  // where a form submission will be validated, for example when the select-address form (a 'post' designated form) is
+  // POSTed to the UI the submission will be checked. forms.handleRequest() is where all the Joi validation and
+  // custom error message determination happens
+  if (isEqualCaseInsensitive(request.method, defaultForm.method)) {
+    processedForm = forms.handleRequest(defaultForm, request, formContainer.schema(request))
   }
 
-  return form
+  return processedForm
 }
 
 exports.handleFormRequest = handleFormRequest

--- a/test/internal/modules/address-entry/controller.test.js
+++ b/test/internal/modules/address-entry/controller.test.js
@@ -10,6 +10,7 @@ const {
 const sandbox = require('sinon').createSandbox()
 const { v4: uuid } = require('uuid')
 
+const AddressEntryPreHandlers = require('../../../../src/internal/modules/address-entry/pre-handlers.js')
 const controller = require('internal/modules/address-entry/controller')
 const session = require('internal/modules/address-entry/lib/session')
 
@@ -80,6 +81,8 @@ experiment('src/internal/modules/address-entry/controller.js', () => {
       redirect: sandbox.stub(),
       postRedirectGet: sandbox.stub()
     }
+
+    sandbox.stub(AddressEntryPreHandlers, 'searchForAddressesByPostcode').resolves(request.pre.addressSearchResults)
 
     sandbox.stub(session, 'merge').returns({
       redirectPath: REDIRECT_PATH


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3943

This was spotted when attempting to sign off the next release of the service and running through creating a new billing account with a new address during charge version creation. Having entered a postcode and searched for it you are presented with the drop-down of addresses found from which you must make a selection.

If you don't select anything and click continue, the validation message should be 'Select an address from the list'. Instead, the Ui is erroring and returning a `500` to the user.

This is not the result of a recent change, but one we made back in August 2022; [Remove catbox-redis](https://github.com/DEFRA/water-abstraction-service/pull/1794) from service So, the error has been present for some time. The reason given for adding [catbox-redis](https://github.com/hapijs/catbox-redis) by the previous team was

> caching avoids API rate limit being exceeded on subsequent identical requests

As part of our general maintenance of the service, this was identified as being woefully out-of-date and was going to need us to re-write our code in order to work with the latest version.

But we also knew that we are using a version of the [Address-facade](https://github.com/DEFRA/ea-address-facade) which has a rate limiter built-in so we are protected from getting into trouble with OS Places. And we are not a service that sees enough traffic to be hitting their rate limiter anyway. So, this appeared to be a performance/protection change that was unnecessary. On that basis, we instead chose to remove **catbox-redis**. One less dependency, code deleted and a baby step towards a simpler solution.

When we investigated the problem we found who was causing us to hit the rate limit by performing the equivalent of a DOS attack; us!

The sequence we found is

- user submits postcode and UI redirects the request to the address selection page after validating the postcode
- redirect GET request received by UI and pre-handler function calls the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) to perform the postcode search
  - address-facade receives request, hits OS Places and returns results to the water-abstraction-service
  - water-abstraction-service returns the results to the UI
- UI returns the page to the user with the address dropdown populated with the results (UPRN and address for each one)
- user clicks continue without selecting an address
- POST request received by UI and pre-handler function calls the water-abstraction-service to perform the postcode search (it is grabbing the results in preparation for identifying which one has the UPRN the user selected)
- UI deems the request invalid because no UPRN was selected and redirects to the address selection page
- redirect GET request received by the UI and the pre-handler function calls the water-abstraction-service to perform the postcode search
  - address-facade receives request and rejects it. This is because the last 2 requests come within a few milliseconds of each other
  - water-abstraction-service does not handle the error so returns a 500 to the UI
- UI does not handle the error so returns a 500 to the user

It's the previous team's love of [pre-handlers](https://hapi.dev/api/?v=21.3.0#route.options.pre) to blame here. We shouldn't be making the request for address results in the POST request until we have verified that the user has submitted a UPRN. But the previous team liked to hide a lot of functionality in these pre-handler methods which are always called before the controller. It's very much a "we have a groovy new hammer. Now everything looks like a nail" approach.

This change does what we think should be done; drop the pre-handler on the POST request in the UI and only call the water-abstraction-service once we have confirmed a UPRN has been selected.

But nothing is ever simple! This area of the UI is where the previous team decided to use the custom form engine they built into the app! So, all the pages use generic code to generate the page based on properties, modules and functions you have to provide.

In the case of the select address 'form' they have not been consistent in their approach. Some places protect against the address results being blank. In others it is assumed you have results and that the pre-handler has run. So, without them, we cause other errors to be thrown.

We also found that the error [joi](https://github.com/hapijs/joi) generates when the UPRN is missing doesn't match the custom error assigned to this custom field in the custom form. I mean, for the love of...! 😩🤦

So, we fix all that as well 😁