### PR TITLE
Highlight flagged for SROC supplementary billing

### DIFF
--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -78,6 +78,7 @@ const getLicenceSummary = async (request, h) => {
     },
     links: getLinks({ licenceId, documentId }, permissions),
     validityMessage: mappers.getValidityNotice(licence),
+    includeInSupplementaryBillingMessage: _includeInSupplementaryBillingMessage(licence),
     back: '/licences'
   })
 }
@@ -133,6 +134,22 @@ const postMarkLicenceForSupplementaryBilling = async (request, h) => {
     panelText: `Licence number: ${licenceRef}`,
     licenceId
   })
+}
+
+const _includeInSupplementaryBillingMessage = (licence) => {
+  const includeInPresroc = ['yes', 'reprocess'].includes(licence.includeInSupplementaryBilling)
+  const includeInSroc = licence.includeInSrocSupplementaryBilling
+
+  let message = null
+  if (includeInPresroc && includeInSroc) {
+    message = 'This licence has been marked for the next old charge and current charge scheme supplementary bill runs'
+  } else if (includeInPresroc) {
+    message = 'This licence has been marked for the next old charge scheme supplementary bill run'
+  } else if (includeInSroc) {
+    message = 'This licence has been marked for the next supplementary bill run'
+  }
+
+  return message
 }
 
 exports.getLicenceSummary = getLicenceSummary

--- a/src/internal/views/nunjucks/view-licences/licence.njk
+++ b/src/internal/views/nunjucks/view-licences/licence.njk
@@ -9,9 +9,9 @@
     <div class="govuk-grid-column-full">
 
 
-    {% if licence.includeInSupplementaryBilling == 'yes' or licence.includeInSupplementaryBilling == 'reprocess'  %}
+    {% if includeInSupplementaryBillingMessage %}
         {{ govukNotificationBanner({
-              html: '<strong>This licence has been marked for the next supplementary bill run</strong>'
+              html: '<strong>' + includeInSupplementaryBillingMessage + '</strong>'
         }) }}
     {% endif %}
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3948

We have an issue that the current `include_in_supplementary_billing` flag was added at a time there was only 1 charge scheme. A licence gets flagged irrespective of whether the change relates to PRESROC or SROC.

Where that has impacted us is when sending a billing batch. When it gets sent it clears the flag for _all_ licences included. But if we cancel one, for example, the PRESROC bill run, and send the SROC one we lose which licences still need to be processed on the PRESROC one.

[Our solution](https://github.com/DEFRA/water-abstraction-service/pull/2077) was to add a new `include_in_sroc_supplementary_billing` flag to the `licences` table and only set it to 'true' when an SROC charge version is approved. But this means a licence might be flagged only for SROC supplementary billing and the existing functionality to highlight this only looks at the `include_in_supplementary_billing` field.

This change updates the 'marked for next supplementary bill run' notice to handle

- marked for next PRESROC supplementary bill run only
- marked for next SROC supplementary bill run only
- marked for both schemes next supplementary bill run only

<details>
<summary>Examples of the updated notice</summary>

![sup-billing-notice](https://user-images.githubusercontent.com/1789650/228056276-7e50ed0b-9d3f-41d0-8fc4-7f0ae80db692.png)

</details>