### PR TITLE
Download of Bulk Returns Data Fails with Rejected URL

### DIFF
--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -13,7 +13,6 @@ const uploadHelpers = new UploadHelpers('returns', validTypes, services, logger,
 const { NO_FILE, OK } = UploadHelpers.fileStatuses
 const uploadSummaryHelpers = require('../lib/upload-summary-helpers')
 const csvTemplates = require('../lib/csv-templates')
-const { Readable } = require('stream')
 
 const confirmForm = require('../forms/confirm-upload')
 const helpers = require('../lib/helpers')
@@ -241,13 +240,7 @@ const getCSVTemplates = async (request, h) => {
   const zip = await csvTemplates.buildZip(data, companyName)
   const fileName = getZipFilename(companyName, endDate.substring(0, 4))
 
-  // At this stage `zip` is a stream in objectMode. Hapi will not return streams in objectMode so we wrap it in a
-  // readable stream. A better solution would be for `zip` to not be in objectMode in the first place but as far as we
-  // can see the archiver library we use does not support this. More info can be found here:
-  // https://github.com/hapijs/hapi/issues/3733
-  const zipStream = new Readable().wrap(zip)
-
-  return h.response(zipStream)
+  return h.response(zip)
     .header('Content-type', 'application/zip')
     .header('Content-disposition', `attachment; filename="${fileName}"`)
 }

--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -13,6 +13,7 @@ const uploadHelpers = new UploadHelpers('returns', validTypes, services, logger,
 const { NO_FILE, OK } = UploadHelpers.fileStatuses
 const uploadSummaryHelpers = require('../lib/upload-summary-helpers')
 const csvTemplates = require('../lib/csv-templates')
+const { Readable } = require('stream')
 
 const confirmForm = require('../forms/confirm-upload')
 const helpers = require('../lib/helpers')
@@ -240,7 +241,13 @@ const getCSVTemplates = async (request, h) => {
   const zip = await csvTemplates.buildZip(data, companyName)
   const fileName = getZipFilename(companyName, endDate.substring(0, 4))
 
-  return h.response(zip)
+  // At this stage `zip` is a stream in objectMode. Hapi will not return streams in objectMode so we wrap it in a
+  // readable stream. A better solution would be for `zip` to not be in objectMode in the first place but as far as we
+  // can see the archiver library we use does not support this. More info can be found here:
+  // https://github.com/hapijs/hapi/issues/3733
+  const zipStream = new Readable().wrap(zip)
+
+  return h.response(zipStream)
     .header('Content-type', 'application/zip')
     .header('Content-disposition', `attachment; filename="${fileName}"`)
 }

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -7,6 +7,7 @@ const moment = require('moment')
 const util = require('util')
 const archiver = require('archiver')
 const path = require('path')
+const { Readable } = require('stream')
 const { stringify } = require('csv-stringify')
 
 const csvStringify = util.promisify(stringify)
@@ -229,7 +230,11 @@ const buildZip = async (data, companyName, archive) => {
 
   archive.finalize()
 
-  return archive
+  // At this stage `archive` is a stream in objectMode. Hapi will not return streams in objectMode so we wrap it in a
+  // readable stream. A better solution would be for `zip` to not be in objectMode in the first place but as far as we
+  // can see the archiver library we use does not support this. More info can be found here:
+  // https://github.com/hapijs/hapi/issues/3733
+  return new Readable().wrap(archive)
 }
 
 exports._getCSVLineLabel = getCSVLineLabel

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -7,7 +7,7 @@ const moment = require('moment')
 const util = require('util')
 const archiver = require('archiver')
 const path = require('path')
-const { Readable } = require('stream')
+const { PassThrough } = require('stream')
 const { stringify } = require('csv-stringify')
 
 const csvStringify = util.promisify(stringify)
@@ -230,11 +230,11 @@ const buildZip = async (data, companyName, archive) => {
 
   archive.finalize()
 
-  // At this stage `archive` is a stream in objectMode. Hapi will not return streams in objectMode so we wrap it in a
-  // readable stream. A better solution would be for `archive` to not be in objectMode in the first place but as far as
-  // we can see the archiver library we use does not support this. More info can be found here:
-  // https://github.com/hapijs/hapi/issues/3733
-  return new Readable().wrap(archive)
+  // At this stage `archive` is a stream in objectMode. As of 21.0.0 Hapi will not return streams in objectMode so we
+  // pipe it though a readable passthrough stream. A better solution would be for `archive` to not be in objectMode in
+  // the first place but as far as we can see the archiver library we use does not support this. More info can be found
+  // in the 21.0.0 release notes: https://github.com/hapijs/hapi/issues/4386
+  return archive.pipe(new PassThrough())
 }
 
 exports._getCSVLineLabel = getCSVLineLabel

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -231,8 +231,8 @@ const buildZip = async (data, companyName, archive) => {
   archive.finalize()
 
   // At this stage `archive` is a stream in objectMode. Hapi will not return streams in objectMode so we wrap it in a
-  // readable stream. A better solution would be for `zip` to not be in objectMode in the first place but as far as we
-  // can see the archiver library we use does not support this. More info can be found here:
+  // readable stream. A better solution would be for `archive` to not be in objectMode in the first place but as far as
+  // we can see the archiver library we use does not support this. More info can be found here:
   // https://github.com/hapijs/hapi/issues/3733
   return new Readable().wrap(archive)
 }

--- a/test/external/modules/returns/lib/csv-template.test.js
+++ b/test/external/modules/returns/lib/csv-template.test.js
@@ -15,6 +15,12 @@ experiment('csv templates', () => {
   let archive
 
   beforeEach(async () => {
+    // We create an instance of `archive` so it can be piped through a passthrough stream, which would be awkward to do
+    // if we simply created a mock object.
+    archive = archiver('zip')
+    archive.append = sandbox.stub()
+    archive.finalize = sandbox.stub()
+
     sandbox.stub(logger, 'warn')
   })
 
@@ -307,12 +313,6 @@ experiment('csv templates', () => {
   })
 
   experiment('addCSVToArchive', () => {
-    beforeEach(async () => {
-      archive = {
-        append: sandbox.stub()
-      }
-    })
-
     test('adds the CSV file specified in the key to the ZIP archive', async () => {
       const data = {
         day: [['foo', 'bar']]
@@ -327,12 +327,6 @@ experiment('csv templates', () => {
   })
 
   experiment('addReadmeToArchive', () => {
-    beforeEach(async () => {
-      archive = {
-        append: sandbox.stub()
-      }
-    })
-
     test('adds the readme file to the ZIP archive', async () => {
       await csvTemplates._addReadmeToArchive(archive)
 
@@ -381,14 +375,6 @@ experiment('csv templates', () => {
   })
 
   experiment('buildZip', () => {
-    beforeEach(async () => {
-      // We create an instance of `archive` so the function can wrap it as a readable stream, which would be awkward to
-      // do if we simply created a mock object.
-      archive = archiver('zip')
-      archive.append = sandbox.stub()
-      archive.finalize = sandbox.stub()
-    })
-
     test('should build a zip file', async () => {
       const data = {
         day: [['foo', 'bar']]

--- a/test/external/modules/returns/lib/csv-template.test.js
+++ b/test/external/modules/returns/lib/csv-template.test.js
@@ -382,7 +382,8 @@ experiment('csv templates', () => {
 
   experiment('buildZip', () => {
     beforeEach(async () => {
-      // Creating an actual 'archive' instance as we weren't able to wrap it as a readable stream
+      // We create an instance of `archive` so the function can wrap it as a readable stream, which would be awkward to
+      // do if we simply created a mock object.
       archive = archiver('zip')
       archive.append = sandbox.stub()
       archive.finalize = sandbox.stub()

--- a/test/external/modules/returns/lib/csv-template.test.js
+++ b/test/external/modules/returns/lib/csv-template.test.js
@@ -7,6 +7,7 @@ const sandbox = require('sinon').createSandbox()
 
 const helpers = require('@envage/water-abstraction-helpers')
 
+const archiver = require('archiver')
 const { logger } = require('external/logger')
 const csvTemplates = require('external/modules/returns/lib/csv-templates')
 
@@ -14,10 +15,6 @@ experiment('csv templates', () => {
   let archive
 
   beforeEach(async () => {
-    archive = {
-      append: sandbox.stub(),
-      finalize: sandbox.stub()
-    }
     sandbox.stub(logger, 'warn')
   })
 
@@ -310,6 +307,12 @@ experiment('csv templates', () => {
   })
 
   experiment('addCSVToArchive', () => {
+    beforeEach(async () => {
+      archive = {
+        append: sandbox.stub()
+      }
+    })
+
     test('adds the CSV file specified in the key to the ZIP archive', async () => {
       const data = {
         day: [['foo', 'bar']]
@@ -324,6 +327,12 @@ experiment('csv templates', () => {
   })
 
   experiment('addReadmeToArchive', () => {
+    beforeEach(async () => {
+      archive = {
+        append: sandbox.stub()
+      }
+    })
+
     test('adds the readme file to the ZIP archive', async () => {
       await csvTemplates._addReadmeToArchive(archive)
 
@@ -372,6 +381,13 @@ experiment('csv templates', () => {
   })
 
   experiment('buildZip', () => {
+    beforeEach(async () => {
+      // Creating an actual 'archive' instance as we weren't able to wrap it as a readable stream
+      archive = archiver('zip')
+      archive.append = sandbox.stub()
+      archive.finalize = sandbox.stub()
+    })
+
     test('should build a zip file', async () => {
       const data = {
         day: [['foo', 'bar']]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3954

When trying to download the data for Bulk returns, you receive the Rejected URL error rather than the save file page.

This turns out to be because the zip file is generated as a stream in `objectMode` but hapi does not allow `objectMode` streams to be returned. We therefore need to wrap the zip file in a Readable stream to keep hapi happy.

Ideally, the zip file would not be generated as a stream in `objectMode` but we couldn't see anything in the Archiver package docs to indicate this is possible!

More info on hapi and `objectMode` streams can be found here: https://github.com/hapijs/hapi/issues/3733