### PR TITLE
Update include licence in supp. billing messages

### DIFF
--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -142,11 +142,11 @@ const _includeInSupplementaryBillingMessage = (licence) => {
 
   let message = null
   if (includeInPresroc && includeInSroc) {
-    message = 'This licence has been marked for the next old charge and current charge scheme supplementary bill runs'
+    message = 'This licence has been marked for the next supplementary bill runs for the current and old charge schemes.'
   } else if (includeInPresroc) {
-    message = 'This licence has been marked for the next old charge scheme supplementary bill run'
+    message = 'This licence has been marked for the next supplementary bill run for the old charge scheme.'
   } else if (includeInSroc) {
-    message = 'This licence has been marked for the next supplementary bill run'
+    message = 'This licence has been marked for the next supplementary bill run.'
   }
 
   return message

--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -272,7 +272,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
           const [, { includeInSupplementaryBillingMessage }] = h.view.lastCall.args
           expect(includeInSupplementaryBillingMessage).to.equal(
-            'This licence has been marked for the next old charge scheme supplementary bill run'
+            'This licence has been marked for the next supplementary bill run for the old charge scheme.'
           )
         })
       })
@@ -287,7 +287,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
           const [, { includeInSupplementaryBillingMessage }] = h.view.lastCall.args
           expect(includeInSupplementaryBillingMessage).to.equal(
-            'This licence has been marked for the next supplementary bill run'
+            'This licence has been marked for the next supplementary bill run.'
           )
         })
       })
@@ -303,7 +303,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
           const [, { includeInSupplementaryBillingMessage }] = h.view.lastCall.args
           expect(includeInSupplementaryBillingMessage).to.equal(
-            'This licence has been marked for the next old charge and current charge scheme supplementary bill runs'
+            'This licence has been marked for the next supplementary bill runs for the current and old charge schemes.'
           )
         })
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3948

In [Highlight flagged for SROC supplementary billing](https://github.com/DEFRA/water-abstraction-ui/pull/2322) we made a change to the notice shown to users when a licence is flagged for supplementary billing. The first iteration of the wording was what us developers had put together based on the existing messages and changes elsewhere in the service.

Our UAT team have now had a chance to look at them and asked for some tweaks.

Pre-sroc (old charge scheme) needs to be

> This licence has been marked for the next supplementary bill run for the old charge scheme.

When a licence is flagged for both the old and new schemes

> This licence has been marked for the next supplementary bill runs for the current and old charge schemes.
