### PR TITLE
Enable cancel btn for empty & errored bill runs

### DIFF
--- a/src/internal/views/nunjucks/billing/batch-empty.njk
+++ b/src/internal/views/nunjucks/billing/batch-empty.njk
@@ -1,7 +1,9 @@
 {% extends "./nunjucks/layout.njk" %}
 
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "./nunjucks/billing/macros/batch-header.njk" import batchHeader %}
+{% from "./nunjucks/billing/macros/batch-buttons.njk" import cancelBatchButton %}
 
 {% block content %}
 
@@ -16,9 +18,18 @@
 
   {{ batchHeader(pageTitle, batch) }}
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <section class="govuk-!-margin-bottom-6">
+
+        {{ cancelBatchButton(batch) }}
+
+      </section>
+    </div>
+  </div>
+
   <p>
     <a href="{{ back }}">Return to bill runs</a>
   </p>
 
 {% endblock %}
-

--- a/src/internal/views/nunjucks/billing/batch-error.njk
+++ b/src/internal/views/nunjucks/billing/batch-error.njk
@@ -1,7 +1,9 @@
 {% extends "./nunjucks/layout.njk" %}
 
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "./nunjucks/billing/macros/batch-header.njk" import batchHeader %}
+{% from "./nunjucks/billing/macros/batch-buttons.njk" import cancelBatchButton %}
 
 {% block content %}
 
@@ -11,6 +13,16 @@
   }) }}
 
   {{ batchHeader(pageTitle, batch) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <section class="govuk-!-margin-bottom-6">
+
+        {{ cancelBatchButton(batch) }}
+
+      </section>
+    </div>
+  </div>
 
   <p class="govuk-body">
     <a href="{{ back }}">Return to bill runs</a>

--- a/src/internal/views/nunjucks/billing/macros/batch-buttons.njk
+++ b/src/internal/views/nunjucks/billing/macros/batch-buttons.njk
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro cancelBatchButton(batch) %}
-  {% if batch.status in['ready', 'review'] %}
+  {% if batch.status in['ready', 'review', 'empty', 'error'] %}
     {{
     govukButton({
       text: "Cancel bill run",


### PR DESCRIPTION
We've been hitting the supplementary bill run process _hard_ over the last few months as we have tested and investigated the myriad scenarios we need to cover. During this we've noted we get many more `EMPTY` bill runs because of the need to kick off both PRESROC and SROC. It has also always puzzled us why you can't get rid of `ERRORED` bill runs.

So, this quick tweak adds the **Cancel** button to the empty and errored bill run pages to allow users to get rid of them from the listings. It might also help the performance of the page not to include these bill runs in the results.

<details>
<summary>Screenshot of bill runs page</summary>

<img width="978" alt="Screenshot 2023-05-10 at 09 34 25" src="https://github.com/DEFRA/water-abstraction-ui/assets/1789650/ef970c0c-f379-4016-93d2-42fa57f5c7d2">

</detail>