### PR TITLE
Additional charges incorrect for supported sources

### DIFF
--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -52,7 +52,7 @@ const getSortKey = trans => `${get(trans, 'chargeElement.id')}_${trans.isCompens
 const getAdditionalCharges = transaction => {
   const additionalCharges = []
   if (transaction.supportedSourceName) {
-    additionalCharges.push(`Supported source ${transaction.supportedSourceName} (${numberFormatter.formatCurrency(transaction.grossValuesCalculated.supportedSourceCharge, transaction.isCredit, true)})`)
+    additionalCharges.push(`Supported source ${transaction.supportedSourceName} (${numberFormatter.formatCurrency(transaction.grossValuesCalculated.supportedSourceCharge, transaction.isCredit, true, false)})`)
   }
   if (transaction.isWaterCompanyCharge) {
     additionalCharges.push('Public Water Supply')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4001

Following the fix in https://github.com/DEFRA/water-abstraction-service/pull/2142, which fixed the issue where the incorrect value was being used for the Support Sources additional charges.

It has been found during testing that this value is incorrectly formatted from pence to pounds. As the corrected value is already in pounds and needs no conversion.

This PR will fix that issue by preventing the `numberFormatter.formatCurrency()` function from converting the value from pence to pounds by setting its `penceToPounds` value to `false` from its default of `true`.