### PR TITLE
Remove package `del`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,13 +3,22 @@ const sass = require('gulp-sass')(require('sass'))
 const sourcemaps = require('gulp-sourcemaps')
 const concat = require('gulp-concat')
 const uglify = require('gulp-uglify')
-const del = require('del')
+const fs = require('fs')
 
 const paths = {
   public: 'public/'
 }
 
-gulp.task('clean', () => del([paths.public]))
+gulp.task('clean', (done) => {
+  fs.rm(paths.public, { recursive: true }, (error) => {
+    if (error) {
+      console.error(error.message)
+    } else {
+      console.log(`Directory ${paths.public} deleted!`)
+    }
+    done()
+  })
+})
 
 const combineMinifyJs = (files, destination) => {
   return gulp.src(files)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const paths = {
 gulp.task('clean', (done) => {
   fs.rm(paths.public, { recursive: true }, (error) => {
     if (error) {
-      console.error(error.message)
+      console.log(error.message)
     } else {
       console.log(`Directory ${paths.public} deleted!`)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "cypress": "^8.7.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-multi-reporters": "^1.6.3",
-        "del": "^6.0.0",
         "gulp": "^4.0.2",
         "gulp-concat": "^2.6.1",
         "gulp-sass": "^5.1.0",
@@ -5213,37 +5212,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8791,15 +8759,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-path-inside": {
@@ -19261,30 +19220,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "requires": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -22060,12 +21995,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true
     },
     "is-path-inside": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "cypress": "^8.7.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.3",
-    "del": "^6.0.0",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-sass": "^5.1.0",


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/78

After working on the issue [Swap out or remove Deprecated packages](https://github.com/DEFRA/water-abstraction-team/issues/22) for the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui) in this [PR #2302](https://github.com/DEFRA/water-abstraction-ui/pull/2302) we found that in order to update/replace/remove some of the packages a significant amount of work was needed. These are therefore going to be done individually in separate PRs.

This PR removes the `del` package since we don't need to import a package just to delete a folder!