### PR TITLE
Warn the user if a bill run is 'processing'

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -89,7 +89,7 @@ const getBillingBatchList = async (request, h) => {
   const batches = data.map(mappers.mapBatchListRow)
 
   const billRunBuilding = batches.some((batch) => {
-    return batch.status === 'processing'
+    return batch.status === 'processing' || batch.status === 'queued'
   })
 
   return h.view('nunjucks/billing/batch-list', {

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -86,10 +86,16 @@ const getBillingBatchInvoice = async (request, h) => {
 const getBillingBatchList = async (request, h) => {
   const { page } = request.query
   const { data, pagination } = await batchService.getBatchList(page, billRunsToDisplayPerPage)
+  const batches = data.map(mappers.mapBatchListRow)
+
+  const billRunBuilding = batches.some((batch) => {
+    return batch.status === 'processing'
+  })
 
   return h.view('nunjucks/billing/batch-list', {
     ...request.view,
-    batches: data.map(mappers.mapBatchListRow),
+    batches,
+    billRunBuilding,
     pagination,
     form: featureToggles.deleteAllBillingData && confirmForm.form(request, 'Delete all bills and charge information', {
       action: '/billing/batch/delete-all-data',

--- a/src/internal/views/nunjucks/billing/batch-list.njk
+++ b/src/internal/views/nunjucks/billing/batch-list.njk
@@ -3,18 +3,24 @@
 {% from "paginate.njk" import paginate %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "./nunjucks/billing/macros/totals.njk" import chargeOrDash %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% block content %}
 
+  {% if billRunBuilding %}
+    {{ govukNotificationBanner({
+        html: '<p class="govuk-notification-banner__heading">A bill run is currently building.</p>
+          <p class="govuk-body">You must wait for this bill run to finish before you can create another one.</p>'
+    }) }}
+  {% endif %}
+
   {{ title(pageTitle) }}
   <p class="govuk-body">Create a supplementary, annual or two-part tariff bill run.</p>
-  {{
 
-  govukButton({
-    text: "Create a bill run",
-    href: '/billing/batch/type'
-  })
-}}
+  {{ govukButton({
+      text: "Create a bill run",
+      href: '/billing/batch/type'
+    }) }}
 
   {% if batches.length %}
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-top-3">

--- a/src/internal/views/nunjucks/billing/batch-list.njk
+++ b/src/internal/views/nunjucks/billing/batch-list.njk
@@ -10,7 +10,7 @@
   {% if billRunBuilding %}
     {{ govukNotificationBanner({
         html: '<p class="govuk-notification-banner__heading">A bill run is currently building.</p>
-          <p class="govuk-body">You must wait for this bill run to finish before you can create another one.</p>'
+          <p class="govuk-body">Please wait for this bill run to finish building before creating another one.</p>'
     }) }}
   {% endif %}
 

--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -518,7 +518,7 @@ experiment('internal/modules/billing/controller', () => {
 
     test('passes the required batch list data to the view', async () => {
       const [, context] = h.view.lastCall.args
-      const { batches } = context
+      const { batches, billRunBuilding } = context
 
       expect(batches).to.be.array()
       expect(batches[0].batchType).to.equal('Supplementary')
@@ -533,6 +533,7 @@ experiment('internal/modules/billing/controller', () => {
       expect(batches[1].billCount).to.equal(8)
       expect(batches[1].link).to.be.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e2/two-part-tariff-review')
       expect(batches[1].scheme).to.equal('sroc')
+      expect(billRunBuilding).to.be.true()
     })
 
     test('configures the expected view template', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4030

The B&D frequently report issues with performance in the WRLS service. The same goes for errors when running bill runs.

This isn’t surprising to the new dev team based on how we now understand the service has been built and architected.

Since joining, we have advocated that the B&D should only run one bill at a time. We believe this will reduce the performance hit on the overall service and the likelihood of errors.

It seems that this message has not always been received or understood. Recent supplementary billing testing highlighted this when all the region leads were trying to test bill runs simultaneously.

This PR adds a notification banner to the 'Bill runs' page which is displayed if a bill run has a status of 'Building' or 'Queued'. This notification instructs the user to wait for the bill run to finish before creating another one.