### PR TITLE
Add POST support to system proxy

### DIFF
--- a/src/internal/modules/system-proxy/routes.js
+++ b/src/internal/modules/system-proxy/routes.js
@@ -59,6 +59,23 @@ const routes = [
       auth: false,
       description: 'Proxies CSS asset requests to the Water Abstraction System'
     }
+  },
+  {
+    method: 'POST',
+    // This will match all path segments after /system. Note in our proxy URI we refer to this only as {tail}. The path
+    // param hapi provides will contain all the segments, for example, request.params.tail === '/test/supplementary'.
+    // We need to refer to it in the same way we access it on the request object.
+    path: '/system/{tail*}',
+    handler: {
+      proxy: {
+        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/{tail}{query}`,
+        ...proxyDefaults
+      }
+    },
+    config: {
+      auth: false,
+      description: 'Proxies requests to the Water Abstraction System'
+    }
   }
 ]
 


### PR DESCRIPTION
We need to send POST requests to water-abstraction-system, for example, when calling `/data/tear-down`. So, we need to add a POST route to the system proxy routes to support this.