### PR TITLE
Fix name used for billing contact

### DIFF
--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -35,11 +35,12 @@ const getBillingAccount = (request, h) => {
     `/billing-accounts/${billingAccountId}/bills`
 
   const metadataHtml = generateBillingAccountMetadata(billingAccount)
+  console.log('🚀 ~ file: billing-accounts.js:38 ~ getBillingAccount ~ billingAccount:', billingAccount)
 
   return h.view('nunjucks/billing-accounts/view', {
     ...request.view,
     caption: getBillingAccountCaption(billingAccount),
-    pageTitle: `Billing account for ${titleCase(billingAccount.company.name)}`,
+    pageTitle: `Billing account for ${titleCase(_billForName(billingAccount))}`,
     back,
     currentAddress: getCurrentAddress(billingAccount),
     billingAccount,
@@ -68,6 +69,18 @@ const getBillingAccountBills = (request, h) => {
     pagination,
     path: request.path
   })
+}
+
+function _billForName (invoiceAccount) {
+  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+    return new Date(b.date) - new Date(a.date)
+  })
+
+  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  }
+
+  return invoiceAccount.company.name
 }
 
 exports.getBillingAccount = getBillingAccount

--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -72,15 +72,19 @@ const getBillingAccountBills = (request, h) => {
 }
 
 function _billForName (invoiceAccount) {
-  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
-    return new Date(b.date) - new Date(a.date)
-  })
+  let result = invoiceAccount.company.name
 
-  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
-    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  if (invoiceAccount.invoiceAccountAddresses) {
+    invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date)
+    })
+
+    if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+      result = invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+    }
   }
 
-  return invoiceAccount.company.name
+  return result
 }
 
 exports.getBillingAccount = getBillingAccount

--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -35,12 +35,11 @@ const getBillingAccount = (request, h) => {
     `/billing-accounts/${billingAccountId}/bills`
 
   const metadataHtml = generateBillingAccountMetadata(billingAccount)
-  console.log('🚀 ~ file: billing-accounts.js:38 ~ getBillingAccount ~ billingAccount:', billingAccount)
 
   return h.view('nunjucks/billing-accounts/view', {
     ...request.view,
     caption: getBillingAccountCaption(billingAccount),
-    pageTitle: `Billing account for ${titleCase(_billForName(billingAccount))}`,
+    pageTitle: `Billing account for ${titleCase(billingAccount.company.name)}`,
     back,
     currentAddress: getCurrentAddress(billingAccount),
     billingAccount,
@@ -69,22 +68,6 @@ const getBillingAccountBills = (request, h) => {
     pagination,
     path: request.path
   })
-}
-
-function _billForName (invoiceAccount) {
-  let result = invoiceAccount.company.name
-
-  if (invoiceAccount.invoiceAccountAddresses) {
-    invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
-      return new Date(b.date) - new Date(a.date)
-    })
-
-    if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
-      result = invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
-    }
-  }
-
-  return result
 }
 
 exports.getBillingAccount = getBillingAccount

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -67,7 +67,7 @@ const getBillingBatchInvoice = async (request, h) => {
   return h.view('nunjucks/billing/batch-invoice', {
     ...request.view,
     back: `/billing/batch/${batchId}/summary`,
-    pageTitle: `Bill for ${titleCase(invoice.invoiceAccount.company.name)}`,
+    pageTitle: `Bill for ${titleCase(_billForName(invoice.invoiceAccount))}`,
     invoice,
     financialYearEnding: invoice.financialYear.yearEnding,
     batch,
@@ -304,6 +304,18 @@ const _errorList = (errorCode) => {
 const postDeleteAllBillingData = async (request, h) => {
   await services.water.billingBatches.deleteAllBillingData()
   return h.redirect(BATCH_LIST_ROUTE)
+}
+
+function _billForName (invoiceAccount) {
+  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+    return new Date(b.date) - new Date(a.date)
+  })
+
+  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  }
+
+  return invoiceAccount.company.name
 }
 
 module.exports = {

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -307,15 +307,19 @@ const postDeleteAllBillingData = async (request, h) => {
 }
 
 function _billForName (invoiceAccount) {
-  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
-    return new Date(b.date) - new Date(a.date)
-  })
+  let result = invoiceAccount.company.name
 
-  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
-    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  if (invoiceAccount.invoiceAccountAddresses) {
+    invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date)
+    })
+
+    if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+      result = invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+    }
   }
 
-  return invoiceAccount.company.name
+  return result
 }
 
 module.exports = {

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -39,15 +39,19 @@ const getCSVFileName = batch => {
 }
 
 function _billForName (invoiceAccount) {
-  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
-    return new Date(b.date) - new Date(a.date)
-  })
+  let result = invoiceAccount.company.name
 
-  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
-    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  if (invoiceAccount.invoiceAccountAddresses) {
+    invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date)
+    })
+
+    if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+      result = invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+    }
   }
 
-  return invoiceAccount.company.name
+  return result
 }
 
 function _csvLineAlcs (invoice, invoiceLicence, transaction, chargeVersions) {

--- a/src/internal/modules/billing/services/transactions-csv.js
+++ b/src/internal/modules/billing/services/transactions-csv.js
@@ -38,6 +38,18 @@ const getCSVFileName = batch => {
   return `${batch.region.displayName} ${batchType.toLowerCase()} bill run ${batch.billRunNumber}.csv`
 }
 
+function _billForName (invoiceAccount) {
+  invoiceAccount.invoiceAccountAddresses.sort((a, b) => {
+    return new Date(b.date) - new Date(a.date)
+  })
+
+  if (invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name) {
+    return invoiceAccount.invoiceAccountAddresses[0]?.agentCompany?.name
+  }
+
+  return invoiceAccount.company.name
+}
+
 function _csvLineAlcs (invoice, invoiceLicence, transaction, chargeVersions) {
   const csvLine = {
     'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
@@ -101,7 +113,7 @@ function _csvLineAlcs (invoice, invoiceLicence, transaction, chargeVersions) {
 function _csvLineSroc (invoice, invoiceLicence, transaction, chargeVersions) {
   const csvLine = {
     'Billing account number': invoice.invoiceAccount.invoiceAccountNumber,
-    'Customer name': invoice.invoiceAccount.company.name,
+    'Customer name': _billForName(invoice.invoiceAccount),
     'Licence number': invoiceLicence.licenceRef,
     'Bill number': invoice.invoiceNumber,
     'Financial year': invoice.financialYearEnding,

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -42,22 +42,11 @@
 {% macro billingContactCell(invoice) %}
   <td class="govuk-table__cell">
 
-    {% if invoice.faoContact  %}
-      {{ invoice.faoContact }}
-
-      {% elif invoice.billingContact.agentCompanyName %}
+    {% if invoice.billingContact.agentCompanyName  %}
       {{ invoice.billingContact.agentCompanyName }}
-
-      {% elif invoice.billingContact.roleContact.licenceHolder %}
-      {{  invoice.billingContact.roleContact.licenceHolder }}
-
-      {% elif invoice.billingContact.roleContact.billing %}
-      {{  invoice.billingContact.roleContact.billing }}
-
     {% else %}
       {{ invoice.name | titleCase }}
     {% endif %}
-
 
   </td>
 {% endmacro %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3973

> TL;DR show the same name we send to the [Charging Module API's customer-changes endpoint](https://defra.github.io/sroc-charging-module-api-docs/#/customer/CreateCustomerChange).

-----

As part of creating a new billing account, you will select a 'customer (company)' and an address. Assume you selected the same 'company' as the previous charge version (the address doesn't matter).

You then get the option to create an 'FAO'. When you do you are creating a crm_v2.contacts record. This will automatically be linked to the company you selected to use for the new invoice account via a `crm_v2.company_contacts` record.

It will also create a new `crm_v2.invoice_account_addresses` record which links the address and new contact records to the `crm_invoice_account` we're creating.

This is the key difference between an invoice account with an FAO and one without; the `contact_id` in the `crm_v2.invoice_account_addresses` record will be empty.

So, onto the problem. When displaying the invoices the one linked to an invoice account with an FAO (a contact) displays as expected.

Any without a contact falls back on other logic. The service returns to the company record and looks for any contacts linked to it with the role of 'Billing'. And we now know the current service behaviour is to link any new FAO contact to the company. That logic finds the FAO contact again, so displays the name again.

This is the critical bit of code in the `src/internal/views/nunjucks/billing/macros/invoices-table.njk`

```html
{% macro billingContactCell(invoice) %}
  <td class="govuk-table__cell">
    {% if invoice.faoContact  %}
      {{ invoice.faoContact }}

      {% elif invoice.billingContact.agentCompanyName %}
      {{ invoice.billingContact.agentCompanyName }}

      {% elif invoice.billingContact.roleContact.licenceHolder %}
      {{  invoice.billingContact.roleContact.licenceHolder }}

      {% elif invoice.billingContact.roleContact.billing %}
      {{  invoice.billingContact.roleContact.billing }}

    {% else %}
      {{ invoice.name | titleCase }}
    {% endif %}

  </td>
{% endmacro %}
```

Before the charge version with the FAO was added (and assuming no previous contact exists for the company) it would fall into the final if/else block and just display the company name.

When the charge version with an FAO is created it results in `elif invoice.billingContact.roleContact.billing` returning a value for the invoice linked to the charge version without an FAO.

IMHO, the CRM entities have been so over complicated it's no wonder you see behaviour like this. But as it stands, it's been specifically coded to behave this way, i.e.

- if the invoice account address has a contact use it
- else if the invoice account company has any contact, use the latest (oh yeah, add another contact and you'll see the latest displayed instead!)
- else just display the company name

-----

That's the background for this change. When we went back to the users for clarification we got a very clear direction back; use the same name that is sent to the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api). When an invoice account is created or amended we have to let the Charging Module know. This is because it generates a 'customers' file that is sent to SOP for use when generating the invoices. That logic is different to the UI hence the discrepancy.

This change updates the UI logic to match what [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service) is doing when generating the `/customer-changes` request to the CHA.