### PR TITLE
Fix licence number undefined in view

### DIFF
--- a/src/internal/views/nunjucks/view-licences/licence.njk
+++ b/src/internal/views/nunjucks/view-licences/licence.njk
@@ -18,7 +18,7 @@
       {% if not primaryUser %}
         {{ title(licence.licenceNumber, 'Unregistered licence') }}
       {% else %}
-        {{ title('Licence number ' + summary.licenceNumber, summary.documentName ) }}
+        {{ title('Licence number ' + licence.licenceNumber, summary.documentName ) }}
       {% endif %}
 
       {% if validityMessage %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4033

It was found during some acceptance testing that a licence when viewed was displaying 'Licence number undefined'.

Initially, we thought it was a 'bad record' but when we investigated we found a subset of all licences will be affected by this. If the licence

- has a 'primary user' (an external user has added it to their account)
- is no longer active (has expired, lapsed or been revoked)

Then they will see 'undefined' in the view. This is because the view has this bit of logic

```
{% if not primaryUser %}
  {{ title(licence.licenceNumber, 'Unregistered licence') }}
{% else %}
  {{ title('Licence number ' + summary.licenceNumber, summary.documentName ) }}
{% endif %}
```

If there is a primary user it takes the licence number from the `summary` data object passed to the view from the controller. That `summary` object is generated by a pre-handler on the route (because why make things simple!?)

It has logic that checks whether the licence is active; if not, it returns `null`.

```javascript
const loadSummary = async request => {
  const { licence, document: { document_id: documentId }, licenceVersion } = request.pre
  // Skip if licence is not active, as only the "current" version of a licence
  // is currently supported
  if (!licence.isActive) {
    return null
  }

  // ...
}
```

Hence, in this scenario the view will be trying to display `summary.licenceNumber` but `summary` is `null` hence you see 'Licence number undefined'.

There are comments in the pre-handler that say if the licence is not active it's '[not] currently supported'. So, we didn't want to go messing with that code as we don't fully understand it yet. But this change fixes the issue by _always_ using `licence.licenceNumber` as the source of the licence number in the view because if `licence` is `null` we've got bigger problems!

> For reference - what we have been able to tell is the summary block (which is based on `crm.document_header`) is generated purely to display a caption in the title to show the document name. Only 7% of licences have a document name 😬.