### PR TITLE
Send change address requests to system in future

### DIFF
--- a/src/internal/lib/connectors/services/system/BillRunsApiClient.js
+++ b/src/internal/lib/connectors/services/system/BillRunsApiClient.js
@@ -2,7 +2,7 @@
 
 const ServiceClient = require('../../../../../shared/lib/connectors/services/ServiceClient')
 
-class SystemService extends ServiceClient {
+class BillRunsApiClient extends ServiceClient {
   /**
    * Creates a new bill run
    *
@@ -29,4 +29,4 @@ class SystemService extends ServiceClient {
   }
 }
 
-module.exports = SystemService
+module.exports = BillRunsApiClient

--- a/src/internal/lib/connectors/services/system/BillingAccountsApiClient.js
+++ b/src/internal/lib/connectors/services/system/BillingAccountsApiClient.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ServiceClient = require('../../../../../shared/lib/connectors/services/ServiceClient')
+
+class BillingAccountsApiClient extends ServiceClient {
+  changeAddress (invoiceAccountId, data) {
+    const url = this.joinUrl(`billing-accounts/${invoiceAccountId}/change-address`)
+    const options = {
+      body: {
+        ...data
+      }
+    }
+    return this.serviceRequest.post(url, options)
+  }
+}
+
+module.exports = BillingAccountsApiClient

--- a/src/internal/lib/connectors/services/system/index.js
+++ b/src/internal/lib/connectors/services/system/index.js
@@ -1,10 +1,12 @@
 'use strict'
 
 // Internal services
+const BillingAccountsApiClient = require('./BillingAccountsApiClient.js')
 const BillRunsApiClient = require('./BillRunsApiClient.js')
 
 const { logger } = require('../../../../logger')
 
 module.exports = config => ({
+  billingAccounts: new BillingAccountsApiClient(config.services.system, logger),
   billRuns: new BillRunsApiClient(config.services.system, logger)
 })

--- a/src/internal/lib/connectors/services/system/index.js
+++ b/src/internal/lib/connectors/services/system/index.js
@@ -1,10 +1,10 @@
 'use strict'
 
 // Internal services
-const BillRunsService = require('./BillRunsService.js')
+const BillRunsApiClient = require('./BillRunsApiClient.js')
 
 const { logger } = require('../../../../logger')
 
 module.exports = config => ({
-  billRuns: new BillRunsService(config.services.system, logger)
+  billRuns: new BillRunsApiClient(config.services.system, logger)
 })

--- a/src/internal/modules/billing-accounts/controllers/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/controllers/select-billing-account.js
@@ -258,7 +258,8 @@ const persistData = async state => {
 
   // For both new account and address updates, post the agent, contact and address
   // to the create address endpoint
-  const invoiceAccountAddress = await services.water.invoiceAccounts.createInvoiceAccountAddress(clonedState.data.id,
+  const invoiceAccountAddress = await services.system.billingAccounts.changeAddress(
+    clonedState.data.id,
     mapper.mapSessionDataToCreateInvoiceAccountAddress(clonedState)
   )
   Object.assign(clonedState.data, pick(invoiceAccountAddress, ['address', 'agentCompany', 'contact']))

--- a/test/internal/lib/connectors/services/system/BillRunsApiClient.test.js
+++ b/test/internal/lib/connectors/services/system/BillRunsApiClient.test.js
@@ -13,14 +13,14 @@ const sandbox = Sinon.createSandbox()
 const { serviceRequest } = require('@envage/water-abstraction-helpers')
 
 // Thing under test
-const BillRunsService = require('../../../../../../src/internal/lib/connectors/services/system/BillRunsService.js')
+const BillRunsApiClient = require('../../../../../../src/internal/lib/connectors/services/system/BillRunsApiClient.js')
 
-experiment('services/system/BillRunsService', () => {
+experiment('services/system/BillRunsApiClient', () => {
   let service
 
   beforeEach(async () => {
     sandbox.stub(serviceRequest, 'post')
-    service = new BillRunsService('http://127.0.0.1:8013')
+    service = new BillRunsApiClient('http://127.0.0.1:8013')
   })
 
   afterEach(async () => {

--- a/test/internal/lib/connectors/services/system/BillingAccountsApiClient.test.js
+++ b/test/internal/lib/connectors/services/system/BillingAccountsApiClient.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+const sandbox = Sinon.createSandbox()
+
+// Things we need to stub
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+
+// Thing under test
+const BillingAccountsApiClient = require('../../../../../../src/internal/lib/connectors/services/system/BillingAccountsApiClient.js')
+
+experiment('services/system/BillingAccountsApiClient', () => {
+  let service
+
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'post')
+    service = new BillingAccountsApiClient('http://127.0.0.1:8013')
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  experiment('.changeAddress', () => {
+    beforeEach(async () => {
+      await service.changeAddress(
+        '89dfe495-69b3-4643-b8f5-8a59016ccec7',
+        {
+          address: { addressLine1: 'Horizon House' }
+        }
+      )
+    })
+
+    test('passes the expected URL to the service request', async () => {
+      const url = serviceRequest.post.lastCall.args[0]
+
+      expect(url).to.equal('http://127.0.0.1:8013/billing-accounts/89dfe495-69b3-4643-b8f5-8a59016ccec7/change-address')
+    })
+
+    test('passes the query in the request body', async () => {
+      const options = serviceRequest.post.lastCall.args[1]
+
+      expect(options.body).to.equal({
+        address: { addressLine1: 'Horizon House' }
+      })
+    })
+  })
+})

--- a/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
+++ b/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
@@ -132,7 +132,7 @@ experiment('internal/modules/billing-accounts/controllers/select-billing-account
     sandbox.stub(session, 'get').returns(data.sessionData)
     sandbox.stub(session, 'setProperty')
     sandbox.stub(services.water.companies, 'postInvoiceAccount')
-    sandbox.stub(services.water.invoiceAccounts, 'createInvoiceAccountAddress')
+    sandbox.stub(services.system.billingAccounts, 'changeAddress')
     sandbox.stub(logger, 'error')
   })
 
@@ -764,7 +764,7 @@ experiment('internal/modules/billing-accounts/controllers/select-billing-account
       })
 
       test('creates the billing account address', async () => {
-        const [invoiceAccountId, data] = services.water.invoiceAccounts.createInvoiceAccountAddress.lastCall.args
+        const [invoiceAccountId, data] = services.system.billingAccounts.changeAddress.lastCall.args
         expect(invoiceAccountId).to.equal(INVOICE_ACCOUNT_ID)
         expect(data).to.equal({
           agentCompany: null,
@@ -791,7 +791,7 @@ experiment('internal/modules/billing-accounts/controllers/select-billing-account
 
       test('only the "create address" service endpoint is called', async () => {
         expect(services.water.companies.postInvoiceAccount.called).to.be.false()
-        expect(services.water.invoiceAccounts.createInvoiceAccountAddress.called).to.be.true()
+        expect(services.system.billingAccounts.changeAddress.called).to.be.true()
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4092

We are working on migrating the change billing account address functionality from the legacy code to the [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), our new home for shiny, happy code! 🦄❤️

This change is the final part of the migration; updating the UI to send the request to the **water-abstraction-system** instead of the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service).