### PR TITLE
Prevent double button click for send notification for licence renewals

### DIFF
--- a/src/internal/views/nunjucks/notifications/preview.njk
+++ b/src/internal/views/nunjucks/notifications/preview.njk
@@ -40,7 +40,8 @@
         {{
           govukButton({
             text: "Send notification",
-            classes: "govuk-!-margin-top-5"
+            classes: "govuk-!-margin-top-5",
+            preventDoubleClick: true
           })
         }}
       </form>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4101

This change prevents the 'Send Notification' button from being clicked twice when renewing reminder licences.