### PR TITLE
Redirect /service-status to system app

### DIFF
--- a/src/internal/modules/service-status/controller.js
+++ b/src/internal/modules/service-status/controller.js
@@ -4,6 +4,8 @@ const Catbox = require('@hapi/catbox')
 const CatboxRedis = require('@hapi/catbox-redis')
 const { pick } = require('lodash')
 
+const config = require('../../config.js')
+
 const getRedisCacheStatus = async (redisConfig, logger) => {
   let result = 'Not connected'
 
@@ -48,22 +50,9 @@ const getVirusScannerStatus = async () => {
 }
 
 const getServiceStatus = async (request, h) => {
-  const { services, redis, logger } = h.realm.pluginOptions
+  const healthInfoUrl = new URL('/health/info', config.services.system)
 
-  const [status, virusScanner, cacheConnection] = await Promise.all([
-    services.water.serviceStatus.getServiceStatus(),
-    getVirusScannerStatus(),
-    getRedisCacheStatus(redis, logger)
-  ])
-
-  const serviceStatus = Object.assign({}, status.data, { virusScanner }, { cacheConnection })
-
-  return request.query.format === 'json'
-    ? serviceStatus
-    : h.view('nunjucks/service-status/index', {
-      ...request.view,
-      ...serviceStatus
-    })
+  return h.redirect(healthInfoUrl)
 }
 
 exports.getServiceStatus = getServiceStatus

--- a/src/internal/modules/service-status/controller.js
+++ b/src/internal/modules/service-status/controller.js
@@ -1,55 +1,8 @@
 'use strict'
 
-const Catbox = require('@hapi/catbox')
-const CatboxRedis = require('@hapi/catbox-redis')
-const { pick } = require('lodash')
-
 const config = require('../../config.js')
 
-const getRedisCacheStatus = async (redisConfig, logger) => {
-  let result = 'Not connected'
-
-  try {
-    const options = {
-      ...pick(redisConfig, ['host', 'port', 'password', 'tls']),
-      db: 0
-    }
-
-    const cache = new Catbox.Client(CatboxRedis, options)
-    await cache.start()
-
-    const key = { segment: 'serviceStatus', id: 'testStatus' }
-    await cache.set(key, true, 10000)
-    const value = await cache.get(key)
-
-    if (value) {
-      result = 'Connected'
-    }
-  } catch (err) {
-    logger.error('Cache not connected', err.stack)
-  }
-
-  return result
-}
-
-const fileCheck = require('shared/lib/file-check')
-
-/**
- * Checks if virus scanner is working correctly
- * @return {Promise} Resolves with boolean true if OK
- */
-const getVirusScannerStatus = async () => {
-  try {
-    const clean = await fileCheck.virusCheck('./test/shared/lib/test-files/test-file.txt')
-    const infected = await fileCheck.virusCheck('./test/shared/lib/test-files/eicar-test.txt')
-    const result = clean.isClean && !infected.isClean
-    return result ? 'OK' : 'ERROR'
-  } catch (err) {
-    return 'ERROR'
-  }
-}
-
-const getServiceStatus = async (request, h) => {
+const getServiceStatus = async (_request, h) => {
   const healthInfoUrl = new URL('/health/info', config.services.system)
 
   return h.redirect(healthInfoUrl)

--- a/test/internal/modules/service-status/controller.test.js
+++ b/test/internal/modules/service-status/controller.test.js
@@ -10,23 +10,13 @@ const {
 const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
 
+const config = require('../../../../src/internal/config.js')
+
 const controller = require('internal/modules/service-status/controller')
-const fileCheck = require('shared/lib/file-check')
-const Catbox = require('@hapi/catbox')
 
 experiment('shared/plugins/service-status/controller', () => {
-  let cache
-
   beforeEach(async () => {
-    sandbox.stub(fileCheck, 'virusCheck').resolves(true)
-
-    cache = {
-      start: sandbox.stub().resolves(),
-      set: sandbox.stub().resolves(),
-      get: sandbox.stub().resolves(true)
-    }
-
-    sandbox.stub(Catbox, 'Client').returns(cache)
+    sandbox.stub(config.services, 'system').value('http://localhost:8013')
   })
 
   afterEach(async () => {
@@ -39,124 +29,17 @@ experiment('shared/plugins/service-status/controller', () => {
 
     beforeEach(async () => {
       h = {
-        view: sandbox.spy(),
-        realm: {
-          pluginOptions: {
-            logger: {
-              error: sandbox.spy()
-            },
-            redis: {
-              host: 'test-host',
-              port: 1234
-            },
-            services: {
-              water: {
-                serviceStatus: {
-                  getServiceStatus: async () => ({
-                    data: {
-                      testing: true
-                    }
-                  })
-                }
-              }
-            }
-          }
-        }
-      }
-      request = {
-        query: {}
+        redirect: sandbox.stub()
       }
     })
 
-    experiment('the cache is tested', () => {
-      test('a new cache is created', async () => {
-        await controller.getServiceStatus(request, h)
-        const [, options] = Catbox.Client.lastCall.args
-        expect(options).to.equal({
-          host: 'test-host',
-          port: 1234,
-          db: 0
-        })
-      })
+    test('redirects to the the system /health/info page', async () => {
+      await controller.getServiceStatus(request, h)
 
-      test('a new cache is created using a password if supplied', async () => {
-        h.realm.pluginOptions.redis.password = 'sshhhh'
+      const firstCallArgs = h.redirect.args[0]
 
-        await controller.getServiceStatus(request, h)
-        const [, options] = Catbox.Client.lastCall.args
-        expect(options).to.equal({
-          host: 'test-host',
-          port: 1234,
-          password: 'sshhhh',
-          db: 0
-        })
-      })
-
-      test('returns "Not connected" if the cache will not start', async () => {
-        cache.start.rejects()
-        await controller.getServiceStatus(request, h)
-
-        const [, status] = h.view.lastCall.args
-        expect(status.cacheConnection).to.equal('Not connected')
-      })
-
-      test('returns "Not connected" if the cache will not set a value', async () => {
-        cache.set.rejects()
-        await controller.getServiceStatus(request, h)
-
-        const [, status] = h.view.lastCall.args
-        expect(status.cacheConnection).to.equal('Not connected')
-      })
-
-      test('returns "Not connected" if the cache will not get a value', async () => {
-        cache.get.rejects()
-        await controller.getServiceStatus(request, h)
-
-        const [, status] = h.view.lastCall.args
-        expect(status.cacheConnection).to.equal('Not connected')
-      })
-
-      test('returns "Connected" if the cache will get and set value', async () => {
-        await controller.getServiceStatus(request, h)
-
-        const [, status] = h.view.lastCall.args
-        expect(status.cacheConnection).to.equal('Connected')
-      })
-    })
-
-    experiment('when requesting the status page', () => {
-      beforeEach(async () => {
-        await controller.getServiceStatus(request, h)
-      })
-
-      test('the expected view is used', async () => {
-        const [view] = h.view.lastCall.args
-        expect(view).to.equal('nunjucks/service-status/index')
-      })
-
-      test('the service status object is passed to the view', async () => {
-        const [, status] = h.view.lastCall.args
-
-        expect(status).to.equal({
-          cacheConnection: 'Connected',
-          testing: true,
-          virusScanner: 'ERROR'
-        })
-      })
-    })
-
-    experiment('when the request for JSON is made', () => {
-      test('the service status is returned', async () => {
-        request.query = { format: 'json' }
-
-        const status = await controller.getServiceStatus(request, h)
-
-        expect(status).to.equal({
-          cacheConnection: 'Connected',
-          testing: true,
-          virusScanner: 'ERROR'
-        })
-      })
+      expect(h.redirect.calledOnce).to.be.true()
+      expect(firstCallArgs[0].href).to.equal('http://localhost:8013/health/info')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4099

We are replacing the existing `/service-status` page with an updated version. But as all new code is being developed in [water-abstraction-system](https://github.com/water-abstraction-system) we need the UI to redirect the request to there.

This change just covers that. We'll look at what code we can delete when we are happy everything is working as expected.