### PR TITLE
Fix service status redirect to system

### DIFF
--- a/src/internal/modules/service-status/controller.js
+++ b/src/internal/modules/service-status/controller.js
@@ -1,11 +1,7 @@
 'use strict'
 
-const config = require('../../config.js')
-
 const getServiceStatus = async (_request, h) => {
-  const healthInfoUrl = new URL('/health/info', config.services.system)
-
-  return h.redirect(healthInfoUrl)
+  return h.redirect('/system/health/info')
 }
 
 exports.getServiceStatus = getServiceStatus

--- a/test/internal/modules/service-status/controller.test.js
+++ b/test/internal/modules/service-status/controller.test.js
@@ -10,15 +10,9 @@ const {
 const { expect } = require('@hapi/code')
 const sandbox = require('sinon').createSandbox()
 
-const config = require('../../../../src/internal/config.js')
-
 const controller = require('internal/modules/service-status/controller')
 
 experiment('shared/plugins/service-status/controller', () => {
-  beforeEach(async () => {
-    sandbox.stub(config.services, 'system').value('http://localhost:8013')
-  })
-
   afterEach(async () => {
     sandbox.restore()
   })
@@ -39,7 +33,7 @@ experiment('shared/plugins/service-status/controller', () => {
       const firstCallArgs = h.redirect.args[0]
 
       expect(h.redirect.calledOnce).to.be.true()
-      expect(firstCallArgs[0].href).to.equal('http://localhost:8013/health/info')
+      expect(firstCallArgs[0]).to.equal('/system/health/info')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4099

In [Redirect /service-status to system app](https://github.com/DEFRA/water-abstraction-ui/pull/2426) we redirected the `/service-status` endpoint to `/health/info` in the [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) app.

But we were too clever and thought we needed the address for the system app. It works locally but in our AWS environments, the redirect would fail because you cannot access the system app directly.

So, instead, we need to redirect the request through the proxy implemented within the UI which passes requests onto our system app.