### PR TITLE
Fix missing cookie in system proxy

### DIFF
--- a/src/internal/modules/system-proxy/routes.js
+++ b/src/internal/modules/system-proxy/routes.js
@@ -11,7 +11,13 @@ const proxyDefaults = {
   // Sets the 'X-Forwarded-For', 'X-Forwarded-Port', 'X-Forwarded-Proto', 'X-Forwarded-Host' headers. 'X-Forwarded-For',
   // for example, is the standard header for identifying the originating IP address of a client connecting to a web
   // server through a proxy server. As such, it is often used in security and authentication checks.
-  xforward: true
+  xforward: true,
+  // When false (the default) any locally defined state is removed from incoming requests before being sent to the
+  // upstream service. In practice we saw any other cookies set in our browser were being passed to system but not the
+  // ones set by this app; sid and session. This app still handles login and initialises the sid cookie. System needs
+  // to be able to see it to also confirm the user is authenticated and authorised to access whatever page they've been
+  // directed to. Hence, we set this to true.
+  localStatePassThrough: true
 }
 
 const routes = [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085
https://eaflood.atlassian.net/browse/WATER-4155

In our new repo [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) we added a [new authentication plugin](https://github.com/DEFRA/water-abstraction-system/pull/351). We want this UI to be able to redirect users to new pages we create in **water-abstraction-system** and for that to be seamless and secure.

We could have managed authentication in our `src/internal/modules/system-proxy` module. But the idea is to move away from the legacy code base which means at some point **water-abstraction-system** needs to be doing authentication and authorisation.

So, we opted to perform the same checks there; admittedly we're performing authentication twice but it will give us more flexibility in the future.

Anyway, that is the background so on to our issue. We're building our first page in **water-abstraction-system** where the user needs to be authenticated. This should have just worked only it didn't. After much head scratching we tracked down the problem to the cookie this project creates not getting passed through. Every cookie was, just not the one we need!!

The answer was just to tweak the config for [hapi/h202](https://hapi.dev/module/h2o2/) to allow local state to be passed through.