### PR TITLE
Typo on Login Screen error message

### DIFF
--- a/src/shared/plugins/reset-password/forms/change-password.js
+++ b/src/shared/plugins/reset-password/forms/change-password.js
@@ -29,7 +29,7 @@ const form = (request, h) => {
         message: 'Your password must be contain an uppercase character'
       },
       'password.symbol': {
-        message: 'Your password must be contain a symbol character'
+        message: 'Your password must contain a symbol character'
       }
 
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4170

When changing your password, if you enter a new password without a symbol character you receive an error message.  This error message has a typo in it. This PR is to fix a typo.