### PR TITLE
Link to new bill page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ LAZY_REDIS=true
 # Feature toggles
 ENABLE_DELETE_ALL_BILLING_DATA_FEATURE=
 SHOW_VERIFICATION_CODE_FEATURE=
+USE_NEW_BILL_VIEW=
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -169,7 +169,8 @@ module.exports = {
     allowChargeVersionUploads: (get(process.env, 'ALLOW_CHARGE_VERSION_UPLOADS') || '').toLowerCase() === 'true',
     triggerSrocSupplementary: (get(process.env, 'TRIGGER_SROC_SUPPLEMENTARY') || '').toLowerCase() === 'true',
     acceptanceTestsProxy: !isProduction,
-    showVerificationCode: process.env.SHOW_VERIFICATION_CODE_FEATURE === 'true' && !isProduction
+    showVerificationCode: process.env.SHOW_VERIFICATION_CODE_FEATURE === 'true' && !isProduction,
+    useNewBillView: (get(process.env, 'USE_NEW_BILL_VIEW') || '').toLowerCase() === 'true'
   },
   billRunsToDisplayPerPage: process.env.BILL_RUNS_TO_DISPLAY_PER_PAGE || 20
 }

--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -4,6 +4,8 @@ const { pick } = require('lodash')
 const { titleCase } = require('shared/lib/string-formatter')
 const { getCurrentAddress, generateBillingAccountMetadata } = require('../lib/helpers')
 
+const { featureToggles } = require('../../../config.js')
+
 const getBillingAccountCaption = billingAccount =>
   `Billing account ${billingAccount.accountNumber}`
 
@@ -48,7 +50,8 @@ const getBillingAccount = (request, h) => {
     moreBillsLink,
     rebillingLink: `/billing-accounts/${billingAccountId}/rebilling`,
     rebillable: rebillableBills.length > 0,
-    metadataHtml
+    metadataHtml,
+    useNewBillView: featureToggles.useNewBillView
   })
 }
 
@@ -66,7 +69,8 @@ const getBillingAccountBills = (request, h) => {
     back: `/billing-accounts/${billingAccountId}`,
     bills,
     pagination,
-    path: request.path
+    path: request.path,
+    useNewBillView: featureToggles.useNewBillView
   })
 }
 

--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -41,7 +41,8 @@ const getBillingBatchSummary = async (request, h) => {
     errors: mappers.mapBatchLevelErrors(batch, invoices),
     // only show the back link from the list page, so not to offer the link
     // as part of the batch creation flow.
-    back: request.query.back && BATCH_LIST_ROUTE
+    back: request.query.back && BATCH_LIST_ROUTE,
+    useNewBillView: featureToggles.useNewBillView
   })
 }
 

--- a/src/internal/views/nunjucks/billing-accounts/macros/bills-table.njk
+++ b/src/internal/views/nunjucks/billing-accounts/macros/bills-table.njk
@@ -13,11 +13,11 @@
   </thead>
 {% endmacro %}
 
-{% macro tableRow(bill) %}
+{% macro tableRow(bill, useNewBillView) %}
   {% set row = { invoice : bill, batch: bill.batch } %}
 
   <tr class="govuk-table__row">
-      {{ invoiceLink(row) }}
+      {{ invoiceLink(row, useNewBillView) }}
       {{ dateCreatedCell(row) }}
       {{ batchTypeCell(bill.batch) }}
       {{ billRunNumberCell(bill.batch) }}
@@ -26,7 +26,7 @@
   </tr>
 {% endmacro %}
 
-{% macro billsTable(bills, caption) %}
+{% macro billsTable(bills, caption, useNewBillView) %}
   <table class="govuk-table">
     {% if caption %}
     <caption class="govuk-table__caption govuk-heading-l">
@@ -36,7 +36,7 @@
     {{ tableHeader() }}
     <tbody class="govuk-table__body">
       {% for bill in bills %}
-        {{ tableRow(bill) }}
+        {{ tableRow(bill, useNewBillView) }}
       {% endfor %}
     </tbody>
   </table>

--- a/src/internal/views/nunjucks/billing-accounts/view-bills.njk
+++ b/src/internal/views/nunjucks/billing-accounts/view-bills.njk
@@ -12,7 +12,7 @@
 
     {{ title(pageTitle, caption) }}
 
-    {{ billsTable(bills) }}
+    {{ billsTable(bills, null, useNewBillView) }}
 
     {{ paginate(pagination, path)}}
   </div>

--- a/src/internal/views/nunjucks/billing-accounts/view.njk
+++ b/src/internal/views/nunjucks/billing-accounts/view.njk
@@ -39,8 +39,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    {{ billsTable(bills, "Sent bills") }}
+    {{ billsTable(bills, "Sent bills", useNewBillView) }}
 
     {% if moreBillsLink %}
     <p>

--- a/src/internal/views/nunjucks/billing/batch-summary.njk
+++ b/src/internal/views/nunjucks/billing/batch-summary.njk
@@ -99,12 +99,12 @@ chargeOrDash %}
 
         {% set waterUndertakersHtml %}
         <h2 class="govuk-heading-l">Water companies</h2>
-        {{ invoicesTable(batch, invoices.waterUndertakers )}}
+        {{ invoicesTable(batch, invoices.waterUndertakers, useNewBillView )}}
         {% endset %}
 
         {% set otherAbstractorsHtml %}
         <h2 class="govuk-heading-l">Other abstractors</h2>
-        {{ invoicesTable(batch, invoices.otherAbstractors )}}
+        {{ invoicesTable(batch, invoices.otherAbstractors, useNewBillView )}}
         {% endset %}
 
         {{ govukTabs({
@@ -127,7 +127,7 @@ chargeOrDash %}
         }) }}
 
       {% else %}
-        {{ invoicesTable(batch, invoices )}}
+        {{ invoicesTable(batch, invoices, useNewBillView )}}
       {% endif %}
 
     </div>

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -99,10 +99,15 @@
   </td>
 {% endmacro %}
 
-{% macro actionsCell(batch, invoice) %}
+{% macro actionsCell(batch, invoice, useNewBillView) %}
   <td class="govuk-table__cell govuk-table__cell--numeric">
     {% if invoice.netTotal %}
-      <a class="govuk-link" href="/billing/batch/{{batch.id}}/invoice/{{invoice.id}}">View<span class="govuk-visually-hidden">
+      {% if useNewBillView === true %}
+        {% set link = '/system/bills/' + invoice.id %}
+      {% else %}
+        {% set link = '/billing/batch/' + batch.id + '/invoice/' + invoice.id %}
+      {% endif %}
+      <a class="govuk-link" href="{{ link }}">View<span class="govuk-visually-hidden">
           invoice for
           {{ invoice.accountNumber }}</span></a>
     {% endif %}
@@ -121,54 +126,54 @@
   </td>
 {% endmacro %}
 
-{% macro tableRow(batch, invoice) %}
+{% macro tableRow(batch, invoice, useNewBillView) %}
   <tr class="govuk-table__row">
     {{ billingAccountCell(invoice) }}
     {{ billingContactCell(invoice) }}
     {{ licenceNumbersCell(invoice) }}
     {{ totalCell(invoice)}}
-    {{ actionsCell(batch, invoice) }}
+    {{ actionsCell(batch, invoice, useNewBillView) }}
   {% endmacro %}
 
-  {% macro tableRowSupplementary(batch, invoice) %}
+  {% macro tableRowSupplementary(batch, invoice, useNewBillView) %}
     <tr class="govuk-table__row">
       {{ billingAccountCell(invoice) }}
       {{ billingContactCell(invoice) }}
       {{ licenceNumbersCell(invoice) }}
       {{ financialYearCell(invoice) }}
       {{ totalCell(invoice) }}
-      {{ actionsCell(batch, invoice) }}
+      {{ actionsCell(batch, invoice, useNewBillView) }}
     </tr>
   {% endmacro %}
 
-  {% macro nonSupplementaryInvoicesTable(batch, invoices) %}
+  {% macro nonSupplementaryInvoicesTable(batch, invoices, useNewBillView) %}
     <table class="govuk-table">
       {{ tableHeader() }}
       <tbody class="govuk-table__body">
         {% for invoice in invoices %}
-          {{ tableRow(batch, invoice) }}
+          {{ tableRow(batch, invoice, useNewBillView) }}
         {% endfor %}
       </tbody>
     </table>
   {% endmacro %}
 
-  {% macro supplementaryInvoicesTable(batch, invoices) %}
+  {% macro supplementaryInvoicesTable(batch, invoices, useNewBillView) %}
     <table class="govuk-table">
       {{ tableHeaderSupplementary() }}
       <tbody class="govuk-table__body">
         {% for invoice in invoices %}
-          {{ tableRowSupplementary(batch, invoice) }}
+          {{ tableRowSupplementary(batch, invoice, useNewBillView) }}
         {% endfor %}
       </tbody>
     </table>
   {% endmacro %}
 
-  {% macro invoicesTable(batch, invoices) %}
+  {% macro invoicesTable(batch, invoices, useNewBillView) %}
     {% if invoices.length > 0 %}
       {% if batch.type == 'supplementary' %}
-        {{ supplementaryInvoicesTable(batch, invoices) }}
+        {{ supplementaryInvoicesTable(batch, invoices, useNewBillView) }}
       {% else %}
-        {{ nonSupplementaryInvoicesTable(batch, invoices) }}
+        {{ nonSupplementaryInvoicesTable(batch, invoices, useNewBillView) }}
       {% endif %}
     {% endif %}
   {% endmacro %}

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -234,9 +234,9 @@
     </td>
   {% endmacro %}
 
-  {% macro tableRowLicenceInvoices(row) %}
+  {% macro tableRowLicenceInvoices(row, useNewBillView) %}
     <tr class="govuk-table__row">
-      {{ invoiceLink(row) }}
+      {{ invoiceLink(row, useNewBillView) }}
       {{ dateCreatedCell(row) }}
       {{ billingAccountCell(row.invoice) }}
       {{ batchTypeCell(row.batch) }}
@@ -245,7 +245,7 @@
     </tr>
   {% endmacro %}
 
-  {% macro licenceInvoicesTable(invoices, caption) %}
+  {% macro licenceInvoicesTable(invoices, caption, useNewBillView) %}
     <table class="govuk-table">
     {% if caption %}
       <caption class="govuk-table__caption govuk-heading-m">
@@ -255,15 +255,15 @@
       {{ tableHeaderLicenceInvoices() }}
       <tbody class="govuk-table__body">
         {% for invoice in invoices %}
-          {{ tableRowLicenceInvoices(invoice) }}
+          {{ tableRowLicenceInvoices(invoice, useNewBillView) }}
         {% endfor %}
       </tbody>
     </table>
   {% endmacro %}
 
-  {% macro licenceInvoicesView(invoices, caption) %}
+  {% macro licenceInvoicesView(invoices, caption, useNewBillView) %}
     {% if invoices.length > 0 %}
-      {{ licenceInvoicesTable(invoices, caption) }}
+      {{ licenceInvoicesTable(invoices, caption, useNewBillView) }}
     {% else %}
       <p>No bills sent for this licence.</p>
     {% endif %}

--- a/src/internal/views/nunjucks/billing/macros/invoices-table.njk
+++ b/src/internal/views/nunjucks/billing/macros/invoices-table.njk
@@ -204,9 +204,14 @@
      {% endif %}
   {% endmacro %}
 
-  {% macro invoiceLink(row) %}
+  {% macro invoiceLink(row, useNewBillView) %}
+    {% if useNewBillView === true %}
+      {% set link = '/system/bills/' + row.invoice.id %}
+    {% else %}
+      {% set link = '/billing/batch/' + row.batch.id + '/invoice/' + row.invoice.id %}
+    {% endif %}
     <td class="govuk-table__cell" scope="row">
-      <a href="/billing/batch/{{ row.batch.id }}/invoice/{{ row.invoice.id }}">
+      <a href="{{ link }}">
         {{row.invoice.displayLabel}}
       </a>
       {{displayRebillingState(row.invoice)}}

--- a/src/internal/views/nunjucks/view-licences/tabs/bills.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/bills.njk
@@ -1,10 +1,10 @@
 {% from 'nunjucks/billing/macros/invoices-table.njk' import licenceInvoicesView %}
 
 <h2 class="govuk-heading-l">Bills</h2>
-{{ licenceInvoicesView(bills.data) }}
+{{ licenceInvoicesView(bills.data, '', featureToggles.useNewBillView) }}
 
 {% if bills.pagination | hasMorePages %}
 <p>
   <a href="{{ links.bills }}">View all sent bills</a>
-</p>  
+</p>
 {% endif %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4155

We are working on implementing a new version of the bill page. The current one tries to display all transaction details for all licences on a single page when the bill is selected.

In the larger annual bill runs this might equate to more than 150 licences and their transactions which means the page is failing to load.

All that work is being done in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) as part of our ongoing efforts to migrate away from the legacy code.

This means we need to update the UI to point to the system app and the endpoint we are building there when a user follows a view bill link.

We know there are 3 places we link to a bill; from the bill run summary, when looking at the bills for a selected billing account and from the licence summary 'Bills' tab. Because the work is not complete we'll put the change behind a feature flag to allow us to ship other changes if we need to.