### PR TITLE
Add cookie to http requests to system

### DIFF
--- a/src/internal/lib/connectors/services/system/BillRunsApiClient.js
+++ b/src/internal/lib/connectors/services/system/BillRunsApiClient.js
@@ -10,13 +10,17 @@ class BillRunsApiClient extends ServiceClient {
    * @param {String} scheme The scheme to create the bill run for (ie. sroc etc.)
    * @param {String} region The GUID of the region to create the bill run for
    * @param {String} user The email address of the user requesting bill run creation
+   * @param {Object} cookie Existing cookie set by this app needed for pass-through authentication
    * @param {String} [previousBillRunId] The id of the previous bill run
    *
    * @return {Promise} resolves with the new bill run details
    */
-  createBillRun (type, scheme, region, user, previousBillRunId = undefined) {
+  createBillRun (type, scheme, region, user, cookie, previousBillRunId = undefined) {
     const url = this.joinUrl('bill-runs')
     const options = {
+      headers: {
+        cookie
+      },
       body: {
         type,
         scheme,

--- a/src/internal/lib/connectors/services/system/BillingAccountsApiClient.js
+++ b/src/internal/lib/connectors/services/system/BillingAccountsApiClient.js
@@ -3,9 +3,12 @@
 const ServiceClient = require('../../../../../shared/lib/connectors/services/ServiceClient')
 
 class BillingAccountsApiClient extends ServiceClient {
-  changeAddress (invoiceAccountId, data) {
+  changeAddress (invoiceAccountId, data, cookie) {
     const url = this.joinUrl(`billing-accounts/${invoiceAccountId}/change-address`)
     const options = {
+      headers: {
+        cookie
+      },
       body: {
         ...data
       }

--- a/src/internal/modules/billing-accounts/controllers/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/controllers/select-billing-account.js
@@ -244,7 +244,9 @@ const getCheckAnswers = (request, h) => {
   })
 }
 
-const persistData = async state => {
+const persistData = async request => {
+  const cookie = request.headers.cookie
+  const state = request.pre.sessionData
   const clonedState = cloneDeep(state)
   const { isUpdate } = state
 
@@ -260,7 +262,8 @@ const persistData = async state => {
   // to the create address endpoint
   const invoiceAccountAddress = await services.system.billingAccounts.changeAddress(
     clonedState.data.id,
-    mapper.mapSessionDataToCreateInvoiceAccountAddress(clonedState)
+    mapper.mapSessionDataToCreateInvoiceAccountAddress(clonedState),
+    cookie
   )
   Object.assign(clonedState.data, pick(invoiceAccountAddress, ['address', 'agentCompany', 'contact']))
   return clonedState
@@ -268,7 +271,7 @@ const persistData = async state => {
 
 const postCheckAnswers = async (request, h) => {
   try {
-    const { data } = await persistData(request.pre.sessionData)
+    const { data } = await persistData(request)
     // Set address in session and redirect back to parent flow
     const { key } = request.params
     const { redirectPath } = session.merge(request, key, { data })

--- a/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
+++ b/test/internal/modules/billing-accounts/controllers/select-billing-account.test.js
@@ -103,6 +103,9 @@ const createRequest = (overrides = {}) => ({
     billingAccounts: overrides.billingAccounts || data.billingAccounts,
     account: data.account
   },
+  headers: {
+    cookie: 'taste=yummy'
+  },
   accountEntryRedirect: sandbox.stub().returns(ACCOUNT_ENTRY_PATH),
   addressLookupRedirect: sandbox.stub().returns(ADDRESS_ENTRY_PATH),
   contactEntryRedirect: sandbox.stub().returns(CONTACT_ENTRY_PATH),

--- a/test/internal/modules/billing/controllers/create-bill-run.test.js
+++ b/test/internal/modules/billing/controllers/create-bill-run.test.js
@@ -131,6 +131,9 @@ const createRequest = () => ({
     }),
     set: sandbox.stub(),
     clear: sandbox.stub()
+  },
+  headers: {
+    cookie: 'taste=yummy'
   }
 })
 
@@ -289,6 +292,7 @@ experiment('internal/modules/billing/controllers/create-bill-run', () => {
     }
     beforeEach(async () => {
       sandbox.stub(services.water.billingBatches, 'createBillingBatch')
+      sandbox.stub(services.system.billRuns, 'createBillRun').resolves()
     })
 
     experiment('when the form is valid', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4085

When we [enabled authentication by default](https://github.com/DEFRA/water-abstraction-system/pull/466) in **water-abstraction-system** we just had in mind requests proxied through or redirected from **water-abstraction-ui**.

We overlooked requests the UI was generating itself using `ServiceClient` from [water-abstraction-helpers](https://github.com/DEFRA/water-abstraction-helpers).

Doh! 🤦

So, we've inadvertently broken SROC supplementary billing and changing a billing account address because the requests we're sending to **water-abstraction-system** are being redirected to the `/signin` page.

The 'quick' fix would have been to remove auth off those routes but that would expose a vulnerability if we didn't then try to block them in `src/internal/modules/system-proxy`.

What **water0abstraction-system** needs is the cookie the UI has set once someone has been authenticated. It gets passed automatically when requests are proxied or redirected.

So, this change grabs that cookie of the [Hapi request](https://hapi.dev/api/?v=21.3.2#request) and passes it through to the HTTP request generated by **water-abstraction-helpers**. SROC supplementary billing and changing a billing account address work again!