### PR TITLE
Prevent SROC 2PT being triggered when FYE < 2023

### DIFF
--- a/src/internal/modules/billing/controllers/create-bill-run.js
+++ b/src/internal/modules/billing/controllers/create-bill-run.js
@@ -209,6 +209,11 @@ const _batching = async (h, batch, request) => {
 async function _initiateSrocBatch (batch, cookie) {
   const { batchType, financialYearEnding, regionId, userEmail } = batch
 
+  // SROC only applies from 1st April 2022 so we don't care about any with a FYE < 2023
+  if (financialYearEnding < 2023) {
+    return
+  }
+
   // SROC 2PT is still in development so controlled by a feature toggle and 'annual' is processed by the old engine
   if ((!config.featureToggles.triggerSrocTwoPartTariff && batchType === TWO_PART_TARIFF) || batchType === ANNUAL) {
     return

--- a/test/internal/modules/billing/controllers/create-bill-run.test.js
+++ b/test/internal/modules/billing/controllers/create-bill-run.test.js
@@ -776,7 +776,7 @@ experiment('internal/modules/billing/controllers/create-bill-run', () => {
       request.params.region = '07ae7f3a-2677-4102-b352-cc006828948c'
       request.params.season = 'summer'
 
-      request.payload['select-financial-year'] = '2022'
+      request.payload['select-financial-year'] = '2023'
 
       loggerErrorStub = sandbox.stub(logger, 'error')
       sandbox.stub(services.water.billingBatches, 'createBillingBatch').resolves({
@@ -786,6 +786,22 @@ experiment('internal/modules/billing/controllers/create-bill-run', () => {
             status: 'processing'
           }
         }
+      })
+    })
+
+    experiment('and the financial year ending is less than 2023', () => {
+      beforeEach(() => {
+        request.params.billingType = 'supplementary'
+
+        request.payload['select-financial-year'] = '2022'
+        createSrocBillRunStub = sandbox.stub(services.system.billRuns, 'createBillRun')
+      })
+
+      test('does not trigger the creation of an SROC bill run', async () => {
+        await controller.postBillingBatchFinancialYear(request, h)
+
+        expect(createSrocBillRunStub.called).to.be.false()
+        expect(loggerErrorStub.called).to.be.false()
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4197

Following on from the work we did to create a trigger for the SROC two-part-tariff bill runs we have realised that the bill run can be triggered for billing periods outside of the SROC billing period.

This PR will fix that issue by preventing an SROC 2PT bill run from being triggered when the `financialYearEnding` is prior to 2023.