### PR TITLE
Link to new bill page from all sent bills page

### DIFF
--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -102,7 +102,8 @@ const getBillsForLicence = async (request, h) => {
     bills: data,
     pagination,
     licenceId,
-    back: `/licences/${licenceId}#bills`
+    back: `/licences/${licenceId}#bills`,
+    useNewBillView: featureToggles.useNewBillView
   })
 }
 

--- a/src/internal/views/nunjucks/billing/bills.njk
+++ b/src/internal/views/nunjucks/billing/bills.njk
@@ -7,7 +7,7 @@
   {{ title(pageTitle, caption) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        {{ licenceInvoicesView(bills, tableCaption) }}
+        {{ licenceInvoicesView(bills, tableCaption, useNewBillView) }}
 
         {{paginate(pagination)}}
     </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

We have been working on replacing the existing views of a bill in the legacy code because they are slow and timeout when attempting to view large bills with many licences.

In [Link to new bill page](https://github.com/DEFRA/water-abstraction-ui/pull/2461) we thought we had updated all existing links that point to a bill to instead point to our new page.

But we missed one. After searching for a licence and having selected the 'Bills' tab there is a link at the bottom that takes you to a 'View all sent bills page'. If you click on a bill in there it takes you to the legacy view.

This change updates that link as well to point to the new bill view.