### PR TITLE
Redirect to new bill run page

### DIFF
--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -531,7 +531,7 @@ experiment('internal/modules/billing/controller', () => {
       expect(batches[1].region.name).to.equal('Midlands')
       expect(batches[1].status).to.equal('review')
       expect(batches[1].billCount).to.equal(8)
-      expect(batches[1].link).to.be.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e2/two-part-tariff-review')
+      expect(batches[1].link).to.be.equal('/system/bill-runs/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e2/review')
       expect(batches[1].scheme).to.equal('sroc')
       expect(billRunBuilding).to.be.true()
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

We have been working on implementing a new version of the bill page. The current one tries to display all transaction details for all licences on a single page when the bill is selected.

In the larger annual bill runs this might equate to more than 150 licences and their transactions which means the page is failing to load.

All that work has been done in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) as part of our ongoing efforts to migrate away from the legacy code. It is in the final throws of testing and will soon be released.

To get to the new pages you have to pass through the existing bill run summary page. What our work has highlighted is this page also leaves a lot to desire! Again, the larger the bill run the slower it is, noticeably so. Though it at least always loads 😁. It also is inconsistent. It has a different layout depending on the bill run type, and one of those depends on tabs which is an incorrect use of the component.

We'd like to remove this remaining 'bump' in our billing user journey so have rebuilt the page in **water-abstraction-system**. So, now if the feature toggle `USE_NEW_BILL_VIEW` is enabled we direct the user to the new page.

---

We also use the opportunity to simplify what is going on in `getBillingBatchRoute()`. At least we think it is simpler and clearer!