### PR TITLE
Make bill run summary page backlink fixed

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -39,9 +39,8 @@ const getBillingBatchSummary = async (request, h) => {
     isAnnual: batch.type === 'annual',
     isEditable: batch.status === 'ready',
     errors: mappers.mapBatchLevelErrors(batch, invoices),
-    // only show the back link from the list page, so not to offer the link
-    // as part of the batch creation flow.
-    back: request.query.back && BATCH_LIST_ROUTE,
+    back: '/billing/batch/list',
+    backText: 'Go back to bill runs',
     useNewBillView: featureToggles.useNewBillView
   })
 }

--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -290,14 +290,8 @@ experiment('internal/modules/billing/controller', () => {
         })
       })
 
-      test('does not include the back link if the "back" query param is zero', async () => {
+      test('includes a backlink to the bill runs page', async () => {
         await controller.getBillingBatchSummary(request, h)
-        const [, view] = h.view.lastCall.args
-        expect(view.back).to.equal(0)
-      })
-
-      test('includes the back link if "back" query param is 1', async () => {
-        await controller.getBillingBatchSummary({ ...request, query: { back: 1 } }, h)
         const [, view] = h.view.lastCall.args
         expect(view.back).to.equal('/billing/batch/list')
       })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

The new bill pages we have been developing to replace the existing ones take a different approach to backlinks. Currently, in the service backlinks are intended to act like the browser back button. Clicking them should take you back to wherever you came from.

That's not the intent of backlinks in the design system though. When added to a page they _should_ take you back to the step or context before where you currently are. So, if you are on the bill page, you should go back to the bill run that the bill is linked to.

The browser back button is there for those who truly want to go back to wherever they came from.

Another reason for following this guidance is backlinks that just trigger `javascript:history.back()` are notorious for getting people stuck in loops. And that is now happening with our new pages. Suppose a user comes to the new bill page via the bill run summary page. Our new fixed link will take them back to the bill run summary. But the backlink in that page will just trigger the javascript sending them back ... to the bill page!

To avoid this and at the same time bring the page in line with our new ones, this change updates the backlink to always go back to the bill runs list page.