### PR TITLE
Redirect to new bill run page from batch sent page

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -160,7 +160,8 @@ const getBillingBatchConfirmSuccess = (request, h) => {
     ...request.view,
     pageTitle: 'Bill run sent',
     panelText: `You've sent the ${getBillRunPageTitle(batch)} ${batch.billRunNumber}`,
-    batch
+    batch,
+    featureToggles
   })
 }
 

--- a/src/internal/views/nunjucks/billing/batch-sent-success.njk
+++ b/src/internal/views/nunjucks/billing/batch-sent-success.njk
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ 
+      {{
         govukPanel({
           titleText: pageTitle,
           text: panelText
@@ -17,7 +17,13 @@
 
       {{ downloadBatchButton(batch) }}
 
-      <p><a href="/billing/batch/{{batch.id}}/summary">Go to bill run</a></p>
+      {% if featureToggles.useNewBillView %}
+        {% set viewLink = '/system/bill-runs/' + batch.id %}
+      {% else %}
+        {% set viewLink = '/billing/batch/' + batch.id + '/summary' %}
+      {% endif %}
+
+      <p><a href="{{viewLink}}">Go to bill run</a></p>
 
     </div>
   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4223

We have been working on implementing a new version of the bill page. The current one tries to display all transaction details for all licences on a single page when the bill is selected.

In the larger annual bill runs this might equate to more than 150 licences and their transactions which means the page is failing to load.

All that work has been done in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) as part of our ongoing efforts to migrate away from the legacy code. It is in the final throws of testing and will soon be released.

Late in testing, we've spotted that the 'send a bill run' success page displays a 'Go to the bill run' link which is currently taking you to the old view.

So, this change applies a similar change we did in [Redirect to new bill run page](https://github.com/DEFRA/water-abstraction-ui/pull/2473), using the feature toggles to determine what link to use.