### PR TITLE
Fix unique ID confused for licence in notice

### DIFF
--- a/src/internal/modules/returns-notifications/controllers/paper-forms.js
+++ b/src/internal/modules/returns-notifications/controllers/paper-forms.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Boom = require('@hapi/boom')
-const { get, partialRight, has } = require('lodash')
+const { get, partialRight } = require('lodash')
 const { v4: uuid } = require('uuid')
 
 const sessionForms = require('shared/lib/session-forms')

--- a/src/internal/modules/returns-notifications/controllers/paper-forms.js
+++ b/src/internal/modules/returns-notifications/controllers/paper-forms.js
@@ -50,7 +50,21 @@ const getEnterLicenceNumber = async (request, h) => {
 
 const isMultipleLicenceHoldersForLicence = data => data.some(row => row.documents.length > 1)
 const isReturnsDueForLicences = data => data.some(row => row.documents.length > 0)
-const licencesWithNoReturnsDue = data => Object.values(data).filter(row => !(has(row, 'document')))
+const licencesWithNoReturnsDue = (data) => {
+  const results = []
+
+  for (const [key, value] of Object.entries(data)) {
+    if (key === 'uniqueJobId') {
+      continue
+    }
+
+    if (!value.document) {
+      results.push(value)
+    }
+  }
+
+  return results
+}
 
 /**
  * Post handler for licence numbers entry


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4106

In [Generate unique job ID for paper return forms](https://github.com/DEFRA/water-abstraction-ui/pull/2458) we added a unique ID to the session created when generating paper form return notices. This was part of our efforts to avoid mis-clicks or double-clicks sending duplicate requests to generate the notices.

We didn't realise that some logic uses [Lodash](https://lodash.com/) to check the objects in the session for licences that do not have returns due.

```javascript
const licencesWithNoReturnsDue = data => Object.values(data).filter(row => !(has(row, 'document')))
```

This was fine when the session data looked like this

```javascript
{
  'b79fdd34-d937-417c-86dd-f2f6ecf4b70f': 'AT/CURR/MONTHLY/01',
  'ff571075-10bd-4583-b817-bb8dba7562fb': {
    licence: {
      id: '2589611b-c575-44e3-9871-d85b5a6efa24',
      licenceNumber: 'AT/CURR/MONTHLY/02',
      isWaterUndertaker: false,
      startDate: '2020-01-01',
      expiredDate: null,
      lapsedDate: null,
      revokedDate: null,
      includeInSupplementaryBilling: 'no',
      includeInSrocSupplementaryBilling: false,
      historicalArea: [Object],
      regionalChargeArea: [Object],
      region: [Object],
      isFutureDated: false,
      endDate: null,
      endDateReason: null,
      isActive: true
    },
    document: {
      roles: [Array],
      id: 'ff571075-10bd-4583-b817-bb8dba7562fb',
      dateRange: [Object],
      licenceNumber: 'AT/CURR/MONTHLY/02'
    },
    returns: [ [Object], [Object], [Object], [Object] ],
    isSelected: true,
    isMultipleDocument: false,
    selectedRole: 'licenceHolder'
  }
}
```

`['AT/CURR/MONTHLY/01']` would be returned by the function as a licence without returns due.

> We assume only licences with returns due get all the extra info added.

But when we added `uniqueJobId: 'ce138350-9263-4a53-b29b-20093729afba'` to the object it to passes the filter's test so you get `['AT/CURR/MONTHLY/01', 'ce138350-9263-4a53-b29b-20093729afba']` returned.

This change fixes the issue by ditching the fancy stuff and using good old basic JavaScript!

<details>
<summary>Screenshot of effected notice</summary>

![Screenshot 2024-01-21 at 21 09 15](https://github.com/DEFRA/water-abstraction-ui/assets/1789650/8f24758b-2715-4bd9-b67c-a7eb201e447c)

</details>