### PR TITLE
Fixing proxying to system from external UI

### DIFF
--- a/server-external.js
+++ b/server-external.js
@@ -5,6 +5,7 @@ const { createPlugins, createCache } = require('./server-common')
 
 // -------------- Require vendor code -----------------
 const Hapi = require('@hapi/hapi')
+const H2o2 = require('@hapi/h2o2')
 
 // -------------- Require project code -----------------
 const config = require('./src/external/config')
@@ -81,6 +82,9 @@ async function start () {
 
     // Auth plugin
     await server.register(authPlugin)
+
+    // Proxy plugin
+    await server.register(H2o2)
 
     server.route(routes)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4352

https://github.com/DEFRA/water-abstraction-ui/pull/2507

When trying to access the external site, found there was an issue causing "This site can't be reached" being displayed.

Upon inspection, this was being caused by a missing import for proxying configuration within the external which was already present in the internal UI.

This change adds the configuration needed for the external site to work.