### PR TITLE
Link empty bill runs to view bill page

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -17,20 +17,12 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     return `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`
   }
 
-  if (status === 'ready') {
-    if (opts.invoiceId) {
-      return `/billing/batch/${id}/invoice/${opts.invoiceId}`
-    }
-
-    return `/system/bill-runs/${id}`
+  if (opts.invoiceId && status === 'ready') {
+    return `/billing/batch/${id}/invoice/${opts.invoiceId}`
   }
 
-  if (status === 'sent') {
-    if (opts.showSuccessPage) {
-      return `/billing/batch/${id}/confirm/success`
-    }
-
-    return `/system/bill-runs/${id}`
+  if (opts.showSuccessPage && status === 'sent') {
+    return `/billing/batch/${id}/confirm/success`
   }
 
   if (status === 'review') {
@@ -41,7 +33,11 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     return `/billing/batch/${id}/two-part-tariff-review`
   }
 
-  return `/billing/batch/${id}/${status}`
+  if (status === 'error') {
+    return `/billing/batch/${id}/error`
+  }
+
+  return `/system/bill-runs/${id}`
 }
 
 const getTwoPartTariffLicenceReviewRoute = (batch, invoiceLicenceId) =>

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -145,7 +145,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the empty batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/empty`)
+        expect(result).to.equal(`/system/bill-runs/${batch.id}`)
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4396

We have replaced the legacy version of the view empty bill run page with one in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

This updates the routing logic to return a link to the new view. If you look at the change you'll see this is the same route as when viewing a ready or sent bill run. In our new repo, we don't make separate routes based on status. Instead, it is one `GET /bill-runs/{id}` route to view a bill run and logic in the app will decide how the bill run is presented.