### PR TITLE
Link errored bill runs to view bill page

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -33,10 +33,6 @@ const getBillingBatchRoute = (batch, opts = {}) => {
     return `/billing/batch/${id}/two-part-tariff-review`
   }
 
-  if (status === 'error') {
-    return `/billing/batch/${id}/error`
-  }
-
   return `/system/bill-runs/${id}`
 }
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -157,7 +157,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the error batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/error`)
+        expect(result).to.equal(`/system/bill-runs/${batch.id}`)
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4398

We have replaced the legacy version of the view errored bill run page with one in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

This updates the routing logic to return a link to the new view. If you look at the change you'll see this is the same route as when viewing a ready or sent bill run. In our new repo, we don't make separate routes based on status. Instead, it is one `GET /bill-runs/{id}` route to view a bill run and logic in the app will decide how the bill run is presented.