### PR TITLE
Display cancelling bill runs in bill runs page

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -91,10 +91,15 @@ const getBillingBatchList = async (request, h) => {
     return batch.status === 'processing' || batch.status === 'queued'
   })
 
+  const billRunCancelling = batches.some((batch) => {
+    return batch.status === 'cancel'
+  })
+
   return h.view('nunjucks/billing/batch-list', {
     ...request.view,
     batches,
     billRunBuilding,
+    billRunCancelling,
     pagination,
     form: featureToggles.deleteAllBillingData && confirmForm.form(request, 'Delete all bills and charge information', {
       action: '/billing/batch/delete-all-data',

--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -13,6 +13,10 @@
 const getBillingBatchRoute = (batch, opts = {}) => {
   const { id, scheme, status } = batch
 
+  if (status === 'cancel') {
+    return null
+  }
+
   if (status === 'processing' || status === 'queued' || status === 'sending') {
     return `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`
   }

--- a/src/internal/views/nunjucks/billing/batch-list.njk
+++ b/src/internal/views/nunjucks/billing/batch-list.njk
@@ -7,10 +7,20 @@
 
 {% block content %}
 
-  {% if billRunBuilding %}
+  {% if billRunBuilding and billRunCancelling %}
+    {{ govukNotificationBanner({
+        html: '<p class="govuk-notification-banner__heading">Bill runs are currently busy building and cancelling.</p>
+          <p class="govuk-body">Please wait for these bill runs to finish before creating another one.</p>'
+    }) }}
+  {% elif billRunBuilding %}
     {{ govukNotificationBanner({
         html: '<p class="govuk-notification-banner__heading">A bill run is currently building.</p>
           <p class="govuk-body">Please wait for this bill run to finish building before creating another one.</p>'
+    }) }}
+  {% elif billRunCancelling %}
+    {{ govukNotificationBanner({
+        html: '<p class="govuk-notification-banner__heading">A bill run is currently cancelling.</p>
+          <p class="govuk-body">Please wait for this bill run to finish cancelling before creating another one.</p>'
     }) }}
   {% endif %}
 
@@ -41,7 +51,6 @@
           </thead>
           <tbody class="govuk-table__body">
             {% for batch in batches %}
-            {% if (batch.status !== 'cancel') %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">
                   {% if batch.link %}
@@ -70,7 +79,6 @@
 
                 <td class="govuk-table__cell govuk-table__cell--numeric">{{ badge(batch | batchBadge) }}</td>
               </tr>
-              {% endif %}
             {% endfor %}
           </tbody>
         </table>

--- a/src/shared/view/nunjucks/filters/batch-badge.js
+++ b/src/shared/view/nunjucks/filters/batch-badge.js
@@ -8,7 +8,8 @@ const badge = {
   review: { status: 'todo', text: 'Review' },
   error: { status: 'error', text: 'Error' },
   empty: { status: 'inactive', text: 'Empty' },
-  queued: { status: 'warning', text: 'Queued' }
+  queued: { status: 'warning', text: 'Queued' },
+  cancel: { status: 'warning', text: 'Cancelling' }
 }
 
 exports.batchBadge = (batch, isLarge) => ({


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4387

We need to add this to support our work to make cancelling bill runs visible to users.

Cancelling a bill run, especially a large one, can impact the service and take a considerable amount of time (30 minutes for the largest ones!) We want to let users know when a bill run is being cancelled so that they can make a more informed decision as to when it is best to try creating a new bill run.

We've amended [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/pull/2450) to stop filtering bill runs with a status of `cancel` from the bill run results. The final step is to update this project to ensure they are displayed correctly in the table. This means they have a badge and no link to view the bill run.