### PR TITLE
Add reminder banner in external UI to add licences

### DIFF
--- a/src/external/views/nunjucks/view-licences/licences.njk
+++ b/src/external/views/nunjucks/view-licences/licences.njk
@@ -12,9 +12,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       {% set addLicencesBannerHtml %}
-        <div class="govuk-notification-banner__heading max-width-full">Renewed licences not showing in your licences need to be added to your account.<br>
-        <a class="govuk-notification-banner__link" href="/manage_licences">Add licence</a>
-        </div>
+        <p class="govuk-notification-banner__heading govuk-!-margin-bottom-0 max-width-full">Renewed licences not showing in your licences need to be added to your account.</p>
+        <a class="govuk-notification-banner__heading govuk-notification-banner__link" href="/manage_licences">Add licence</a>
       {% endset %}
 
       {{ govukNotificationBanner({

--- a/src/external/views/nunjucks/view-licences/licences.njk
+++ b/src/external/views/nunjucks/view-licences/licences.njk
@@ -1,6 +1,7 @@
 {% extends "./nunjucks/layout.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% from "paginate.njk" import paginate %}
 {% from "sort-icon.njk" import sortIcon %}
@@ -10,6 +11,16 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      {% set addLicencesBannerHtml %}
+        <div class="govuk-notification-banner__heading max-width-full">Renewed licences not showing in your licences need to be added to your account.<br>
+        <a class="govuk-notification-banner__link" href="/manage_licences">Add licence</a>
+        </div>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        html: addLicencesBannerHtml
+      }) }}
+
       {{ title(pageTitle) }}
 
       {% if showVerificationAlert %}

--- a/src/shared/assets/sass/_utils.scss
+++ b/src/shared/assets/sass/_utils.scss
@@ -13,3 +13,10 @@
 .govuk-table__override_no_bottom_border{
   border-bottom: none !important;
 }
+
+// Added to allow us to force the content block inside a notification banner to fill the whole banner. Out of the box
+// GOVUK set `max-width: 605px` on the content and when we asked a maintainer the only response was 'why would you
+// ever want it wider'.
+.max-width-full {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4399

An issue has been raised where Licence Holders don't recognise the need to add licences to their account after a renewal and are missing their returns. There is already a feature in the service to add licences to an account so it has been agreed that a banner highlighting this is an appropriate intermediate step before full account management is tackled.

This adds the banner.

---

Out-of-the-box GOVUK enforces that banner content does get full with of the banner. It only gets approx 2 thirds (`max-width: 605px;` to be exact). Our designers decided that wrapping the content at 2 thirds looks 'odd' so this also involved some custom CSS to override the width of `govuk-notification-banner__content`.

![Screenshot 2024-03-06 at 22 02 42](https://github.com/DEFRA/water-abstraction-ui/assets/1789650/fd7665c2-ed0f-4486-a4e6-0189df6af9ed)
