### PR TITLE
Redirect to new view after remove bill licence

### DIFF
--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -22,7 +22,7 @@ const getBillingBatchRoute = (batch, opts = {}) => {
   }
 
   if (opts.invoiceId && status === 'ready') {
-    return `/billing/batch/${id}/invoice/${opts.invoiceId}`
+    return `/system/bills/${opts.invoiceId}`
   }
 
   if (opts.showSuccessPage && status === 'sent') {

--- a/src/internal/views/nunjucks/billing/batch-processing.njk
+++ b/src/internal/views/nunjucks/billing/batch-processing.njk
@@ -1,12 +1,9 @@
 {% extends "./nunjucks/layout.njk" %}
-{% from "./nunjucks/billing/macros/batch-buttons.njk" import cancelStatusBatchButton %}
 {% from "badge.njk" import badge %}
+
 {% block content %}
-
-
- 
     {{ title(pageTitle, billRunDate | date('D MMMM YYYY')) }}
-    
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
@@ -16,12 +13,6 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        {{ cancelStatusBatchButton(batch) }}
-      </div>
-    </div>
-    
     <meta http-equiv="refresh" content="10">
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <img class="spinner" src="/public/images/ajax-loader.gif" alt="spinner">

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -85,7 +85,7 @@ experiment('internal/modules/billing/lib/routing', () => {
           }
           const result = getBillingBatchRoute(batch, options)
 
-          expect(result).to.equal(`/billing/batch/${batch.id}/invoice/${options.invoiceId}`)
+          expect(result).to.equal(`/system/bills/${options.invoiceId}`)
         })
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

In WATER-4131 we resolved an issue with the legacy service not being able to display large bill runs without erroring. We did this by replacing the existing views with new ones. When we did this though we overlooked a feature; Remove licence from a bill.

We've since [put the button back in](https://github.com/DEFRA/water-abstraction-system/pull/824) to allow users to remove a licence from a bill. But because we are still dependent on the legacy service to do the removal we are also required to use its 'processing' page.

Initial testing showed that for this scenario it was redirecting back to the old view for a bill! So, this change fixes that issue.

Whilst making this change we've also dropped the cancel button from that processing (spinner) page. It's a 'one-page-fits-all' affair hence the cancel button was always shown. However, you cannot cancel a remove bill or remove bill licence once these are in process. We never built-in support for a bill run being cancelled in the middle of creation with the new SROC engines. Finally, using it with the old PRESROC often leads to 'stuck' cancelling bill runs.

So, we're taking this opportunity to remove the button and save us and the users unnecessary issues.