### PR TITLE
Fix back link on billing spinner page

### DIFF
--- a/src/internal/modules/billing/controllers/bill-run.js
+++ b/src/internal/modules/billing/controllers/bill-run.js
@@ -238,14 +238,12 @@ const postBillingBatchDeleteInvoice = async (request, h) => {
  */
 const getBillingBatchProcessing = async (request, h) => {
   const { batch } = request.pre
-  const back = !!request.query.back
 
   return h.view('nunjucks/billing/batch-processing', {
     batch,
     ...request.view,
     caption: moment(batch.createdAt).format('D MMMM YYYY'),
-    pageTitle: `${batch.region.displayName} ${mappers.mapBatchType(batch.type).toLowerCase()} bill run`,
-    back: back && BATCH_LIST_ROUTE
+    pageTitle: `${batch.region.displayName} ${mappers.mapBatchType(batch.type).toLowerCase()} bill run`
   })
 }
 

--- a/src/internal/modules/billing/controllers/two-part-tariff.js
+++ b/src/internal/modules/billing/controllers/two-part-tariff.js
@@ -202,7 +202,7 @@ const getApproveReview = (request, h) => {
 const postApproveReview = async (request, h) => {
   const { batchId } = request.params
   const { data: { batch } } = await services.water.billingBatches.approveBatchReview(batchId)
-  return h.redirect(routing.getBillingBatchRoute(batch, { isBackEnabled: true }))
+  return h.redirect(routing.getBillingBatchRoute(batch))
 }
 
 /**

--- a/src/internal/modules/billing/lib/mappers.js
+++ b/src/internal/modules/billing/lib/mappers.js
@@ -21,7 +21,7 @@ const mapBatchListRow = batch => ({
   ...batch,
   batchType: mapBatchType(batch.type),
   billCount: getBillCount(batch),
-  link: routing.getBillingBatchRoute(batch, { isBackEnabled: true })
+  link: routing.getBillingBatchRoute(batch)
 })
 
 const isTransactionInErrorStatus = transaction => transaction.status === transactionStatuses.error

--- a/src/internal/modules/billing/lib/routing.js
+++ b/src/internal/modules/billing/lib/routing.js
@@ -3,11 +3,11 @@
 /**
  * Gets the correct route for the specified batch depending on its
  * current status
+ *
  * @param {Object} batch - the batch object from water service
- * @param {Object} options - whether back should be enabled on processing page
- *          {Boolean} isBackEnabled - whether back should be enabled on processing page
- *          {Boolean} showSuccessPage - whether to show success or summary page for sent batch
- *          {String} invoiceId - set if user should be redirected to invoice page when batch ready
+ * @param {Object} options - whether to show the success page or batch summary ({Boolean} showSuccessPage). Whether to
+ * redirect to the bill page when the batch status becomes 'ready' ({String} invoiceId)
+ *
  * @return {String} the link
  */
 const getBillingBatchRoute = (batch, opts = {}) => {
@@ -18,7 +18,7 @@ const getBillingBatchRoute = (batch, opts = {}) => {
   }
 
   if (status === 'processing' || status === 'queued' || status === 'sending') {
-    return `/billing/batch/${id}/processing?back=${opts.isBackEnabled ? 1 : 0}`
+    return `/billing/batch/${id}/processing`
   }
 
   if (opts.invoiceId && status === 'ready') {

--- a/src/internal/modules/billing/pre-handlers.js
+++ b/src/internal/modules/billing/pre-handlers.js
@@ -111,7 +111,7 @@ const redirectOnBatchStatus = async (request, h) => {
   }
 
   // Redirect to the correct page for this batch
-  const path = routing.getBillingBatchRoute(batch, { isBackEnabled: true, showSuccessPage: true, invoiceId })
+  const path = routing.getBillingBatchRoute(batch, { showSuccessPage: true, invoiceId })
   return h.redirect(path).takeover()
 }
 

--- a/test/internal/modules/billing/controllers/bill-run.test.js
+++ b/test/internal/modules/billing/controllers/bill-run.test.js
@@ -519,7 +519,7 @@ experiment('internal/modules/billing/controller', () => {
       expect(batches[0].region.name).to.equal('Anglian')
       expect(batches[0].status).to.equal('processing')
       expect(batches[0].billCount).to.equal(14)
-      expect(batches[0].link).to.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e1/processing?back=1')
+      expect(batches[0].link).to.equal('/billing/batch/8ae7c31b-3c5a-44b8-baa5-a10b40aef9e1/processing')
       expect(batches[0].scheme).to.equal('alcs')
       expect(batches[1].type).to.equal('Two-part tariff')
       expect(batches[1].region.name).to.equal('Midlands')
@@ -805,25 +805,6 @@ experiment('internal/modules/billing/controller', () => {
     test('outputs the formatted batch creation date as the caption', async () => {
       const [, { caption }] = h.view.lastCall.args
       expect(caption).to.equal('1 February 2020')
-    })
-
-    experiment('when the back query param is 1', () => {
-      test('back link is to the batch list page', async () => {
-        const [, { back }] = h.view.lastCall.args
-        expect(back).to.equal('/billing/batch/list')
-      })
-    })
-
-    experiment('when the back query param is 0', () => {
-      beforeEach(async () => {
-        request = createRequest(0)
-        await controller.getBillingBatchProcessing(request, h)
-      })
-
-      test('back link is false', async () => {
-        const [, { back }] = h.view.lastCall.args
-        expect(back).to.be.false()
-      })
     })
   })
 

--- a/test/internal/modules/billing/lib/routing.test.js
+++ b/test/internal/modules/billing/lib/routing.test.js
@@ -17,23 +17,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the processing batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
-      })
-
-      experiment('and the back option is not set', () => {
-        test('defaults the back query param to 0', () => {
-          const result = getBillingBatchRoute(batch)
-
-          expect(result).to.endWith('?back=0')
-        })
-      })
-
-      experiment('and the back option is set', () => {
-        test('sets the back query param to 1', () => {
-          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
-
-          expect(result).to.endWith('?back=1')
-        })
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing`)
       })
     })
 
@@ -45,23 +29,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the processing batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
-      })
-
-      experiment('and the back option is not set', () => {
-        test('defaults the back query param to 0', () => {
-          const result = getBillingBatchRoute(batch)
-
-          expect(result).to.endWith('?back=0')
-        })
-      })
-
-      experiment('and the back option is set', () => {
-        test('sets the back query param to 1', () => {
-          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
-
-          expect(result).to.endWith('?back=1')
-        })
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing`)
       })
     })
 
@@ -169,23 +137,7 @@ experiment('internal/modules/billing/lib/routing', () => {
       test('returns the processing batch page url', () => {
         const result = getBillingBatchRoute(batch)
 
-        expect(result).to.equal(`/billing/batch/${batch.id}/processing?back=0`)
-      })
-
-      experiment('and the back option is not set', () => {
-        test('defaults the back query param to 0', () => {
-          const result = getBillingBatchRoute(batch)
-
-          expect(result).to.endWith('?back=0')
-        })
-      })
-
-      experiment('and the back option is set', () => {
-        test('sets the back query param to 1', () => {
-          const result = getBillingBatchRoute(batch, { isBackEnabled: true })
-
-          expect(result).to.endWith('?back=1')
-        })
+        expect(result).to.equal(`/billing/batch/${batch.id}/processing`)
       })
     })
   })

--- a/test/internal/modules/billing/pre-handlers.test.js
+++ b/test/internal/modules/billing/pre-handlers.test.js
@@ -320,7 +320,7 @@ experiment('internal/modules/billing/pre-handlers', () => {
       await preHandlers.redirectOnBatchStatus(request, h)
 
       const [path] = h.redirect.lastCall.args
-      expect(path).to.equal('/billing/batch/test-batch-id/processing?back=1')
+      expect(path).to.equal('/billing/batch/test-batch-id/processing')
       expect(h.takeover.called).to.be.true()
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4410

We realised recently that we'd inadvertently dropped the button that allows users to remove a bill licence from a bill. We've now put the button back in but this means the process has come under the beady eye of our QA team!

They've discovered that the spinner page often has a back link but clicking it can have varying results from 'page not found' to outright errors.

From looking at the legacy code we can see there was logic built in to make displaying the back link optional. If whatever code redirects to the spinner page doesn't include the appropriate option, the backlink will get displayed when it shouldn't.

~Or should it? A much simpler and cleaner solution that will work in all cases (the same spinner page is used for a host of reasons) is to have a fixed backlink that returns the user to the bill run they are working with.~

~This change implements that better solution (till we can drop the spinner page altogether!)~

That was going to be our solution but then we remembered. This repo includes client-side javascript that hijacks all backlinks and has them work in the same way as clicking back in the browser! 😱😭🤬 

So, plan B. We are just removing the back link altogether from this page.