### PR TITLE
Make manage workflow 'to setup' links intelligent

### DIFF
--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -172,7 +172,8 @@ module.exports = {
     showVerificationCode: process.env.SHOW_VERIFICATION_CODE_FEATURE === 'true' && !isProduction,
     showReturnRequirements: (get(process.env, 'SHOW_RETURN_REQUIREMENTS') || '').toLowerCase() === 'true' && !isProduction,
     triggerSrocAnnual: (get(process.env, 'TRIGGER_SROC_ANNUAL') || '').toLowerCase() === 'true',
-    useNewBillRunSetup: (get(process.env, 'USE_NEW_BILL_RUN_SETUP') || '').toLowerCase() === 'true'
+    useNewBillRunSetup: (get(process.env, 'USE_NEW_BILL_RUN_SETUP') || '').toLowerCase() === 'true',
+    useWorkflowSetupLinks: (get(process.env, 'USE_WORKFLOW_SETUP_LINKS') || 'true').toLowerCase() === 'true'
   },
   billRunsToDisplayPerPage: process.env.BILL_RUNS_TO_DISPLAY_PER_PAGE || 20
 }

--- a/src/internal/views/nunjucks/charge-information/workflow-tabs/to-set-up.njk
+++ b/src/internal/views/nunjucks/charge-information/workflow-tabs/to-set-up.njk
@@ -26,8 +26,8 @@
                         <td class="govuk-table__cell">{{row.licenceHolderRole.company.name}}</td>
                         <td class="govuk-table__cell">{{row.licenceVersion.startDate | date}}</td>
                         <td class="govuk-table__cell">
-                            <a href="/licences/{{row.licenceId}}/charge-information/create?chargeVersionWorkflowId={{row.chargeVersionWorkflowId}}">Set up</a>
-                            {% if isReviewer %} 
+                            <a href="{{row.link.href}}">{{row.link.text}}</a>
+                            {% if isReviewer %}
                             | <a href="/charge-information-workflow/{{row.chargeVersionWorkflowId}}/remove">Remove</a>
                             {% endif %}
                         </td>

--- a/test/internal/modules/charge-information/pre-handlers.test.js
+++ b/test/internal/modules/charge-information/pre-handlers.test.js
@@ -349,8 +349,8 @@ experiment('internal/modules/charge-information/pre-handlers', () => {
         expect(services.water.chargeVersionWorkflows.getChargeVersionWorkflows.called).to.be.true()
       })
       test('returns the results ordered by licence start date', async () => {
-        expect(result.data[0]).to.equal({ licence: { startDate: '2000-09-30' } })
-        expect(result.data[1]).to.equal({ licence: { startDate: '2002-05-03' } })
+        expect(result.data[0].licence).to.equal({ startDate: '2000-09-30' })
+        expect(result.data[1].licence).to.equal({ startDate: '2002-05-03' })
       })
     })
     experiment('when the service response is invalid', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4437

For context, we found out legacy background jobs scheduled in BullMQ only run intermittently. One we found hadn't run for the last 2 years so agreed to bin. Two we need to deal with at some point but intermittent is fine for now. The critical job, which is putting updated licences into workflow, we solved by migrating to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/903).

As part of solving it we took the opportunity to add data to the workflow record to allow us to identify that the record was added because of an updated licence. We also spotted that our time-limited job was broken 😱 so [fixed that](https://github.com/DEFRA/water-abstraction-system/pull/908) and updated it to _also_ add some info to the workflow record.

With these handy bits of info now in the workflow record, it seems a shame we don't make the reason why the record was added visible to the user.

So, this change amends the link in the 'To setup' based on that extra info. In the pre-handler that fetches the to-setup workflow records we now iterate through the results and add the link details to use in the view.

If it spots the `timeLimitedChargeVersionId` property we add to the data field it will generate a link that will take the user directly to the charge version with the time-limited element.

Else if the `chargeVersionExists` property is present we know the record was added by the licence updates job. If the property is true we direct the user to the charge information tab for the licence rather than drop them into a new one. That way they can see the existing ones and determine if a new one is needed.

Else if `chargeVersionExists` property is missing or false we leave the link as it was and direct the user to create a new charge version.