### PR TITLE
Adding tags for acceptance tests (returns required)

### DIFF
--- a/src/internal/views/nunjucks/view-licences/tabs/charge.njk
+++ b/src/internal/views/nunjucks/view-licences/tabs/charge.njk
@@ -160,7 +160,7 @@
 
 {% if featureToggles.showReturnRequirements %}
 <h2 class="govuk-heading-l">Returns requirements (for testing)</h2>
-<a href="/system/licences/{{ licenceId }}/returns-required" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-right-3" data-module="govuk-button">
+<a href="/system/licences/{{ licenceId }}/returns-required" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-right-3" data-module="govuk-button" data-test="meta-data-returns-required">
     Set up new returns requirement
 </a>
 <a href="/system/licences/{{ licenceId }}/no-returns-required" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-test="meta-data-no-returns">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4485

When writing acceptance tests, due to the way [crypress](https://docs.cypress.io/guides/overview/why-cypress) works, some components of a page can be hard to locate.

For example, imagine a summary list which has nested values. This might be the address on the page provided by cypress:

```
':nth-child(2) > .govuk-summary-list.govuk-\!-margin-bottom-2 > :nth-child(1) > .govuk-summary-list__value'
```

To make it easier to locate the elements on the page we want to test, we add tags like so:
```
'<span data-test="meta-data-reason">' + reason + '</span>'
```

This PR is focused on adding tags to the views in the returns required journey.