### PR TITLE
Fix missed links to legacy view licence page

### DIFF
--- a/src/internal/modules/returns/controllers/internal.js
+++ b/src/internal/modules/returns/controllers/internal.js
@@ -26,6 +26,8 @@ const {
   internalRoutingFormSchema
 } = require('../forms')
 
+const config = require('../../../config.js')
+
 /**
  * Loads a WaterReturn instance using the supplied returnId
  * @param  {String}  returnId - return service return ID
@@ -75,7 +77,7 @@ const getInternalRouting = async (request, h, form) => {
     return: data,
     back: STEP_LICENCES,
     links: {
-      licence: `/licences/${licence.id}`
+      licence: linkToViewLicence(licence.id)
     }
   })
 }
@@ -190,6 +192,14 @@ const getReceiptLogged = async (request, h) => {
 const getQueryLogged = async (request, h) => {
   const view = await getSubmittedViewData(request)
   return h.view('nunjucks/returns/query-logged', view)
+}
+
+const linkToViewLicence = (licenceId) => {
+  if (config.featureToggles.enableSystemLicenceView) {
+    return `/system/licences/${licenceId}/summary`
+  } else {
+    return `/licences/${licenceId}`
+  }
 }
 
 exports.getInternalRouting = getInternalRouting

--- a/src/internal/modules/returns/controllers/view.js
+++ b/src/internal/modules/returns/controllers/view.js
@@ -8,6 +8,8 @@ const { getEditButtonPath } = require('internal/lib/return-path')
 
 const services = require('../../../lib/connectors/services')
 
+const config = require('../../../config.js')
+
 /**
  * Get a list of returns for a particular licence
  * @param {String} request.params.documenId - the CRM doc ID for the licence
@@ -67,11 +69,19 @@ const getReturn = async (request, h) => {
     isVoid: data.status === 'void',
     endReading: get(data, `meters[0].readings.${helpers.endReadingKey(data)}`),
     links: {
-      licence: `/licences/${licence.id}`
+      licence: linkToViewLicence(licence.id)
     }
   }
 
   return h.view('nunjucks/returns/return', view)
+}
+
+const linkToViewLicence = (licenceId) => {
+  if (config.featureToggles.enableSystemLicenceView) {
+    return `/system/licences/${licenceId}/summary`
+  } else {
+    return `/licences/${licenceId}`
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4558

> Part of the work to replace the legacy view licence page

It looks like when we did [Add feature flag for links to the water abstraction system](https://github.com/DEFRA/water-abstraction-ui/pull/2579) we missed some links that have been found in testing.

This changes updates where the code is redirecting or generating links to the legacy view licence page to instead link to the new one built in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).