### PR TITLE
Fix customer licence view link toggle

### DIFF
--- a/src/internal/views/nunjucks/customers/tabs/licences.njk
+++ b/src/internal/views/nunjucks/customers/tabs/licences.njk
@@ -13,7 +13,11 @@
         {% if licence.id %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" scope="row">
+              {% if featureFlags.enableSystemLicenceView == true %}
+                <a href='/system/licences/{{ licence.id }}/summary'>{{ licence.licenceNumber }}</a>
+              {% else %}
                 <a href='/licences/{{ licence.id }}'>{{ licence.licenceNumber }}</a>
+              {% endif %}
             </td>
             <td class="govuk-table__cell" scope="row">
                 {{ licence.name }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4466

We have rebuilt the view licence pages in the system repo. As part of this work we introduced toggles in the old UI to direct user to the new view licence pages.

This link was missed by the previous work.