### PR TITLE
Update /workflow page to remove 'charge' elements

### DIFF
--- a/src/internal/modules/charge-information/controllers/charge-information-workflow.js
+++ b/src/internal/modules/charge-information/controllers/charge-information-workflow.js
@@ -14,7 +14,7 @@ const getChargeInformationWorkflow = async (request, h) => {
   const view = {
     back: '/manage',
     ...request.view,
-    pageTitle: 'Charge information workflow',
+    pageTitle: 'Workflow',
     licences: {
       changeRequest,
       toSetUp,

--- a/src/internal/modules/charge-information/pre-handlers.js
+++ b/src/internal/modules/charge-information/pre-handlers.js
@@ -231,7 +231,7 @@ const loadChargeVersionWorkflows = async request => {
         }
       } else if (featureToggles.enableSystemLicenceView) {
         workflow.link = {
-          href: `/licences/${licenceId}/set-up`,
+          href: `/system/licences/${licenceId}/set-up`,
           text: 'Set up'
         }
       } else {

--- a/src/internal/modules/charge-information/pre-handlers.js
+++ b/src/internal/modules/charge-information/pre-handlers.js
@@ -217,7 +217,7 @@ const loadChargeVersionWorkflows = async request => {
   try {
     const workflows = await services.water.chargeVersionWorkflows.getChargeVersionWorkflows(toSetupPageNumber, 100, 'to_setup')
     workflows.data.forEach((workflow) => {
-      const { chargeVersionWorkflowId, data, licenceId } = workflow
+      const { data, licenceId } = workflow
 
       if (featureToggles.useWorkflowSetupLinks && data?.timeLimitedChargeVersionId) {
         workflow.link = {
@@ -230,9 +230,16 @@ const loadChargeVersionWorkflows = async request => {
           text: 'Updated'
         }
       } else {
-        workflow.link = {
-          href: `/licences/${licenceId}/charge-information/create?chargeVersionWorkflowId=${chargeVersionWorkflowId}`,
-          text: 'Set up'
+        if (featureToggles.enableSystemLicenceView) {
+          workflow.link = {
+            href: `/licences/${licenceId}/set-up`,
+            text: 'Set up'
+          }
+        } else {
+          workflow.link = {
+            href: `/licences/${licenceId}#charge`,
+            text: 'Set up'
+          }
         }
       }
     })

--- a/src/internal/modules/charge-information/pre-handlers.js
+++ b/src/internal/modules/charge-information/pre-handlers.js
@@ -229,17 +229,15 @@ const loadChargeVersionWorkflows = async request => {
           href: linkToLicenceChargeInformation(licenceId),
           text: 'Updated'
         }
+      } else if (featureToggles.enableSystemLicenceView) {
+        workflow.link = {
+          href: `/licences/${licenceId}/set-up`,
+          text: 'Set up'
+        }
       } else {
-        if (featureToggles.enableSystemLicenceView) {
-          workflow.link = {
-            href: `/licences/${licenceId}/set-up`,
-            text: 'Set up'
-          }
-        } else {
-          workflow.link = {
-            href: `/licences/${licenceId}#charge`,
-            text: 'Set up'
-          }
+        workflow.link = {
+          href: `/licences/${licenceId}#charge`,
+          text: 'Set up'
         }
       }
     })

--- a/src/internal/views/nunjucks/charge-information/workflow-tabs/review.njk
+++ b/src/internal/views/nunjucks/charge-information/workflow-tabs/review.njk
@@ -1,7 +1,7 @@
 <div>
     {% if licencesCounts.review > 0 %}
         <h1 class="govuk-heading-l">
-            Review
+            Review charge information
         <br/>
             <span class="govuk-caption-l">
                 {%if licencesCounts.review == 1 %}

--- a/src/internal/views/nunjucks/charge-information/workflow.njk
+++ b/src/internal/views/nunjucks/charge-information/workflow.njk
@@ -33,7 +33,7 @@
             <a class="govuk-tabs__tab" href="#toSetUp">To set up ({{licencesCounts.toSetUp}})</a>
           </li>
           <li class="govuk-tabs__list-item">
-            <a class="govuk-tabs__tab" href="#review">Review ({{licencesCounts.review}})</a>
+            <a class="govuk-tabs__tab" href="#review">Review charge information ({{licencesCounts.review}})</a>
           </li>
           <li class="govuk-tabs__list-item">
             <a class="govuk-tabs__tab" href="#changeRequest">Change request ({{licencesCounts.changeRequest}})</a>

--- a/src/internal/views/nunjucks/notifications/manage-tab.njk
+++ b/src/internal/views/nunjucks/notifications/manage-tab.njk
@@ -22,7 +22,7 @@
   {{ links('Send flow notices', hofNotifications )}}
   {{ links('Manage users', accounts )}}
   {{ links('Billing', billing )}}
-  {{ links('View charge information workflow', chargeInformationWorkflow )}}
+  {{ links('View workflow', chargeInformationWorkflow )}}
   {{ links('Upload charge information', uploadChargeInformation )}}
 
 {% endblock %}

--- a/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
+++ b/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
@@ -49,7 +49,7 @@ const createRequest = () => ({
   }
 })
 
-experiment('internal/modules/charge-information/controller', () => {
+experiment.only('internal/modules/charge-information/controller', () => {
   let request, h
 
   beforeEach(async () => {
@@ -86,7 +86,7 @@ experiment('internal/modules/charge-information/controller', () => {
 
     test('has the page title', async () => {
       const { pageTitle } = h.view.lastCall.args[1]
-      expect(pageTitle).to.equal('Charge information workflow')
+      expect(pageTitle).to.equal('Workflow')
     })
 
     test('has no caption', async () => {

--- a/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
+++ b/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
@@ -49,7 +49,7 @@ const createRequest = () => ({
   }
 })
 
-experiment.only('internal/modules/charge-information/controller', () => {
+experiment('internal/modules/charge-information/controller', () => {
   let request, h
 
   beforeEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4570

With WRLS taking over return information when a licence is added or changed and a record is added to workflow, the workflow record needs to direct users to check both return and charge information, not just charge information. It also needs to stop referring to ‘charge information’ only, for example, in the link on the manage page and on the page itself.

This PR is focused on amending the /manage page and it's subsections for the new licence set up view.