### PR TITLE
Display security code in ext. change email page

### DIFF
--- a/src/external/modules/account/controller.js
+++ b/src/external/modules/account/controller.js
@@ -17,6 +17,8 @@ const isLockedHttpStatus = err => [423, 429].includes(err.statusCode)
 const isErrorHttpStatus = err => [401, 404].includes(err.statusCode)
 const isConflictHttpStatus = err => err.statusCode === 409
 
+const config = require('../../config.js')
+
 /**
  * Renders account screen with options to change email/password
  */
@@ -131,12 +133,13 @@ const getVerifyEmail = async (request, h, form) => {
   const { userId } = request.defra
 
   try {
-    const response = await services.water
-      .changeEmailAddress.getStatus(userId)
+    const response = await services.water.changeEmailAddress.getStatus(userId)
 
     const verifyForm = form || verifyNewEmailForm(request)
     const view = {
       ...request.view,
+      showVerificationCode: config.featureToggles.showVerificationCode,
+      securityCode: response.data.securityCode,
       form: verifyForm,
       back: '/account',
       newEmail: get(response, 'data.email')

--- a/src/external/views/nunjucks/account/verify.njk
+++ b/src/external/views/nunjucks/account/verify.njk
@@ -26,6 +26,11 @@
         If the email hasn’t arrived you can
         <a href="/account/change-email/enter-new-email">request another code.</a>
       </p>
+      {%if showVerificationCode%}
+      <p>
+        Your code is <code><b><span data-test="security-code">{{ securityCode }}</span></b></code>
+      </p>
+      {%endif%}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4632

We received a report that the external app's change email journey was broken. We quickly confirmed this.

Nothing related to the fix needed to be made to this project. But such a critical feature shouldn't have been allowed to sit broken for so long.

To ensure this (until we can replace the legacy version), we've [added a test](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/131) to our automated test project. The problem is that the journey relies on sending the user an email code, which they then need to enter.

This change copies a solution that has been used before, where the code is displayed on the screen if the feature toggle `SHOW_VERIFICATION_CODE_FEATURE` has been enabled.

Our acceptance tests can then read this and use it to complete the journey.