### PR TITLE
Tag where permit is used

### DIFF
--- a/src/internal/lib/connectors/services/water/AbstractionReformAnalysisApiClient.js
+++ b/src/internal/lib/connectors/services/water/AbstractionReformAnalysisApiClient.js
@@ -2,6 +2,7 @@ const { APIClient } = require('@envage/hapi-pg-rest-api')
 const urlJoin = require('url-join')
 const { http, serviceRequest } = require('@envage/water-abstraction-helpers')
 
+// TODO: uses the /ar/licence route - permit
 const getEndpoint = serviceUrl => urlJoin(serviceUrl, '/ar/licences')
 
 class AbstractionReformAnalysisApiClient extends APIClient {

--- a/src/internal/modules/abstraction-reform/controllers/edit.js
+++ b/src/internal/modules/abstraction-reform/controllers/edit.js
@@ -152,6 +152,7 @@ const getEditObject = async (request, h) => {
   const args = getAdditionalArgs(id)
 
   // Load licence / AR licence from CRM
+  // TODO: uses permit
   const { licence, finalState } = await load(documentId)
 
   // Check permissions

--- a/src/internal/modules/abstraction-reform/controllers/wr22.js
+++ b/src/internal/modules/abstraction-reform/controllers/wr22.js
@@ -30,6 +30,7 @@ const pre = async (request, h) => {
   const { documentId } = request.params
 
   // Load licence / AR licence from CRM
+  // TODO: uses permit
   const { licence, arLicence, finalState } = await load(documentId)
 
   request.licence = licence

--- a/src/internal/modules/abstraction-reform/lib/form-generator.js
+++ b/src/internal/modules/abstraction-reform/lib/form-generator.js
@@ -38,6 +38,7 @@ const resolveLicenceConditions = async context => {
 }
 
 const resolveLicencePoints = async context => {
+  // TODO: wants points
   const connector = services.water.licences.getPointsByDocumentId
   return resolveLicenceData(context, connector, mapPoint)
 }

--- a/src/internal/modules/abstraction-reform/lib/loader.js
+++ b/src/internal/modules/abstraction-reform/lib/loader.js
@@ -86,12 +86,14 @@ const loadLicence = async (documentId) => {
  * @return {Promise} resolves with {licence, arLicence, finalState }
  */
 const load = async (documentId) => {
+  // TODO: uses permit
   const { licence, arLicence } = await loadLicence(documentId)
 
   // Setup initial state
   const initialState = getInitialState(licence)
 
   // Calculate final state after actions applied
+  // TODO: use the permit licence data licence_data_value
   const finalState = stateManager(initialState, arLicence.licence_data_value.actions)
 
   return {

--- a/src/internal/modules/abstraction-reform/lib/loader.js
+++ b/src/internal/modules/abstraction-reform/lib/loader.js
@@ -115,6 +115,7 @@ const update = async (licenceId, data, licenceNumber) => {
     licence_data_value: JSON.stringify(data)
   }
   const result = await services.permits.licences.updateOne(licenceId, payload)
+  // TODO: uses the /ar/licence route
   await services.water.abstractionReformAnalysis.arRefreshLicenceWebhook(licenceNumber)
   return result
 }

--- a/src/internal/modules/abstraction-reform/lib/wr22-helpers.js
+++ b/src/internal/modules/abstraction-reform/lib/wr22-helpers.js
@@ -53,6 +53,7 @@ const getAddFormAndSchema = async (request) => {
   const { documentId, schema: schemaName } = request.params
 
   const action = getAddFormAction(documentId, schemaName)
+  // TODO: uses permits licence here
   const schema = await formGenerator.dereference(getSchema(schemaName), { documentId })
   const form = formGenerator.schemaToForm(action, request, schema)
 

--- a/src/shared/lib/connectors/services/permits/LicencesApiClient.js
+++ b/src/shared/lib/connectors/services/permits/LicencesApiClient.js
@@ -11,6 +11,7 @@ class LicencesApiClient extends APIClient {
    * @param {Object} logger The system logger object
    */
   constructor (config, logger) {
+    // TODO: any permit call here
     const serviceUrl = config.services.permits
 
     super(http.request, {

--- a/src/shared/lib/connectors/services/water/LicencesService.js
+++ b/src/shared/lib/connectors/services/water/LicencesService.js
@@ -50,6 +50,7 @@ class LicencesService extends ServiceClient {
   }
 
   getPointsByDocumentId (documentId) {
+    // TODO: mention of points
     const url = this.joinUrl('documents', documentId, 'licence/points')
     return getRequest(this.serviceRequest, url)
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4626

We want to establish what features in the legacy code depend on the permit.licence table. For example, we know in our own code, we depend on it to identify the ‘points’ for a licence.

The NALD import creates the permit licence table and document header table during the NALD import job.

The issue is that the permit.licence record is just a massive JSONB dump of all the NALD data related to the licence. It looks like the later licence import in water-abstraction-import did a much better job of breaking the same data down into constituent tables.

We’re focusing our efforts on recreating a new licence import ready for ReSP. But until we can confirm what legacy features depend on the old permit.licence table, we can’t decide whether to drop creating permit.licence records or recreate the massive JSONB dump.