### PR TITLE
Add system supplementary flag for returns

### DIFF
--- a/src/internal/lib/connectors/services/system/LicencesApiClient.js
+++ b/src/internal/lib/connectors/services/system/LicencesApiClient.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const ServiceClient = require('../../../../../shared/lib/connectors/services/ServiceClient')
+
+class LicencesApiClient extends ServiceClient {
+  /**
+   * Flags a licence for the supplementary bill run
+   *
+   * @param {String} returnId - The UUID of the return log that needs flagging
+   * @param {Object} cookie - Existing cookie set by this app needed for pass-through authentication
+   *
+   * @returns {Promise} resolves with the licence being flagged for the supplementary bill run
+   */
+  supplementary (returnId, cookie) {
+    const url = this.joinUrl('licences/supplementary')
+    const options = {
+      headers: {
+        cookie
+      },
+      body: {
+        returnId
+      }
+    }
+    return this.serviceRequest.post(url, options)
+  }
+}
+
+module.exports = LicencesApiClient

--- a/src/internal/lib/connectors/services/system/index.js
+++ b/src/internal/lib/connectors/services/system/index.js
@@ -3,10 +3,12 @@
 // Internal services
 const BillingAccountsApiClient = require('./BillingAccountsApiClient.js')
 const BillRunsApiClient = require('./BillRunsApiClient.js')
+const LicencesApiClient = require('./LicencesApiClient.js')
 
 const { logger } = require('../../../../logger')
 
 module.exports = config => ({
   billingAccounts: new BillingAccountsApiClient(config.services.system, logger),
-  billRuns: new BillRunsApiClient(config.services.system, logger)
+  billRuns: new BillRunsApiClient(config.services.system, logger),
+  licences: new LicencesApiClient(config.services.system, logger)
 })

--- a/src/internal/modules/returns/controllers/edit.js
+++ b/src/internal/modules/returns/controllers/edit.js
@@ -362,7 +362,7 @@ const getSubmitted = async (request, h) => {
 
   const returnUrl = `/returns/return?id=${data.returnId}`
 
-  const markForSupplementaryBillingUrl = `/licences/${licence.id}/mark-for-supplementary-billing`
+  const markForSupplementaryBillingUrl = `/licences/${licence.id}/mark-for-supplementary-billing?returnId=${data.returnId}`
 
   return h.view('nunjucks/returns/submitted', {
     ...request.view,

--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -141,8 +141,6 @@ const getMarkLicenceForSupplementaryBilling = (request, h) => {
 const postMarkLicenceForSupplementaryBilling = async (request, h) => {
   const { licenceId } = request.params
   const { returnId } = request.payload
-  const cookie = request.headers.cookie
-
   const { document } = request.pre
   const { system_external_id: licenceRef } = document
 
@@ -151,6 +149,8 @@ const postMarkLicenceForSupplementaryBilling = async (request, h) => {
 
   if (returnId) {
     try {
+      const cookie = request.headers.cookie
+
       await services.system.licences.supplementary(returnId, cookie)
     } catch (error) {
       logger.error('Flag supplementary request to system failed', error.stack)

--- a/src/internal/modules/view-licences/forms/mark-for-supplementary-billing.js
+++ b/src/internal/modules/view-licences/forms/mark-for-supplementary-billing.js
@@ -6,6 +6,7 @@ const markForSupplementaryBillingForm = request => {
 
   f.fields.push(fields.hidden('csrf_token', {}, request.view.csrfToken))
   f.fields.push(fields.hidden('licenceId', {}, request.params.licenceId))
+  f.fields.push(fields.hidden('returnId', {}, request.query.returnId))
 
   f.fields.push(fields.button(null, { label: 'Confirm' }))
   return f

--- a/test/internal/lib/connectors/services/system/LicencesApiClient.js
+++ b/test/internal/lib/connectors/services/system/LicencesApiClient.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+const sandbox = Sinon.createSandbox()
+
+// Things we need to stub
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+
+// Thing under test
+const LicencesApiClient = require('../../../../../../src/internal/lib/connectors/services/system/LicencesApiClient.js')
+
+experiment('services/system/LicencesApiClient', () => {
+  let service
+
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'post')
+    service = new LicencesApiClient('http://127.0.0.1:8013')
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  experiment('.supplementary', () => {
+    beforeEach(async () => {
+      await service.supplementary('v1:6:01/115:10032782:2023-04-01:2024-03-31')
+    })
+
+    test('passes the expected URL to the service request', async () => {
+      const url = serviceRequest.post.lastCall.args[0]
+
+      expect(url).to.equal('http://127.0.0.1:8013/licences/supplementary')
+    })
+
+    test('passes the query in the request body', async () => {
+      const options = serviceRequest.post.lastCall.args[1]
+
+      expect(options.body).to.equal({ returnId: 'v1:6:01/115:10032782:2023-04-01:2024-03-31' })
+    })
+  })
+})

--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -28,6 +28,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
       redirect: sandbox.stub()
     }
     sandbox.stub(services.water.licences, 'postMarkLicenceForSupplementaryBilling').resolves()
+    sandbox.stub(services.system.licences, 'supplementary').resolves()
     sandbox.stub(services.water.licences, 'getDocumentByLicenceId').resolves({
       metadata: {},
       system_external_id: 'test id'
@@ -385,6 +386,9 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
       params: {
         licenceId: tempLicenceId
       },
+      query: {
+        returnId: 'some-return-id'
+      },
       pre: {
         document: {
           system_external_id: '10/10/10'
@@ -414,6 +418,12 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
       method: 'get',
       params: {
         licenceId: tempLicenceId
+      },
+      headers: {
+        cookie: 'taste=yummy'
+      },
+      payload: {
+        returnId: 'some-return-id'
       },
       pre: {
         document: {

--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -413,6 +413,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
   experiment('.postMarkLicenceForSupplementaryBilling', () => {
     const tempLicenceId = uuid()
+    const tempReturnId = uuid()
     const request = {
       view: {},
       method: 'get',
@@ -423,7 +424,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
         cookie: 'taste=yummy'
       },
       payload: {
-        returnId: 'some-return-id'
+        returnId: tempReturnId
       },
       pre: {
         document: {
@@ -438,6 +439,10 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
     test('calls the backend', () => {
       expect(services.water.licences.postMarkLicenceForSupplementaryBilling.calledWith(tempLicenceId)).to.be.true()
+    })
+
+    test('calls system', () => {
+      expect(services.system.licences.supplementary.calledWith(tempReturnId)).to.be.true()
     })
 
     test('returns the correct view data objects', async () => {

--- a/test/internal/modules/view-licences/forms/mark-for-supplementary-billing.test.js
+++ b/test/internal/modules/view-licences/forms/mark-for-supplementary-billing.test.js
@@ -10,6 +10,9 @@ const createRequest = () => ({
   },
   params: {
     licenceId: 'some-licence-id'
+  },
+  query: {
+    returnId: 'some-return-id'
   }
 })
 
@@ -32,6 +35,11 @@ experiment('mark for supplementary billing form', () => {
   test('has CSRF token field', async () => {
     const csrf = findField(form, 'csrf_token')
     expect(csrf.value).to.equal('token')
+  })
+
+  test('has returnId as a hidden field', async () => {
+    const returnId = findField(form, 'returnId')
+    expect(returnId.value).to.equal('some-return-id')
   })
 
   test('has a confirm button', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4199

When a return is submitted or edited the user is given the chance to flag the licence for the next supplementary bill run. As part of our work to create a two-part tariff supplementary bill run, we also need the same functionality to flag licences for our new bill run type. This PR is setting up the UI to call our endpoint in system that determines which years on the licence need to be flagged.