### PR TITLE
Fix links to system view licence in /user/*/status

### DIFF
--- a/src/internal/modules/internal-search/controller.js
+++ b/src/internal/modules/internal-search/controller.js
@@ -14,6 +14,8 @@ const { setPermissionsForm, setPermissionsSchema, permissionsChoices } = require
 const { hasScope } = require('../../lib/permissions')
 const { scope } = require('internal/lib/constants')
 
+const config = require('../../config.js')
+
 /**
  * Renders a search form and results pages for internal users to search
  * for licences, licence holders, users, and returns
@@ -99,7 +101,8 @@ const getUserStatus = async (request, h, formFromPost) => {
     userStatus,
     form: formFromPost || await getPermissionsFormData(request),
     deleteAccountLink: `/account/delete-account/${userId}`,
-    unlinkLicencePathTail: `unlink-licence?userId=${userId}`
+    unlinkLicencePathTail: `unlink-licence?userId=${userId}`,
+    enableSystemLicenceView: config.featureToggles.enableSystemLicenceView
   }
 
   return h.view('nunjucks/internal-search/user-status', view)

--- a/src/internal/views/nunjucks/internal-search/macros/company-licences.njk
+++ b/src/internal/views/nunjucks/internal-search/macros/company-licences.njk
@@ -1,6 +1,6 @@
 {% from "details-when.njk" import detailsWhen %}
 
-{% macro companyLicences(licences, userCanUnlinkLicences, unlinkLicencePathTail) %}
+{% macro companyLicences(licences, userCanUnlinkLicences, unlinkLicencePathTail, enableSystemLicenceView) %}
   {% if licences.length > 0 %}
     <h3 class="govuk-heading-m govuk-!-margin-0">
       {{ licences | length }} {{ 'licence' | pluralize(licences) }}
@@ -18,8 +18,8 @@
           {% for licence in licences %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell" scope="row">
-              {% if featureFlags.enableSystemLicenceView == true %}
-                <a class="govuk-link" href="/summary/licences/{{ licence.licence.id }}/summary">{{ licence.licenceRef }}</a>
+              {% if enableSystemLicenceView == true %}
+                <a class="govuk-link" href="/system/licences/{{ licence.licence.id }}/summary">{{ licence.licenceRef }}</a>
               {% else %}
                 <a class="govuk-link" href="/licences/{{ licence.licence.id }}">{{ licence.licenceRef }}</a>
               {% endif %}

--- a/src/internal/views/nunjucks/internal-search/macros/user-companies.njk
+++ b/src/internal/views/nunjucks/internal-search/macros/user-companies.njk
@@ -1,7 +1,7 @@
 {% from "./company-verifications.njk" import companyVerifications %}
 {% from "./company-licences.njk" import companyLicences %}
 
-{% macro userCompanies(companies, user, unlinkLicencePathTail) %}
+{% macro userCompanies(companies, user, unlinkLicencePathTail, enableSystemLicenceView) %}
   {% for company in companies %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-l govuk-!-margin-0">{{ company.name }}</h2>
@@ -11,6 +11,6 @@
     {{ companyVerifications(company.outstandingVerifications) }}
 
     {% set userCanUnlinkLicences = (('unlink_licences' in user.scope) and ('primary_user' in company.userRoles)) %}
-    {{ companyLicences(company.registeredLicences, userCanUnlinkLicences, unlinkLicencePathTail) }}
+    {{ companyLicences(company.registeredLicences, userCanUnlinkLicences, unlinkLicencePathTail, enableSystemLicenceView) }}
   {% endfor %}
 {% endmacro %}

--- a/src/internal/views/nunjucks/internal-search/user-status.njk
+++ b/src/internal/views/nunjucks/internal-search/user-status.njk
@@ -19,7 +19,7 @@
         {% endif %}
       {% else %}
         {% if userStatus.licenceCount %}
-          {{ userCompanies(userStatus.companies, user, unlinkLicencePathTail) }}
+          {{ userCompanies(userStatus.companies, user, unlinkLicencePathTail, enableSystemLicenceView) }}
         {% else %}
           <p class="govuk-body-l">
             This user does not have any licences linked to their account


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4558

> Part of the work to replace the legacy view licence page

Spotted whilst [fixing an issue in the water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/1291) version of the view licence page. The links in the `/user/{id}/status` page still point to the old view.

After taking a look, we realised

- feature flags were never actually being passed to the view
- the flags were not being passed through the many (_many_ 😩) layers of macros to where it was being used
- the link we would have generated would have been broken

This change fixes all those issues and gets the link working.