### PR TITLE
Amend mark for supplementary billing

### DIFF
--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -138,14 +138,24 @@ const getMarkLicenceForSupplementaryBilling = (request, h) => {
   })
 }
 
+/**
+ * The `postMarkLicenceForSupplementaryBilling` function is used in two different scenarios:
+ *
+ * 1. When a return is submitted
+ * 2. When the 'Recalculate Bills' link is clicked on the legacy licence page
+ *
+ * Recent changes to support SROC two-part tariff supplementary billing require passing the `returnId`
+ * to this function. This enables the system repo to determine whether the licence needs flagging based on the update
+ * return.
+ *
+ * In the case of the legacy "Recalculate Bills" link, only the licence ID is needed to flag the licence
+ * for pre-SROC and SROC supplementary billing.
+ */
 const postMarkLicenceForSupplementaryBilling = async (request, h) => {
   const { licenceId } = request.params
   const { returnId } = request.payload
   const { document } = request.pre
   const { system_external_id: licenceRef } = document
-
-  // Call backend to mark the licence for supplementary billing
-  await services.water.licences.postMarkLicenceForSupplementaryBilling(licenceId)
 
   if (returnId) {
     try {
@@ -155,6 +165,9 @@ const postMarkLicenceForSupplementaryBilling = async (request, h) => {
     } catch (error) {
       logger.error('Flag supplementary request to system failed', error.stack)
     }
+  } else {
+    // Call backend to mark the licence for supplementary billing
+    await services.water.licences.postMarkLicenceForSupplementaryBilling(licenceId)
   }
 
   return h.view('nunjucks/billing/marked-licence-for-supplementary-billing', {

--- a/src/internal/modules/view-licences/controller.js
+++ b/src/internal/modules/view-licences/controller.js
@@ -145,7 +145,7 @@ const getMarkLicenceForSupplementaryBilling = (request, h) => {
  * 2. When the 'Recalculate Bills' link is clicked on the legacy licence page
  *
  * Recent changes to support SROC two-part tariff supplementary billing require passing the `returnId`
- * to this function. This enables the system repo to determine whether the licence needs flagging based on the update
+ * to this function. This enables the system repo to determine whether the licence needs flagging based on the updated
  * return.
  *
  * In the case of the legacy "Recalculate Bills" link, only the licence ID is needed to flag the licence

--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -412,46 +412,74 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
   })
 
   experiment('.postMarkLicenceForSupplementaryBilling', () => {
-    const tempLicenceId = uuid()
-    const tempReturnId = uuid()
-    const request = {
-      view: {},
-      method: 'get',
-      params: {
-        licenceId: tempLicenceId
-      },
-      headers: {
-        cookie: 'taste=yummy'
-      },
-      payload: {
-        returnId: tempReturnId
-      },
-      pre: {
-        document: {
-          system_external_id: '10/10/10'
-        }
-      },
-      yar: { get: sandbox.spy() }
-    }
-    beforeEach(async () => {
-      await controller.postMarkLicenceForSupplementaryBilling(request, h)
+    experiment('when passed a returnId', () => {
+      const tempLicenceId = uuid()
+      const tempReturnId = uuid()
+      const request = {
+        view: {},
+        method: 'get',
+        params: {
+          licenceId: tempLicenceId
+        },
+        headers: {
+          cookie: 'taste=yummy'
+        },
+        payload: {
+          returnId: tempReturnId
+        },
+        pre: {
+          document: {
+            system_external_id: '10/10/10'
+          }
+        },
+        yar: { get: sandbox.spy() }
+      }
+
+      beforeEach(async () => {
+        await controller.postMarkLicenceForSupplementaryBilling(request, h)
+      })
+
+      test('calls system', () => {
+        expect(services.system.licences.supplementary.calledWith(tempReturnId)).to.be.true()
+      })
     })
 
-    test('calls the backend', () => {
-      expect(services.water.licences.postMarkLicenceForSupplementaryBilling.calledWith(tempLicenceId)).to.be.true()
-    })
+    experiment('when not passed a returnId', () => {
+      const tempLicenceId = uuid()
+      const request = {
+        view: {},
+        method: 'get',
+        params: {
+          licenceId: tempLicenceId
+        },
+        headers: {
+          cookie: 'taste=yummy'
+        },
+        payload: {},
+        pre: {
+          document: {
+            system_external_id: '10/10/10'
+          }
+        },
+        yar: { get: sandbox.spy() }
+      }
 
-    test('calls system', () => {
-      expect(services.system.licences.supplementary.calledWith(tempReturnId)).to.be.true()
-    })
+      beforeEach(async () => {
+        await controller.postMarkLicenceForSupplementaryBilling(request, h)
+      })
 
-    test('returns the correct view data objects', async () => {
-      const keys = Object.keys(h.view.lastCall.args[1])
+      test('calls the backend', () => {
+        expect(services.water.licences.postMarkLicenceForSupplementaryBilling.calledWith(tempLicenceId)).to.be.true()
+      })
 
-      expect(keys).to.include([
-        'pageTitle',
-        'panelText',
-        'licenceId'])
+      test('returns the correct view data objects', async () => {
+        const keys = Object.keys(h.view.lastCall.args[1])
+
+        expect(keys).to.include([
+          'pageTitle',
+          'panelText',
+          'licenceId'])
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4199
https://eaflood.atlassian.net/browse/WATER-4676

During testing for the first ticket, it was discovered that editing a return on a licence and then flagging that licence for supplementary billing, was always flagging the licence for pre-sroc supplementary billing even when the years were for sroc. 

The system now handles flagging a licence for two-part tariff supplementary, so this change is allowing system to handle all the flagging for editing a return. 
The `postMarkLicenceForSupplementaryBilling` function is being used during two flagging routes. 

The first is when a return is edited. As we now handle that in system the call to the UI just passes the information for system to work out if the licence for the edited return needs to be flagged. 

The second route is through the legacy licence link of `recalculate bills`. This functionality has also since been rebuilt in system, so whilst the code remains in case we ever need to rely on using the legacy view licence page, this route is now otherwise redundant. 