### PR TITLE
Add monitoring stations feature flag for search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11749,9 +11749,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.79.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.2.tgz",
-      "integrity": "sha512-YmT1aoF1MwHsZEu/eXhbAJNsPGAhNP4UixW9ckEwWCvPcVdVF0/C104OGDVEqtoctKq0N+wM20O/rj+sSPsWeg==",
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
       "dev": true,
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -22915,9 +22915,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.79.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.2.tgz",
-      "integrity": "sha512-YmT1aoF1MwHsZEu/eXhbAJNsPGAhNP4UixW9ckEwWCvPcVdVF0/C104OGDVEqtoctKq0N+wM20O/rj+sSPsWeg==",
+      "version": "1.79.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+      "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
       "dev": true,
       "requires": {
         "chokidar": "^4.0.0",

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -175,7 +175,7 @@ module.exports = {
     useNewBillRunSetup: (get(process.env, 'USE_NEW_BILL_RUN_SETUP') || '').toLowerCase() === 'true',
     useWorkflowSetupLinks: (get(process.env, 'USE_WORKFLOW_SETUP_LINKS') || 'true').toLowerCase() === 'true',
     enableSystemLicenceView: process.env.ENABLE_SYSTEM_LICENCE_VIEW === 'true',
-    enableMonitoringStations: process.env.ENABLE_MONITORING_STATIONS === 'true'
+    enableMonitoringStationsView: process.env.ENABLE_MONITORING_STATIONS_VIEW === 'true'
   },
   billRunsToDisplayPerPage: process.env.BILL_RUNS_TO_DISPLAY_PER_PAGE || 20
 }

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -174,7 +174,8 @@ module.exports = {
     triggerSrocAnnual: (get(process.env, 'TRIGGER_SROC_ANNUAL') || '').toLowerCase() === 'true',
     useNewBillRunSetup: (get(process.env, 'USE_NEW_BILL_RUN_SETUP') || '').toLowerCase() === 'true',
     useWorkflowSetupLinks: (get(process.env, 'USE_WORKFLOW_SETUP_LINKS') || 'true').toLowerCase() === 'true',
-    enableSystemLicenceView: process.env.ENABLE_SYSTEM_LICENCE_VIEW === 'true'
+    enableSystemLicenceView: process.env.ENABLE_SYSTEM_LICENCE_VIEW === 'true',
+    enableMonitoringStations: process.env.ENABLE_MONITORING_STATIONS === 'true'
   },
   billRunsToDisplayPerPage: process.env.BILL_RUNS_TO_DISPLAY_PER_PAGE || 20
 }

--- a/src/internal/views/nunjucks/internal-search/index.njk
+++ b/src/internal/views/nunjucks/internal-search/index.njk
@@ -81,9 +81,15 @@
 
 {% macro gaugingStationLink(station) %}
   {% if station.gaugingStationId %}
+    {% if featureFlags.enableMonitoringStations == true %}
+      <a href="/system/monitoring-stations/{{ station.gaugingStationId }}">
+        {{ station.label }}
+      </a>
+    {% else %}
       <a href="/monitoring-stations/{{ station.gaugingStationId }}">
         {{ station.label }}
       </a>
+    {% endif %}
   {% else %}
       {{ station.label }}
   {% endif %}

--- a/src/internal/views/nunjucks/internal-search/index.njk
+++ b/src/internal/views/nunjucks/internal-search/index.njk
@@ -81,7 +81,7 @@
 
 {% macro gaugingStationLink(station) %}
   {% if station.gaugingStationId %}
-    {% if featureFlags.enableMonitoringStations == true %}
+    {% if featureFlags.enableMonitoringStationsView == true %}
       <a href="/system/monitoring-stations/{{ station.gaugingStationId }}">
         {{ station.label }}
       </a>

--- a/src/shared/view/default-context.js
+++ b/src/shared/view/default-context.js
@@ -7,6 +7,6 @@ module.exports = {
   cssVersion: pkg.version,
   featureFlags: {
     enableSystemLicenceView: config.featureToggles.enableSystemLicenceView,
-    enableMonitoringStations: config.featureToggles.enableMonitoringStations
+    enableMonitoringStationsView: config.featureToggles.enableMonitoringStationsView
   }
 }

--- a/src/shared/view/default-context.js
+++ b/src/shared/view/default-context.js
@@ -6,6 +6,7 @@ module.exports = {
   htmlLang: 'en',
   cssVersion: pkg.version,
   featureFlags: {
-    enableSystemLicenceView: config.featureToggles.enableSystemLicenceView
+    enableSystemLicenceView: config.featureToggles.enableSystemLicenceView,
+    enableMonitoringStations: config.featureToggles.enableMonitoringStations
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4679

While adding the feature flag for the monitoring stations for the license summary page, we realised that the monitoring station can also be reached via the internal search tool. This could mean users are at one point in the journey being shown the new migration monitoring station page, and at another point are shown the legacy monitoring station view.

This PR adds the feature flag functionality to the UI internal search tool to send users to the new monitoring station view.