### PR TITLE
Stop display null for site description in view rtn

### DIFF
--- a/src/shared/view/nunjucks/macros/returns/return-header.njk
+++ b/src/shared/view/nunjucks/macros/returns/return-header.njk
@@ -7,7 +7,9 @@
       Site description
     </dt>
     <dd class="meta__value">
-      {{ return.metadata.description }}
+      {% if return.metadata.description != 'null' %}
+        {{ return.metadata.description }}
+      {% endif %}
     </dd>
   </div>
   <div class="meta__row">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4703

If a return log was created from a return requirement with no site description, when a user views the return log in the UI they see `null`.

We've agreed that we should display nothing when this is the case. This change updates the legacy view to handle this scenario.

<img width="945" alt="Screenshot 2024-10-04 at 17 41 34" src="https://github.com/user-attachments/assets/aafeacfa-2b21-41c6-bac1-6658d9ce04c5">
