### PR TITLE
Flag licences removed from workflow for supp billing

### DIFF
--- a/src/internal/lib/connectors/services/system/WorkflowApiClient.js
+++ b/src/internal/lib/connectors/services/system/WorkflowApiClient.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const ServiceClient = require('../../../../../shared/lib/connectors/services/ServiceClient')
+
+class WorkflowApiClient extends ServiceClient {
+  /**
+   * Flags a licence for the supplementary bill run
+   *
+   * @param {String} chargeVersionWorkflowId - The UUID of the workflow record being removed that needs flagging
+   * @param {Object} cookie - Existing cookie set by this app needed for pass-through authentication
+   *
+   * @returns {Promise} resolves with the licence being flagged for the supplementary bill run
+   */
+  supplementary (chargeVersionWorkflowId, cookie) {
+    const url = this.joinUrl('licences/supplementary')
+    const options = {
+      headers: {
+        cookie
+      },
+      body: {
+        chargeVersionWorkflowId
+      }
+    }
+    return this.serviceRequest.post(url, options)
+  }
+}
+
+module.exports = WorkflowApiClient

--- a/src/internal/lib/connectors/services/system/WorkflowApiClient.js
+++ b/src/internal/lib/connectors/services/system/WorkflowApiClient.js
@@ -6,19 +6,19 @@ class WorkflowApiClient extends ServiceClient {
   /**
    * Flags a licence for the supplementary bill run
    *
-   * @param {String} chargeVersionWorkflowId - The UUID of the workflow record being removed that needs flagging
+   * @param {String} workflowId - The UUID of the workflow record being removed that needs flagging
    * @param {Object} cookie - Existing cookie set by this app needed for pass-through authentication
    *
    * @returns {Promise} resolves with the licence being flagged for the supplementary bill run
    */
-  supplementary (chargeVersionWorkflowId, cookie) {
+  supplementary (workflowId, cookie) {
     const url = this.joinUrl('licences/supplementary')
     const options = {
       headers: {
         cookie
       },
       body: {
-        chargeVersionWorkflowId
+        workflowId
       }
     }
     return this.serviceRequest.post(url, options)

--- a/src/internal/lib/connectors/services/system/index.js
+++ b/src/internal/lib/connectors/services/system/index.js
@@ -4,11 +4,13 @@
 const BillingAccountsApiClient = require('./BillingAccountsApiClient.js')
 const BillRunsApiClient = require('./BillRunsApiClient.js')
 const LicencesApiClient = require('./LicencesApiClient.js')
+const WorkflowApiClient = require('./WorkflowApiClient.js')
 
 const { logger } = require('../../../../logger')
 
 module.exports = config => ({
   billingAccounts: new BillingAccountsApiClient(config.services.system, logger),
   billRuns: new BillRunsApiClient(config.services.system, logger),
-  licences: new LicencesApiClient(config.services.system, logger)
+  licences: new LicencesApiClient(config.services.system, logger),
+  workflow: new WorkflowApiClient(config.services.system, logger)
 })

--- a/src/internal/modules/charge-information/controllers/charge-information-workflow.js
+++ b/src/internal/modules/charge-information/controllers/charge-information-workflow.js
@@ -5,6 +5,7 @@ const { deleteChargeInfo } = require('../forms')
 const services = require('../../../lib/connectors/services')
 const { sortBy } = require('lodash')
 const { clearNoteSessionData } = require('internal/modules/charge-information/lib/helpers')
+const { logger } = require('./../../../logger.js')
 
 const getChargeInformationWorkflow = async (request, h) => {
   const toSetUp = request.pre.chargeInformationWorkflows
@@ -47,6 +48,14 @@ const getRemoveChargeInformationWorkflow = (request, h) => {
 
 const postRemoveChargeInformationWorkflow = async (request, h) => {
   const { chargeVersionWorkflowId } = request.params
+
+  try {
+    const cookie = request.headers.cookie
+    await services.system.workflow.supplementary(chargeVersionWorkflowId, cookie)
+  } catch (error) {
+    logger.error('Flag supplementary request to system failed', error.stack)
+  }
+
   await services.water.chargeVersionWorkflows.deleteChargeVersionWorkflow(chargeVersionWorkflowId)
   clearNoteSessionData(request)
   return h.redirect('/charge-information-workflow')

--- a/test/internal/lib/connectors/services/system/WorkflowApiClient.test.js
+++ b/test/internal/lib/connectors/services/system/WorkflowApiClient.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const Sinon = require('sinon')
+
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { expect } = Code
+const sandbox = Sinon.createSandbox()
+
+// Things we need to stub
+const { serviceRequest } = require('@envage/water-abstraction-helpers')
+
+// Thing under test
+const WorkflowApiClient = require('../../../../../../src/internal/lib/connectors/services/system/WorkflowApiClient.js')
+
+experiment('services/system/WorkflowApiClient', () => {
+  let service
+
+  beforeEach(async () => {
+    sandbox.stub(serviceRequest, 'post')
+    service = new WorkflowApiClient('http://127.0.0.1:8013')
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  experiment('.supplementary', () => {
+    beforeEach(async () => {
+      await service.supplementary('eac49574-f9cc-4619-8807-2a759018728b')
+    })
+
+    test('passes the expected URL to the service request', async () => {
+      const url = serviceRequest.post.lastCall.args[0]
+
+      expect(url).to.equal('http://127.0.0.1:8013/licences/supplementary')
+    })
+
+    test('passes the query in the request body', async () => {
+      const options = serviceRequest.post.lastCall.args[1]
+
+      expect(options.body).to.equal({ workflowId: 'eac49574-f9cc-4619-8807-2a759018728b' })
+    })
+  })
+})

--- a/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
+++ b/test/internal/modules/charge-information/controllers/charge-information-workflow.test.js
@@ -17,6 +17,9 @@ const services = require('../../../../../src/internal/lib/connectors/services')
 const controller = require('../../../../../src/internal/modules/charge-information/controllers/charge-information-workflow')
 
 const createRequest = () => ({
+  headers: {
+    cookie: 'taste=yummy'
+  },
   params: {
     licenceId: 'test-licence-id',
     chargeVersionWorkflowId: 'test-charge-version-workflow-id'
@@ -61,6 +64,7 @@ experiment('internal/modules/charge-information/controller', () => {
 
     sandbox.stub(services.water.chargeVersionWorkflows, 'postChargeVersionWorkflow').resolves()
     sandbox.stub(services.water.chargeVersionWorkflows, 'deleteChargeVersionWorkflow').resolves()
+    sandbox.stub(services.system.workflow, 'supplementary').resolves()
   })
 
   afterEach(async () => {
@@ -190,6 +194,11 @@ experiment('internal/modules/charge-information/controller', () => {
     beforeEach(async () => {
       request = createRequest()
       await controller.postRemoveChargeInformationWorkflow(request, h)
+    })
+
+    test('calls the system repo to flag for supplementary billing', async () => {
+      const [workflowId] = services.system.workflow.supplementary.lastCall.args
+      expect(workflowId).to.equal('test-charge-version-workflow-id')
     })
 
     test('deletes the charge version workflow', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4137

As part of the work to flag licences for the new two-part tariff supplementary billing, we need to be able to flag licences that are removed from the workflow. If a licence is in workflow it does not get picked up for annual billing. This means if the licence is removed without any new charge information added, then we risk the licence not being billed for the year. This change adds a call to our supplementary endpoint in the system repo, which will flag the licence for two-part tariff billing if it meets the criteria.