### PR TITLE
Update missed links to new view monitoring station

### DIFF
--- a/src/internal/modules/gauging-stations/controller.js
+++ b/src/internal/modules/gauging-stations/controller.js
@@ -403,7 +403,14 @@ const getRemoveTagComplete = async (request, h) => {
 
 const postRemoveTagComplete = async (request, h) => {
   await helpers.handleRemovePost(request)
-  return helpers.redirectTo(request, h, '/../')
+
+  let monitoringStationUrl = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    monitoringStationUrl = `/system${monitoringStationUrl}`
+  }
+
+  return h.redirect(monitoringStationUrl)
 }
 
 const getSendAlertSelectAlertType = async (request, h) => {

--- a/src/internal/modules/gauging-stations/controller.js
+++ b/src/internal/modules/gauging-stations/controller.js
@@ -250,11 +250,18 @@ const postNewTaggingCheckYourAnswers = async (request, h) => {
 const getNewTaggingFlowComplete = (request, h) => {
   const { licenceNumber } = session.get(request)
   session.clear(request)
+
+  let monitoringStationUrl = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    monitoringStationUrl = `/system${monitoringStationUrl}`
+  }
+
   return h.view('nunjucks/gauging-stations/new-tag-complete', {
     pageTitle: 'Licence added to monitoring station',
     back: null,
     licenceRef: licenceNumber.value,
-    gaugingStationId: request.params.gaugingStationId
+    monitoringStationUrl
   })
 }
 

--- a/src/internal/modules/gauging-stations/controller.js
+++ b/src/internal/modules/gauging-stations/controller.js
@@ -12,6 +12,8 @@ const { waterAbstractionAlerts: isWaterAbstractionAlertsEnabled } = require('../
 const { hasScope } = require('../../lib/permissions')
 const { manageGaugingStationLicenceLinks, hofNotifications } = require('../../lib/constants').scope
 
+const { featureToggles: featureFlags } = require('../../config.js')
+
 /**
  * Main Gauging station page
  * All data is loaded via shared pre-handlers
@@ -268,6 +270,14 @@ const getRemoveTags = async (request, h) => {
   const { licenceGaugingStations } = request.pre
   const { data } = licenceGaugingStations
 
+  // NOTE: We have updated this just for correctness! Back links are ignored in the legacy UI because of the back link
+  // high-jacking implemented in client-side JavaScript we send to the browser.
+  let back = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    back = `/system${back}`
+  }
+
   /* Used in second step for Multiple tags */
   session.merge(request, {
     selectedLicence: [],
@@ -281,7 +291,7 @@ const getRemoveTags = async (request, h) => {
     pageTitle,
     form: formHandler.handleFormRequest(request, linkageForms.removeTagsLicenceView), /* Generates deduplicated list */
     sessionData: session.get(request),
-    back: `/monitoring-stations/${request.params.gaugingStationId}/`
+    back
   })
 }
 
@@ -393,13 +403,21 @@ const getSendAlertSelectAlertType = async (request, h) => {
   const pageTitle = 'Select the type of alert you need to send'
   const caption = await helpers.getCaption(request)
 
+  // NOTE: We have updated this just for correctness! Back links are ignored in the legacy UI because of the back link
+  // high-jacking implemented in client-side JavaScript we send to the browser.
+  let back = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    back = `/system${back}`
+  }
+
   return h.view('nunjucks/form', {
     ...request.view,
     caption,
     pageTitle,
     sessionData: session.get(request),
     form: formHandler.handleFormRequest(request, linkageForms.sendingAlertType),
-    back: `/monitoring-stations/${request.params.gaugingStationId}`
+    back
   })
 }
 
@@ -617,9 +635,15 @@ const getSendAlertCheck = async (request, h) => {
   const pageTitle = 'Check the alert for each licence and send'
   const caption = await helpers.getCaption(request)
 
+  let monitoringStationUrl = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    monitoringStationUrl = `/system${monitoringStationUrl}`
+  }
+
   const { notificationEventId } = session.get(request)
   if (!notificationEventId) {
-    return h.redirect(`/monitoring-stations/${request.params.gaugingStationId}`)
+    return h.redirect(monitoringStationUrl)
   }
   const event = await services.water.events.findOne(notificationEventId)
   const { data: notifications } = await services.water.notifications.getNotificationMessages(notificationEventId)
@@ -669,9 +693,15 @@ const getSendAlertConfirm = async (request, h) => {
   const pageTitle = 'Check the alert for each licence and send'
   const caption = await helpers.getCaption(request)
 
+  let monitoringStationUrl = `/monitoring-stations/${request.params.gaugingStationId}/`
+
+  if (featureFlags.enableMonitoringStationsView) {
+    monitoringStationUrl = `/system${monitoringStationUrl}`
+  }
+
   const { notificationEventId } = await session.get(request)
   if (!notificationEventId) {
-    return h.redirect(`/monitoring-stations/${request.params.gaugingStationId}`)
+    return h.redirect(monitoringStationUrl)
   }
 
   const event = await services.water.events.findOne(notificationEventId)
@@ -683,13 +713,14 @@ const getSendAlertConfirm = async (request, h) => {
     logger.warn(e)
   }
   session.clear(request)
+
   return h.view('nunjucks/gauging-stations/confirm-sending-successful', {
     ...request.view,
     caption,
     pageTitle,
     recipientCount: event.data.metadata.recipients,
     notificationsReportUrl: '/notifications/report',
-    monitoringStationUrl: `/monitoring-stations/${request.params.gaugingStationId}`
+    monitoringStationUrl
   })
 }
 

--- a/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
+++ b/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
@@ -17,7 +17,7 @@
       }) }}
 
       <p class="govuk-body">
-        <a class="govuk-link" href="{{ monitoringStationUrl }}/">Return to monitoring station</a>
+        <a class="govuk-link" href="{{ monitoringStationUrl }}">Return to monitoring station</a>
       </p>
 
       <p class="govuk-body">or</p>

--- a/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
+++ b/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
@@ -17,13 +17,13 @@
       }) }}
 
       <p class="govuk-body">
-        <a class="govuk-link" href="/monitoring-stations/{{ gaugingStationId }}/">Return to monitoring station</a>
+        <a class="govuk-link" href="{{ monitoringStationUrl }}/">Return to monitoring station</a>
       </p>
 
       <p class="govuk-body">or</p>
 
       <p class="govuk-body">
-        <a class="govuk-link" href="/monitoring-stations/{{ gaugingStationId }}/tagging-licence">Create another tag</a>
+        <a class="govuk-link" href="{{ monitoringStationUrl }}/tagging-licence">Create another tag</a>
       </p>
 
     </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4736

In our last release, we shipped a new version of the view monitoring station page, replacing the legacy one. However, we quickly received feedback that the dates we display for tagged licences don't look right.

We've [fixed those issues](https://github.com/DEFRA/water-abstraction-system/pull/1470), but our QA team have spotted that several of the journeys started on that page still return you to the legacy page.

This change updates those links to the view monitoring station page we missed the first time to redirect to our new page based on the feature flag.