### PR TITLE
Fix invalid link on tagging licence complete page

### DIFF
--- a/src/internal/modules/gauging-stations/controller.js
+++ b/src/internal/modules/gauging-stations/controller.js
@@ -261,6 +261,7 @@ const getNewTaggingFlowComplete = (request, h) => {
     pageTitle: 'Licence added to monitoring station',
     back: null,
     licenceRef: licenceNumber.value,
+    gaugingStationId: request.params.gaugingStationId,
     monitoringStationUrl
   })
 }

--- a/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
+++ b/src/internal/views/nunjucks/gauging-stations/new-tag-complete.njk
@@ -23,7 +23,7 @@
       <p class="govuk-body">or</p>
 
       <p class="govuk-body">
-        <a class="govuk-link" href="{{ monitoringStationUrl }}/tagging-licence">Create another tag</a>
+        <a class="govuk-link" href="/monitoring-stations/{{ gaugingStationId }}/tagging-licence">Create another tag</a>
       </p>
 
     </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4736

In [Update missed links to new view monitoring station](https://github.com/DEFRA/water-abstraction-ui/pull/2638), we updated some links to point to our new view monitoring station page that had been missed when first doing this work.

However, we broke a link that must point to a legacy URL.

This change fixes the link we broke.