### PR TITLE
Refactor notifications setup redirect

### DIFF
--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -68,7 +68,7 @@ const getManageTabConfig = request => mapValues(
 
 const _returnNotificationsInvitations = () => {
   if (config.featureToggles.enableSystemNotifications) {
-    return '/system/notifications/setup/returns-period'
+    return '/system/notifications/setup'
   } else {
     return '/returns-notifications/invitations'
   }

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -235,7 +235,7 @@ experiment('getManageTabConfig', () => {
 
       expect(config.returnNotifications[0]).to.equal({
         name: 'Invitations',
-        path: '/system/notifications/setup/returns-period',
+        path: '/system/notifications/setup',
         scopes: 'bulk_return_notifications'
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4716

As part of the ongoing work to migrate the legacy UI we are replacing the notification journey from the UI and rebuilding in system.

This change changes the notification setup target route. This is done to allow the system to set up an initial session for the journey.

Work done here - https://github.com/DEFRA/water-abstraction-system/pull/1574