### PR TITLE
Add proxies for image asset requests to WRLS

### DIFF
--- a/src/shared/modules/system-proxy/routes.js
+++ b/src/shared/modules/system-proxy/routes.js
@@ -77,7 +77,7 @@ const routes = [
     },
     config: {
       auth: false,
-      description: 'Proxies CSS asset requests to the Water Abstraction System'
+      description: 'Proxies image asset requests to the Water Abstraction System'
     }
   },
   {

--- a/src/shared/modules/system-proxy/routes.js
+++ b/src/shared/modules/system-proxy/routes.js
@@ -67,6 +67,20 @@ const routes = [
     }
   },
   {
+    method: 'GET',
+    path: '/assets/images/{path*}',
+    handler: {
+      proxy: {
+        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/assets/{path*}`,
+        ...proxyDefaults
+      }
+    },
+    config: {
+      auth: false,
+      description: 'Proxies CSS asset requests to the Water Abstraction System'
+    }
+  },
+  {
     method: 'POST',
     // This will match all path segments after /system. Note in our proxy URI we refer to this only as {tail}. The path
     // param hapi provides will contain all the segments, for example, request.params.tail === '/test/supplementary'.

--- a/src/shared/modules/system-proxy/routes.js
+++ b/src/shared/modules/system-proxy/routes.js
@@ -68,16 +68,44 @@ const routes = [
   },
   {
     method: 'GET',
-    path: '/assets/images/{path*}',
+    path: '/assets/images/example-excel-01-min.png',
     handler: {
       proxy: {
-        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/assets/{path*}`,
+        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/assets/example-excel-01-min.png`,
         ...proxyDefaults
       }
     },
     config: {
       auth: false,
-      description: 'Proxies image asset requests to the Water Abstraction System'
+      description: 'Proxies image `example-excel-01-min.png` asset request to the Water Abstraction System'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/assets/images/example-excel-02-min.png',
+    handler: {
+      proxy: {
+        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/assets/example-excel-02-min.png`,
+        ...proxyDefaults
+      }
+    },
+    config: {
+      auth: false,
+      description: 'Proxies image `example-excel-02-min.png` asset request to the Water Abstraction System'
+    }
+  },
+  {
+    method: 'GET',
+    path: '/assets/images/example-input-01-min.png',
+    handler: {
+      proxy: {
+        uri: `${systemUrl.protocol}//${systemUrl.hostname}:${systemUrl.port}/assets/example-input-01-min.png`,
+        ...proxyDefaults
+      }
+    },
+    config: {
+      auth: false,
+      description: 'Proxies image `example-input-01-min.png` asset request to the Water Abstraction System'
     }
   },
   {


### PR DESCRIPTION
We use proxying to send requests from the legacy system to the `water abstraction system` for our new services. We need to also add the routes for proxying images, similar to the proxying of other assets like scss.

This PR adds proxying for images to the system proxy routes.