### PR TITLE
Add custom serializers to improve app logging

### DIFF
--- a/src/shared/lib/services/hapi-pino-serializers.service.js
+++ b/src/shared/lib/services/hapi-pino-serializers.service.js
@@ -1,0 +1,133 @@
+'use strict'
+
+/**
+ * Used by HapiPinoPlugin to customise the log output for the `req` and `res` objects returned by pino
+ * @module HapiPinoSerializersService
+ */
+
+/**
+ * Used by HapiPinoPlugin to customise the log output for the `req` and `res` objects returned by pino
+ *
+ * > We think this is how things work. Why are JavaScript loggers so complex!?
+ *
+ * [Hapi-pino](https://github.com/hapijs/hapi-pino) takes will pass the request (`req`) and response (`res`) objects to
+ * [Pino](https://github.com/pinojs/pino), which then uses
+ * [pino-std-serializers](https://github.com/pinojs/pino-std-serializers) to serialize them into what we see in the
+ * logs.
+ *
+ * These objects though are very verbose, for example.
+ *
+ * ```javascript
+ * {
+ *   req: {
+ *     "id": "1737736750350:9bc56d13c48b:618:m6azkwqb:10004",
+ *     "method": "get",
+ *     "url": "/bill-runs",
+ *     "query": {},
+ *     "headers": {
+ *       "connection": "keep-alive",
+ *       "cache-control": "max-age=0",
+ *       "sec-ch-ua": "\"Not A(Brand\";v=\"8\", \"Chromium\";v=\"132\", \"Google Chrome\";v=\"132\"",
+ *       "sec-ch-ua-mobile": "?0",
+ *       "sec-ch-ua-platform": "\"macOS\"",
+ *       "upgrade-insecure-requests": "1",
+ *       "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+ *       "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng;q=0.8,application/signed-exchange;v=b3;q=0.7",
+ *       "sec-fetch-site": "same-origin",
+ *       "sec-fetch-mode": "navigate",
+ *       "sec-fetch-user": "?1",
+ *       "sec-fetch-dest": "document",
+ *       "referer": "http://localhost:8008/system/bill-runs/a13ad1c9-331d-4ceb-9b61-cbd411a79e7b/cancel",
+ *       "accept-encoding": "gzip, deflate, br, zstd",
+ *       "accept-language": "en-GB,en;q=0.9,en-US;q=0.8",
+ *       "cookie": "imagine_a_long_string_made_up_of_a_mish_mash_of_letters_and_numbers_because_it_is_encrypted",
+ *       "x-forwarded-for": "172.18.0.1",
+ *       "x-forwarded-port": "60884",
+ *       "x-forwarded-proto": "http",
+ *       "x-forwarded-host": "localhost:8008",
+ *       "host": "localhost:8013"
+ *     },
+ *     "remoteAddress": "127.0.0.1",
+ *     "remotePort": 51170
+ *   },
+ *   res: {
+ *     "statusCode": 200,
+ *     "headers": {
+ *       "strict-transport-security": "max-age=15768000",
+ *       "x-frame-options": "DENY",
+ *       "x-xss-protection": "0",
+ *       "x-download-options": "noopen",
+ *       "x-content-type-options": "nosniff",
+ *       "cache-control": "no-cache",
+ *       "set-cookie": [
+ *         "wrlsCrumb=qLVnKWrMY3HUAgrqg5tDOM_QL12lmcft2e3Ytq0kp9y; Secure; HttpOnly; SameSite=Strict; Path=/"
+ *       ],
+ *       "content-type": "text/html; charset=utf-8",
+ *       "vary": "accept-encoding",
+ *       "content-encoding": "gzip"
+ *     }
+ *   },
+ *   responseTime: 47
+ * }
+ * ```
+ *
+ * We realised we were only using a tenth of what was output. The rest was just noise.
+ *
+ * Thankfully, **Hapi-pino** allows us to provide our own
+ * [serializers](https://github.com/hapijs/hapi-pino?tab=readme-ov-file#optionsserializers--key-string-pinoserializerfn-)
+ * that can take the serialized object **pino-std-serializers** returns and generate our own objects for logging.
+ *
+ * This service works alongside `app/plugins/hapi-pino.plugin.js` to remove the noise from our logs.
+ *
+ * @returns {object} an object containing functions to serialize the `req` and `res` objects returned by pino
+ */
+function go() {
+  return {
+    req: _req,
+    res: _res
+  }
+}
+
+/**
+ * Transforms the serialized `req` object [pino-std-serializers](https://github.com/pinojs/pino-std-serializers) returns
+ * so that we only output what we are care about, making our logs easier to work with.
+ *
+ * ```javascript
+ * req: {
+ *   "id": "1737742451819:9bc56d13c48b:1076:m6b2hu4a:10022",
+ *   "method": "get",
+ *   "url": "/return-versions/setup/4b385d95-3585-43ec-a4ec-039df63b288c/note",
+ *   "query": {}
+ * }
+ * ```
+ * @private
+ */
+function _req(req) {
+  return {
+    id: req.id,
+    method: 'get',
+    url: req.url,
+    query: req.query
+  }
+}
+
+/**
+ * Transforms the serialized `res` object [pino-std-serializers](https://github.com/pinojs/pino-std-serializers) returns
+ * so that we only output what we are care about, making our logs easier to work with.
+ *
+ * ```javascript
+ * res: {
+ *   "statusCode": 302
+ * }
+ * ```
+ * @private
+ */
+function _res(res) {
+  return {
+    statusCode: res.statusCode
+  }
+}
+
+module.exports = {
+  go
+}

--- a/src/shared/lib/services/hapi-pino-serializers.service.js
+++ b/src/shared/lib/services/hapi-pino-serializers.service.js
@@ -81,7 +81,7 @@
  *
  * @returns {object} an object containing functions to serialize the `req` and `res` objects returned by pino
  */
-function go() {
+function go () {
   return {
     req: _req,
     res: _res
@@ -102,7 +102,7 @@ function go() {
  * ```
  * @private
  */
-function _req(req) {
+function _req (req) {
   return {
     id: req.id,
     method: 'get',
@@ -122,7 +122,7 @@ function _req(req) {
  * ```
  * @private
  */
-function _res(res) {
+function _res (res) {
   return {
     statusCode: res.statusCode
   }

--- a/src/shared/plugins/hapi-pino.plugin.js
+++ b/src/shared/plugins/hapi-pino.plugin.js
@@ -13,6 +13,7 @@
 const HapiPino = require('hapi-pino')
 
 const HapiPinoIgnoreRequestService = require('../lib/services/hapi-pino-ignore-request.service.js')
+const HapiPinoSerializersService = require('../lib/services/hapi-pino-serializers.service.js')
 
 /**
  * Return test configuration options for the logger
@@ -59,7 +60,15 @@ const HapiPinoPlugin = (logInTest, logAssetRequests) => {
       // We want our logs to focus on the main requests and not become full of 'noise' from requests for /assets or
       // pings from the AWS load balancer to /status. We pass this function to hapi-pino to control what gets filtered
       // https://github.com/pinojs/hapi-pino#optionsignorefunc-options-request--boolean
-      ignoreFunc: HapiPinoIgnoreRequestService.go
+      ignoreFunc: HapiPinoIgnoreRequestService.go,
+      // Add the request params as pathParams to the response event log. This, along with `logPathParams` and
+      // `logQueryParams` helps us see what data was sent in the request to the app in the event of an error.
+      logPathParams: true,
+      // Add the request payload as `payload:` to the response event log
+      logPayload: true,
+      // Add the request query as `queryParams:` to the response event log
+      logQueryParams: true,
+      serializers: HapiPinoSerializersService.go()
     }
   }
 }

--- a/test/shared/lib/services/hapi-pino-serializers.service.test.js
+++ b/test/shared/lib/services/hapi-pino-serializers.service.test.js
@@ -1,0 +1,105 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Thing under test
+const HapiPinoSerializersService = require('../../../../src/shared/lib/services/hapi-pino-serializers.service.js')
+
+describe('Hapi Pino Serializers service', () => {
+  describe('when called', () => {
+    it('returns an object containing two functions called "req" and "res"', () => {
+      const result = HapiPinoSerializersService.go()
+
+      expect(result.req).to.exist()
+      expect(result.res).to.exist()
+    })
+
+    describe('and the function "res" when provided with a pino serialized request object', () => {
+      let requestObject
+
+      beforeEach(() => {
+        requestObject = {
+          id: '1737736750350:9bc56d13c48b:618:m6azkwqb:10004',
+          method: 'get',
+          url: '/bill-runs',
+          query: {},
+          headers: {
+            connection: 'keep-alive',
+            'cache-control': 'max-age=0',
+            'sec-ch-ua': '"Not A(Brand";v="8", "Chromium";v="132", "Google Chrome";v="132"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': 'macOS',
+            'upgrade-insecure-requests': '1',
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
+            accept:
+              'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'sec-fetch-site': 'same-origin',
+            'sec-fetch-mode': 'navigate',
+            'sec-fetch-user': '?1',
+            'sec-fetch-dest': 'document',
+            referer: 'http://localhost:8008/system/bill-runs/a13ad1c9-331d-4ceb-9b61-cbd411a79e7b/cancel',
+            'accept-encoding': 'gzip, deflate, br, zstd',
+            'accept-language': 'en-GB,en;q=0.9,en-US;q=0.8',
+            cookie: 'imagine_a_long_string_made_up_of_a_mish_mash_of_letters_and_numbers_because_it_is_encrypted',
+            'x-forwarded-for': '172.18.0.1',
+            'x-forwarded-port': '60884',
+            'x-forwarded-proto': 'http',
+            'x-forwarded-host': 'localhost:8008',
+            host: 'localhost:8013'
+          },
+          remoteAddress: '127.0.0.1',
+          remotePort: 51170
+        }
+      })
+
+      it('returns version containing only the key properties we care about', () => {
+        const { req } = HapiPinoSerializersService.go()
+
+        expect(req(requestObject)).to.equal({
+          id: '1737736750350:9bc56d13c48b:618:m6azkwqb:10004',
+          method: 'get',
+          url: '/bill-runs',
+          query: {}
+        })
+      })
+    })
+
+    describe('and the function "res" when provided with a pino serialized request object', () => {
+      let responseObject
+
+      beforeEach(() => {
+        responseObject = {
+          statusCode: 200,
+          headers: {
+            'strict-transport-security': 'max-age=15768000',
+            'x-frame-options': 'DENY',
+            'x-xss-protection': '0',
+            'x-download-options': 'noopen',
+            'x-content-type-options': 'nosniff',
+            'cache-control': 'no-cache',
+            'set-cookie': [
+              'wrlsCrumb=qLVnKWrMY3HUAgrqg5tDOM_QL12lmcft2e3Ytq0kp9y; Secure; HttpOnly; SameSite=Strict; Path=/'
+            ],
+            'content-type': 'text/html; charset=utf-8',
+            vary: 'accept-encoding',
+            'content-encoding': 'gzip'
+          }
+        }
+      })
+
+      it('returns version containing only the key properties we care about', () => {
+        const { res } = HapiPinoSerializersService.go()
+
+        expect(res(responseObject)).to.equal({
+          statusCode: 200
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
We've completed a [number of changes to our logging](https://github.com/DEFRA/water-abstraction-team/issues?q=is%3Aissue%20state%3Aclosed%20log) in the time we have been on the project.

Generally, we 'go to the logs' when an issue has been reported in `production`, and we need to figure out what has happened.

Therefore, we constantly balance, ensuring we have all the necessary information while excluding noise.

We recently [made a change to water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/1655) to reduce the noise in our logs via custom serializers (check it out for more details).

This change makes the same change to the logging in this app.