### PR TITLE
Update notifications setup redirect path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11649,10 +11649,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.83.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
-      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "version": "1.84.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.84.0.tgz",
+      "integrity": "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -22601,9 +22602,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.83.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
-      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "version": "1.84.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.84.0.tgz",
+      "integrity": "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==",
       "dev": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",

--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -32,7 +32,7 @@ const manageTabSkeleton = () => ({
     createLink('Invitations', _returnNotificationsInvitations(), scope.bulkReturnNotifications),
     createLink('Paper forms', '/returns-notifications/forms', scope.returns),
     createLink('Reminders', '/returns-notifications/reminders', scope.bulkReturnNotifications),
-    createLink('Ad-hoc returns', '/system/notifications/setup?notification=ad-hoc', config.featureToggles.enableSystemNotifications && scope.returns)
+    createLink('Ad-hoc returns', '/system/notifications/setup?journey=ad-hoc', config.featureToggles.enableSystemNotifications && scope.returns)
   ],
   licenceNotifications: [
     createLink('Renewal', 'notifications/2?start=1', scope.renewalNotifications)
@@ -69,7 +69,7 @@ const getManageTabConfig = request => mapValues(
 
 const _returnNotificationsInvitations = () => {
   if (config.featureToggles.enableSystemNotifications) {
-    return '/system/notifications/setup?notification=invitations'
+    return '/system/notifications/setup?journey=invitations'
   } else {
     return '/returns-notifications/invitations'
   }

--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -32,7 +32,7 @@ const manageTabSkeleton = () => ({
     createLink('Invitations', _returnNotificationsInvitations(), scope.bulkReturnNotifications),
     createLink('Paper forms', '/returns-notifications/forms', scope.returns),
     createLink('Reminders', '/returns-notifications/reminders', scope.bulkReturnNotifications),
-    createLink('Ad-hoc returns', '/system/notifications/ad-hoc-returns/setup', config.featureToggles.enableSystemNotifications && scope.returns)
+    createLink('Ad-hoc returns', '/system/notifications/setup?notification=ad-hoc', config.featureToggles.enableSystemNotifications && scope.returns)
   ],
   licenceNotifications: [
     createLink('Renewal', 'notifications/2?start=1', scope.renewalNotifications)
@@ -69,7 +69,7 @@ const getManageTabConfig = request => mapValues(
 
 const _returnNotificationsInvitations = () => {
   if (config.featureToggles.enableSystemNotifications) {
-    return '/system/notifications/setup'
+    return '/system/notifications/setup?notification=invitations'
   } else {
     return '/returns-notifications/invitations'
   }

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -229,13 +229,13 @@ experiment('getManageTabConfig', () => {
       config.featureToggles.enableSystemNotifications = true
     })
 
-    test('they click the link to "system"', async () => {
+    test.only('they click the link to "system"', async () => {
       const request = createRequest(scope.bulkReturnNotifications)
       const config = getManageTabConfig(request)
 
       expect(config.returnNotifications[0]).to.equal({
         name: 'Invitations',
-        path: '/system/notifications/setup',
+        path: '/system/notifications/setup?notification=invitations',
         scopes: 'bulk_return_notifications'
       })
     })

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -229,7 +229,7 @@ experiment('getManageTabConfig', () => {
       config.featureToggles.enableSystemNotifications = true
     })
 
-    test.only('they click the link to "system"', async () => {
+    test('they click the link to "system"', async () => {
       const request = createRequest(scope.bulkReturnNotifications)
       const config = getManageTabConfig(request)
 

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -235,7 +235,7 @@ experiment('getManageTabConfig', () => {
 
       expect(config.returnNotifications[0]).to.equal({
         name: 'Invitations',
-        path: '/system/notifications/setup?notification=invitations',
+        path: '/system/notifications/setup?journey=invitations',
         scopes: 'bulk_return_notifications'
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4899

As part of the work to implement notifications in the system repo we have multiple journeys for notifications.

This change updates the paths for invitations and ad-hoc returns.

The paths point to the same endpoint with a different query string highlighting which notification type has been chosen.