### PR TITLE
Always display bulk upload link on external site

### DIFF
--- a/src/external/modules/returns/lib/helpers.js
+++ b/src/external/modules/returns/lib/helpers.js
@@ -10,18 +10,8 @@ const services = require('../../../lib/connectors/services')
 const { getReturnPath } = require('external/lib/return-path')
 const { throwIfError } = require('@envage/hapi-pg-rest-api')
 const permissions = require('external/lib/permissions')
-const helpers = require('@envage/water-abstraction-helpers')
 const badge = require('shared/lib/returns/badge')
 const dates = require('shared/lib/returns/dates')
-
-/**
- * Gets the current return cycle object
- * @param  {String} [date] - reference date, for unit testing
- * @return {Object}      { startDate, endDate, isSummer }
- */
-const getCurrentCycle = (date) => {
-  return last(helpers.returns.date.createReturnCycles(undefined, date))
-}
 
 /**
  * Gets all licences from the CRM that can be viewed by the supplied entity ID
@@ -115,17 +105,13 @@ const getLicenceReturns = async (licenceNumbers, page = 1) => {
  * @return {Promise<boolean>} if user has bulk Upload functionality
  */
 const isBulkUpload = async (licenceNumbers, refDate) => {
-  const cycle = getCurrentCycle(refDate)
-
   const filter = {
     'metadata->>isUpload': 'true',
     'metadata->>isCurrent': 'true',
-    'metadata->>isSummer': cycle.isSummer ? 'true' : 'false',
     status: 'due',
-    start_date: { $gte: cycle.startDate },
     end_date: {
       $gte: '2018-10-31',
-      $lte: cycle.endDate
+      $lte: moment().format('YYYY-MM-DD')
     },
     licence_ref: { $in: licenceNumbers }
   }

--- a/src/external/modules/returns/lib/helpers.js
+++ b/src/external/modules/returns/lib/helpers.js
@@ -2,7 +2,7 @@
 
 const Boom = require('@hapi/boom')
 const moment = require('moment')
-const { get, isObject, last } = require('lodash')
+const { get, isObject } = require('lodash')
 
 const config = require('../../../config')
 const services = require('../../../lib/connectors/services')

--- a/test/external/modules/returns/lib/helpers.test.js
+++ b/test/external/modules/returns/lib/helpers.test.js
@@ -31,7 +31,18 @@ experiment('getLicenceReturns', () => {
 })
 
 experiment('isBulkUpload', () => {
+  let clock
+  let testDate
+
+  // Control what the current date is when the test is run
+  beforeEach(() => {
+    testDate = new Date(2025, 2, 29, 20, 31, 57)
+
+    clock = sandbox.useFakeTimers(testDate)
+  })
+
   afterEach(async () => {
+    clock.restore()
     sandbox.restore()
   })
 
@@ -79,38 +90,23 @@ experiment('isBulkUpload', () => {
       expect(filter.status).to.equal('due')
     })
 
-    test('are in the current return cycle', async () => {
-      expect(filter['metadata->>isSummer']).to.equal('false')
-      expect(filter.start_date).to.equal({
-        $gte: '2018-04-01'
-      })
+    test('have an end date after or on the 2018-10-31', async () => {
       expect(filter.end_date).to.equal({
         $gte: '2018-10-31',
-        $lte: '2019-03-31'
+        $lte: testDate
+      })
+    })
+
+    test('have an end date before or on the current date', async () => {
+      expect(filter.end_date).to.equal({
+        $gte: '2018-10-31',
+        $lte: testDate
       })
     })
 
     test('are for the users\' licence numbers', async () => {
       expect(filter.licence_ref).to.equal({
         $in: ['01/123', '04/567']
-      })
-    })
-
-    experiment('for a summer return cycle', () => {
-      beforeEach(async () => {
-        await helpers.isBulkUpload(['01/123', '04/567'], '2019-11-01')
-        filter = services.returns.returns.findMany.lastCall.args[0]
-      })
-
-      test('are in the current return cycle', async () => {
-        expect(filter['metadata->>isSummer']).to.equal('true')
-        expect(filter.start_date).to.equal({
-          $gte: '2018-11-01'
-        })
-        expect(filter.end_date).to.equal({
-          $gte: '2018-10-31',
-          $lte: '2019-10-31'
-        })
       })
     })
   })

--- a/test/external/modules/returns/lib/helpers.test.js
+++ b/test/external/modules/returns/lib/helpers.test.js
@@ -93,14 +93,14 @@ experiment('isBulkUpload', () => {
     test('have an end date after or on the 2018-10-31', async () => {
       expect(filter.end_date).to.equal({
         $gte: '2018-10-31',
-        $lte: testDate
+        $lte: '2025-03-29'
       })
     })
 
     test('have an end date before or on the current date', async () => {
       expect(filter.end_date).to.equal({
         $gte: '2018-10-31',
-        $lte: testDate
+        $lte: '2025-03-29'
       })
     })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4953

Before this change, the bulk upload link in the external UI would only display if there were due returns, flagged for bulk upload, that matched the current return cycle.

Quarterly has changed the submission model from once to four times a year. Therefore, the existing functionality that switched between the summer and winter cycles based on the time of year will no longer work because the submission cycles now overlap.

We must update the logic to determine whether to display the link or ignore the current cycle. In short

- Are there any due returns?
- Do they have an end date less than or equal to the current date? (You can't submit a return that hasn't ended.)
- Do any of them have the `isUpload` flag set to true?

We must display the link if we get a 'yes' to all three.