### PR TITLE
Update upload CSV generation to support quarterly

### DIFF
--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -234,8 +234,8 @@ const getCSVTemplates = async (request, h) => {
   }
 
   // Generate CSV data and build zip
-  const data = csvTemplates.createCSVData(returns)
-  const zip = await csvTemplates.buildZip(data, companyName)
+  const csvDataSets = csvTemplates.createCSVData(returns)
+  const zip = await csvTemplates.buildZip(csvDataSets, companyName)
   const fileName = getZipFilename(companyName)
 
   return h.response(zip)

--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -218,7 +218,7 @@ const getSubmitted = async (request, h) => {
   return h.view('nunjucks/returns/upload-submitted', view)
 }
 
-const getZipFilename = (companyName, year) => `${lowerCase(companyName)} return templates ${year}.zip`
+const getZipFilename = (companyName) => `${lowerCase(companyName)} return templates.zip`
 
 /**
  * Downloads a ZIP of CSV templates
@@ -238,7 +238,7 @@ const getCSVTemplates = async (request, h) => {
   // Generate CSV data and build zip
   const data = csvTemplates.createCSVData(returns)
   const zip = await csvTemplates.buildZip(data, companyName)
-  const fileName = getZipFilename(companyName, endDate.substring(0, 4))
+  const fileName = getZipFilename(companyName)
 
   return h.response(zip)
     .header('Content-type', 'application/zip')

--- a/src/external/modules/returns/controllers/upload.js
+++ b/src/external/modules/returns/controllers/upload.js
@@ -233,8 +233,6 @@ const getCSVTemplates = async (request, h) => {
     throw Boom.notFound('CSV templates error - no current due returns', { companyId })
   }
 
-  const endDate = returns[0].endDate
-
   // Generate CSV data and build zip
   const data = csvTemplates.createCSVData(returns)
   const zip = await csvTemplates.buildZip(data, companyName)

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { last, find, groupBy, lowerCase, get } = require('lodash')
+const { find, groupBy, lowerCase, get } = require('lodash')
 const helpers = require('@envage/water-abstraction-helpers')
 const { getLineLabel } = require('shared/modules/returns/forms/common')
 const moment = require('moment')
@@ -113,8 +113,8 @@ const createCSVData = (returns) => {
 
       // sort by return ID
       frequencyGroup.sort((a, b) => {
-        return a.returnId.localeCompare(b.returnId);
-      });
+        return a.returnId.localeCompare(b.returnId)
+      })
 
       const { earliestStartDate, latestEndDate } = _earliestAndLatestDates(frequencyGroup)
 

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -168,9 +168,9 @@ const isMultipleReturns = (data, key) => data[key][0].length > 2
  * @param  {String}  key     - the return frequency
  * @return {Promise}         resolves when added
  */
-const addCSVToArchive = async (archive, companyName, data, key, dueDateDataSetKey) => {
+const addCSVToArchive = async (archive, companyName, data, key, dueDateAsString) => {
   const str = await csvStringify(data[key])
-  const name = getCSVFilename(companyName, key, dueDateDataSetKey, isMultipleReturns(data, key))
+  const name = getCSVFilename(companyName, key, dueDateAsString, isMultipleReturns(data, key))
   return archive.append(str, { name })
 }
 

--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -24,33 +24,10 @@ const getCSVLineLabel = line => {
   return getLineLabel(line) + ' ' + moment(line.endDate).format('YYYY')
 }
 
-/**
- * Gets the current active return cycle
- * @param {String} [refDate] - for unit testing, controls the date for
- *                             the current cycle calculation
- * @return {Object} - cycle description with { startDate, endDate, isSummer }
- */
-const getCurrentCycle = (refDate) => {
-  const cycles = helpers.returns.date.createReturnCycles(undefined, refDate)
-  return last(cycles)
-}
-
-/**
- * Initialises a 2D array structure to hold on of the CSVs
- * @param  {String} frequency - day|week|month
- * @param {String} [refDate] - for unit testing, controls the date for
- *                             the current cycle calculation
- * @return {[type]}           [description]
- */
-const initialiseCSV = (frequency, refDate) => {
-  // Get date range of current active return cycle
-  const { startDate, endDate } = getCurrentCycle(refDate)
-
-  // Get date lines for the cycle dates and frequency
-  const dateLines = helpers.returns.lines.getRequiredLines(startDate, endDate, frequency)
-
+const initialiseCSV = (dateLines) => {
   // Map to the first column of data in the CSV
   const lineLabels = dateLines.map(line => [getCSVLineLabel(line)])
+
   return [
     ['Licence number'],
     ['Return reference'],
@@ -116,30 +93,48 @@ const pushColumn = (data, column) => {
  * @param  {Array} returns - loaded from water service
  * @return {Object}
  */
-const createCSVData = (returns, refDate) => {
-  const data = {}
+const createCSVData = (returns) => {
+  const csvDataSets = []
 
-  // Get current return cycle dates
-  const { startDate, endDate } = getCurrentCycle(refDate)
+  // Group returns by return end date and then sub group by frequency
+  const nestedGroups = groupBy(returns, ret => ret.dueDate)
 
-  // Group returns by frequency
-  const grouped = groupBy(returns, ret => ret.frequency)
-
-  for (const frequency in grouped) {
-    // Initialise the 2D array
-    data[frequency] = initialiseCSV(frequency)
-
-    // Get all CSV lines for current cycle/frequency
-    const csvLines = helpers.returns.lines.getRequiredLines(startDate, endDate, frequency)
-
-    // For each return of this frequency, generate a column and add to the CSV data
-    grouped[frequency].forEach(ret => {
-      const column = createReturnColumn(ret, csvLines)
-      pushColumn(data[frequency], column)
-    })
+  for (const [key, group] of Object.entries(nestedGroups)) {
+    nestedGroups[key] = groupBy(group, ret => ret.frequency)
   }
 
-  return data
+  const data = {}
+
+  for (const dueDateKey in nestedGroups) {
+    const dueDateGroup = nestedGroups[dueDateKey]
+
+    for (const frequencyKey in dueDateGroup) {
+      const frequencyGroup = dueDateGroup[frequencyKey]
+
+      // sort by return ID
+      frequencyGroup.sort((a, b) => {
+        return a.returnId.localeCompare(b.returnId);
+      });
+
+      const { earliestStartDate, latestEndDate } = _earliestAndLatestDates(frequencyGroup)
+
+      // Get date lines between the two dates based on the specified frequency
+      const dateLines = helpers.returns.lines.getRequiredLines(earliestStartDate, latestEndDate, frequencyKey)
+
+      // Setup the 2D array
+      data[frequencyKey] = initialiseCSV(dateLines)
+
+      for (const returnLog of frequencyGroup) {
+        const column = createReturnColumn(returnLog, dateLines)
+
+        pushColumn(data[frequencyKey], column)
+      }
+
+      csvDataSets.push({ [dueDateKey]: data })
+    }
+  }
+
+  return csvDataSets
 }
 
 /**
@@ -149,13 +144,19 @@ const createCSVData = (returns, refDate) => {
  * @param  {String} frequency   - the return frequency
  * @return {String}             filename, e.g. my-company-daily.csv
  */
-const getCSVFilename = (companyName, frequency, isMultipleReturns) => {
+const getCSVFilename = (companyName, frequency, dueDateAsString, isMultipleReturns) => {
   const map = {
     day: 'daily',
     week: 'weekly',
     month: 'monthly'
   }
-  return lowerCase(`${companyName} ${map[frequency]}`) + ` ${isMultipleReturns ? 'returns' : 'return'}.csv`
+
+  const lowerCaseName = lowerCase(companyName)
+  const frequencyText = map[frequency]
+  const returnsText = isMultipleReturns ? 'returns' : 'return'
+  const dueDateSeparatedWithSpaces = lowerCase(dueDateAsString)
+
+  return `${lowerCaseName} ${frequencyText} ${returnsText} due ${dueDateSeparatedWithSpaces}.csv`
 }
 
 const isMultipleReturns = (data, key) => data[key][0].length > 2
@@ -167,9 +168,9 @@ const isMultipleReturns = (data, key) => data[key][0].length > 2
  * @param  {String}  key     - the return frequency
  * @return {Promise}         resolves when added
  */
-const addCSVToArchive = async (archive, companyName, data, key) => {
+const addCSVToArchive = async (archive, companyName, data, key, dueDateDataSetKey) => {
   const str = await csvStringify(data[key])
-  const name = getCSVFilename(companyName, key, isMultipleReturns(data, key))
+  const name = getCSVFilename(companyName, key, dueDateDataSetKey, isMultipleReturns(data, key))
   return archive.append(str, { name })
 }
 
@@ -213,20 +214,28 @@ const createArchive = () => {
 /**
  * Builds the ZIP archive containing several CSV templates for users
  * to complete their return data
- * @param  {Object}  data        - CSV data object, keys are return frequency
+ * @param  {Object}  csvDataSets - Array of CSV data objects, keys are return frequency
  * @param  {String}  companyName - the current company
  * @param {Object} [archive] - an archiver instance can be passed in for test
  * @return {Promise<Object>} resolves with archive object when finalised
  */
-const buildZip = async (data, companyName, archive) => {
+const buildZip = async (csvDataSets, companyName, archive) => {
   archive = archive || createArchive()
 
-  // Add a CSV to the archive for each frequency
-  const tasks = Object.keys(data).map(key => {
-    return addCSVToArchive(archive, companyName, data, key)
-  })
-  tasks.push(addReadmeToArchive(archive))
-  await Promise.all(tasks)
+  // Add a CSV to the archive for each due date and frequency
+  for (const csvDataSet of csvDataSets) {
+    for (const dueDateDataSetKey in csvDataSet) {
+      const dueDateDataSet = csvDataSet[dueDateDataSetKey]
+
+      const tasks = Object.keys(dueDateDataSet).map(key => {
+        return addCSVToArchive(archive, companyName, dueDateDataSet, key, dueDateDataSetKey)
+      })
+
+      tasks.push(addReadmeToArchive(archive))
+
+      await Promise.all(tasks)
+    }
+  }
 
   archive.finalize()
 
@@ -237,8 +246,30 @@ const buildZip = async (data, companyName, archive) => {
   return archive.pipe(new PassThrough())
 }
 
+function _earliestAndLatestDates (returnLogs) {
+  let earliestStartDate = new Date(returnLogs[0].startDate)
+  let latestEndDate = new Date(returnLogs[0].endDate)
+
+  for (const returnLog of returnLogs) {
+    const startDate = new Date(returnLog.startDate)
+    const endDate = new Date(returnLog.endDate)
+
+    if (startDate < earliestStartDate) {
+      earliestStartDate = startDate
+    }
+
+    if (endDate > latestEndDate) {
+      latestEndDate = endDate
+    }
+  }
+
+  return {
+    earliestStartDate: earliestStartDate.toISOString().split('T')[0],
+    latestEndDate: latestEndDate.toISOString().split('T')[0]
+  }
+}
+
 exports._getCSVLineLabel = getCSVLineLabel
-exports._getCurrentCycle = getCurrentCycle
 exports._initialiseCSV = initialiseCSV
 exports._createReturnColumn = createReturnColumn
 exports._pushColumn = pushColumn

--- a/src/shared/lib/connectors/services/water/CompaniesService.js
+++ b/src/shared/lib/connectors/services/water/CompaniesService.js
@@ -1,21 +1,15 @@
 const ServiceClient = require('../ServiceClient')
-const { last } = require('lodash')
-const { returns: { date: { createReturnCycles } } } = require('@envage/water-abstraction-helpers')
 
 class CompaniesService extends ServiceClient {
   /**
-   * Gets due returns in the current returns cycle for the specified company
+   * Gets due returns for the specified company
    * @param  {String} entityId - company entity ID GUID
    * @return {Promise<Array>} resolves with an array of returns
    */
   getCurrentDueReturns (entityId) {
-    const currentCycle = last(createReturnCycles())
     const url = this.joinUrl('company', entityId, 'returns')
     const options = {
       qs: {
-        startDate: currentCycle.startDate,
-        endDate: currentCycle.endDate,
-        isSummer: currentCycle.isSummer,
         status: 'due'
       }
     }

--- a/test/external/modules/returns/controllers/upload.test.js
+++ b/test/external/modules/returns/controllers/upload.test.js
@@ -351,12 +351,6 @@ experiment('external/modules/returns/controllers/upload', () => {
         }
       })
     })
-
-    // test('redirects to upload form if upload contains no data', async () => {
-    //   services.water.returns.getUploadPreview.resolves([]);
-    //   await controller.getSummary(request, h);
-    //   expect(h.redirect.calledWith(`/returns/upload?error=empty`)).to.equal(true);
-    // });
   })
 
   experiment('.getSummaryReturn', () => {
@@ -488,7 +482,7 @@ experiment('external/modules/returns/controllers/upload', () => {
       test('sets the correct content disposition in the response', async () => {
         const [key, value] = header.secondCall.args
         expect(key).to.equal('Content-disposition')
-        expect(value).to.equal('attachment; filename="test co ltd return templates 2019.zip"')
+        expect(value).to.equal('attachment; filename="test co ltd return templates.zip"')
       })
     })
 

--- a/test/external/modules/returns/lib/csv-template.test.js
+++ b/test/external/modules/returns/lib/csv-template.test.js
@@ -45,62 +45,73 @@ experiment('csv templates', () => {
     })
   })
 
-  experiment('getCurrentCycle', () => {
-    test('should return the current return cycle', async () => {
-      const cycle = csvTemplates._getCurrentCycle('2019-04-01')
-      expect(cycle).to.equal({
-        dueDate: '2019-04-28',
-        startDate: '2018-04-01',
-        endDate: '2019-03-31',
-        isSummer: false
+  experiment('initialiseCSV', () => {
+    let dateLines
+
+    experiment('when the period is daily', () => {
+      beforeEach(() => {
+        dateLines = helpers.returns.lines.getRequiredLines('2018-04-01', '2019-03-31', 'day')
+      })
+
+      test('should initialise a daily CSV 2D array', async () => {
+        const daily = csvTemplates._initialiseCSV(dateLines)
+
+        expect(daily[0][0]).to.equal('Licence number')
+        expect(daily[1][0]).to.equal('Return reference')
+        expect(daily[2][0]).to.equal('Site description')
+        expect(daily[3][0]).to.equal('Purpose')
+        expect(daily[4][0]).to.equal('Nil return Y/N')
+        expect(daily[5][0]).to.equal('Did you use a meter Y/N')
+        expect(daily[6][0]).to.equal('Meter make')
+        expect(daily[7][0]).to.equal('Meter serial number')
+        expect(daily[8][0]).to.equal('1 April 2018')
+        expect(daily[372][0]).to.equal('31 March 2019')
+        expect(daily[373][0]).to.equal('Unique return reference')
       })
     })
-  })
 
-  experiment('initialiseCSV', () => {
-    test('should initialise a daily CSV 2D array', async () => {
-      const daily = csvTemplates._initialiseCSV('day', '2019-04-01')
-      expect(daily[0][0]).to.equal('Licence number')
-      expect(daily[1][0]).to.equal('Return reference')
-      expect(daily[2][0]).to.equal('Site description')
-      expect(daily[3][0]).to.equal('Purpose')
-      expect(daily[4][0]).to.equal('Nil return Y/N')
-      expect(daily[5][0]).to.equal('Did you use a meter Y/N')
-      expect(daily[6][0]).to.equal('Meter make')
-      expect(daily[7][0]).to.equal('Meter serial number')
-      expect(daily[8][0]).to.equal('1 April 2018')
-      expect(daily[372][0]).to.equal('31 March 2019')
-      expect(daily[373][0]).to.equal('Unique return reference')
+    experiment('when the period is weekly', () => {
+      beforeEach(() => {
+        dateLines = helpers.returns.lines.getRequiredLines('2018-04-01', '2019-03-31', 'week')
+      })
+
+      test('should initialise a weekly 2D array', async () => {
+        const weekly = csvTemplates._initialiseCSV(dateLines)
+
+        expect(weekly[0][0]).to.equal('Licence number')
+        expect(weekly[1][0]).to.equal('Return reference')
+        expect(weekly[2][0]).to.equal('Site description')
+        expect(weekly[3][0]).to.equal('Purpose')
+        expect(weekly[4][0]).to.equal('Nil return Y/N')
+        expect(weekly[5][0]).to.equal('Did you use a meter Y/N')
+        expect(weekly[6][0]).to.equal('Meter make')
+        expect(weekly[7][0]).to.equal('Meter serial number')
+        expect(weekly[8][0]).to.equal('Week ending 7 April 2018')
+        expect(weekly[59][0]).to.equal('Week ending 30 March 2019')
+        expect(weekly[60][0]).to.equal('Unique return reference')
+      })
     })
 
-    test('should initialise a weekly CSV 2D array', async () => {
-      const weekly = csvTemplates._initialiseCSV('week', '2019-04-01')
-      expect(weekly[0][0]).to.equal('Licence number')
-      expect(weekly[1][0]).to.equal('Return reference')
-      expect(weekly[2][0]).to.equal('Site description')
-      expect(weekly[3][0]).to.equal('Purpose')
-      expect(weekly[4][0]).to.equal('Nil return Y/N')
-      expect(weekly[5][0]).to.equal('Did you use a meter Y/N')
-      expect(weekly[6][0]).to.equal('Meter make')
-      expect(weekly[7][0]).to.equal('Meter serial number')
-      expect(weekly[8][0]).to.equal('Week ending 7 April 2018')
-      expect(weekly[59][0]).to.equal('Week ending 30 March 2019')
-      expect(weekly[60][0]).to.equal('Unique return reference')
-    })
+    experiment('when the period is monthly', () => {
+      beforeEach(() => {
+        dateLines = helpers.returns.lines.getRequiredLines('2018-04-01', '2019-03-31', 'month')
+      })
 
-    test('should initialise a monthly CSV 2D array', async () => {
-      const monthly = csvTemplates._initialiseCSV('month', '2019-04-01')
-      expect(monthly[0][0]).to.equal('Licence number')
-      expect(monthly[1][0]).to.equal('Return reference')
-      expect(monthly[2][0]).to.equal('Site description')
-      expect(monthly[3][0]).to.equal('Purpose')
-      expect(monthly[4][0]).to.equal('Nil return Y/N')
-      expect(monthly[5][0]).to.equal('Did you use a meter Y/N')
-      expect(monthly[6][0]).to.equal('Meter make')
-      expect(monthly[7][0]).to.equal('Meter serial number')
-      expect(monthly[8][0]).to.equal('April 2018')
-      expect(monthly[19][0]).to.equal('March 2019')
-      expect(monthly[20][0]).to.equal('Unique return reference')
+      test('should initialise a monthly 2D array', async () => {
+        const monthly = csvTemplates._initialiseCSV(dateLines)
+
+        expect(monthly[0][0]).to.equal('Licence number')
+        expect(monthly[1][0]).to.equal('Return reference')
+        expect(monthly[2][0]).to.equal('Site description')
+        expect(monthly[3][0]).to.equal('Purpose')
+        expect(monthly[4][0]).to.equal('Nil return Y/N')
+        expect(monthly[5][0]).to.equal('Did you use a meter Y/N')
+        expect(monthly[6][0]).to.equal('Meter make')
+        expect(monthly[7][0]).to.equal('Meter serial number')
+        expect(monthly[8][0]).to.equal('April 2018')
+        expect(monthly[19][0]).to.equal('March 2019')
+        expect(monthly[20][0]).to.equal('Unique return reference')
+      })
     })
   })
 
@@ -244,13 +255,14 @@ experiment('csv templates', () => {
   })
 
   experiment('createCSVData', () => {
-    test('should create CSV arrays grouped by return frequency', async () => {
+    test('should create CSV arrays grouped by due date and return frequency', async () => {
       const returns = [{
         returnId: 'return_1',
         licenceNumber: 'licence_1',
         returnRequirement: 'requirement_1',
         startDate: '2018-04-01',
         endDate: '2019-03-31',
+        dueDate: '2019-04-28',
         frequency: 'day',
         siteDescription: 'test',
         purposes: []
@@ -260,6 +272,7 @@ experiment('csv templates', () => {
         returnRequirement: 'requirement_2',
         startDate: '2018-04-01',
         endDate: '2019-03-31',
+        dueDate: '2019-04-28',
         frequency: 'month',
         siteDescription: 'test',
         purposes: []
@@ -269,46 +282,54 @@ experiment('csv templates', () => {
         returnRequirement: 'requirement_3',
         startDate: '2018-04-01',
         endDate: '2019-03-31',
+        dueDate: '2019-04-28',
         frequency: 'week',
         siteDescription: 'test',
         purposes: []
       }]
 
-      const csvData = csvTemplates.createCSVData(returns, '2019-03-31')
+      const csvDataSets = csvTemplates.createCSVData(returns)
+      const csvDueDateData = csvDataSets[0]
 
       // Daily
-      expect(csvData.day[0][1]).to.equal('licence_1')
-      expect(csvData.day[1][1]).to.equal('requirement_1')
-      expect(csvData.day[373][1]).to.equal('return_1')
+      const csvDailyData = csvDueDateData['2019-04-28'].day
+
+      expect(csvDailyData[0][1]).to.equal('licence_1')
+      expect(csvDailyData[1][1]).to.equal('requirement_1')
+      expect(csvDailyData[373][1]).to.equal('return_1')
 
       // Monthly
-      expect(csvData.month[0][1]).to.equal('licence_2')
-      expect(csvData.month[1][1]).to.equal('requirement_2')
-      expect(csvData.month[20][1]).to.equal('return_2')
+      const csvMonthlyData = csvDueDateData['2019-04-28'].month
+
+      expect(csvMonthlyData[0][1]).to.equal('licence_2')
+      expect(csvMonthlyData[1][1]).to.equal('requirement_2')
+      expect(csvMonthlyData[20][1]).to.equal('return_2')
 
       // Weekly
-      expect(csvData.week[0][1]).to.equal('licence_3')
-      expect(csvData.week[1][1]).to.equal('requirement_3')
-      expect(csvData.week[60][1]).to.equal('return_3')
+      const csvWeeklyData = csvDueDateData['2019-04-28'].week
+
+      expect(csvWeeklyData[0][1]).to.equal('licence_3')
+      expect(csvWeeklyData[1][1]).to.equal('requirement_3')
+      expect(csvWeeklyData[60][1]).to.equal('return_3')
     })
   })
 
   experiment('getCSVFilename', () => {
     test('creates a filename based on the company name and daily return frequency', async () => {
-      const result = csvTemplates._getCSVFilename('TEST CO', 'day', false)
-      expect(result).to.equal('test co daily return.csv')
+      const result = csvTemplates._getCSVFilename('TEST CO', 'day', '2019-04-28', false)
+      expect(result).to.equal('test co daily return due 2019 04 28.csv')
     })
     test('creates a filename based on the company name and weekly return frequency', async () => {
-      const result = csvTemplates._getCSVFilename('TEST CO', 'week', false)
-      expect(result).to.equal('test co weekly return.csv')
+      const result = csvTemplates._getCSVFilename('TEST CO', 'week', '2019-04-28', false)
+      expect(result).to.equal('test co weekly return due 2019 04 28.csv')
     })
     test('creates a filename based on the company name and monthly return frequency', async () => {
-      const result = csvTemplates._getCSVFilename('TEST CO', 'month', false)
-      expect(result).to.equal('test co monthly return.csv')
+      const result = csvTemplates._getCSVFilename('TEST CO', 'month', '2019-04-28', false)
+      expect(result).to.equal('test co monthly return due 2019 04 28.csv')
     })
     test('pluralises "return" to "returns" when isMultipleReturns is true', async () => {
-      const result = csvTemplates._getCSVFilename('TEST CO', 'day', true)
-      expect(result).to.equal('test co daily returns.csv')
+      const result = csvTemplates._getCSVFilename('TEST CO', 'day', '2019-04-28', true)
+      expect(result).to.equal('test co daily returns due 2019 04 28.csv')
     })
   })
 
@@ -317,12 +338,12 @@ experiment('csv templates', () => {
       const data = {
         day: [['foo', 'bar']]
       }
-      await csvTemplates._addCSVToArchive(archive, 'TEST CO', data, 'day')
+      await csvTemplates._addCSVToArchive(archive, 'TEST CO', data, 'day', '2024-04-01')
 
       const [csvStr, options] = archive.append.lastCall.args
 
       expect(csvStr).to.equal('foo,bar\n')
-      expect(options.name).to.equal('test co daily return.csv')
+      expect(options.name).to.equal('test co daily return due 2024 04 01.csv')
     })
   })
 
@@ -376,10 +397,14 @@ experiment('csv templates', () => {
 
   experiment('buildZip', () => {
     test('should build a zip file', async () => {
-      const data = {
-        day: [['foo', 'bar']]
-      }
-      const result = await csvTemplates.buildZip(data, 'TEST CO', archive)
+      const csvDataSets = [
+        {
+          '2024-04-28': {
+            day: [['foo', 'bar']]
+          }
+        }
+      ]
+      const result = await csvTemplates.buildZip(csvDataSets, 'TEST CO', archive)
 
       expect(result).to.be.an.object()
 

--- a/test/internal/modules/returns/controllers/edit.test.js
+++ b/test/internal/modules/returns/controllers/edit.test.js
@@ -7,6 +7,8 @@ const forms = require('shared/lib/forms')
 const services = require('internal/lib/connectors/services')
 const { URL } = require('url')
 
+const InternalConfig = require('../../../../../src/internal/config.js')
+
 const {
   STEP_START, STEP_METHOD, STEP_UNITS,
   STEP_QUANTITIES, STEP_METER_READINGS, STEP_METER_DETAILS, STEP_CONFIRM,
@@ -104,6 +106,8 @@ experiment('returns edit controller: ', () => {
   let h
 
   beforeEach(async () => {
+    sandbox.stub(InternalConfig, 'featureToggles').value({ enableSystemReturnsView: false })
+
     h = {
       redirect: sandbox.stub(),
       view: sandbox.stub()

--- a/test/shared/lib/connectors/services/water/CompaniesService.test.js
+++ b/test/shared/lib/connectors/services/water/CompaniesService.test.js
@@ -9,9 +9,6 @@ const {
 } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 
-const { returns: { date: { createReturnCycles } } } = require('@envage/water-abstraction-helpers')
-const { last } = require('lodash')
-
 const CompaniesService = require('shared/lib/connectors/services/water/CompaniesService')
 const { serviceRequest } = require('@envage/water-abstraction-helpers')
 
@@ -43,13 +40,9 @@ experiment('services/water/CompaniesService', () => {
     test('passes the expected options to the service request', async () => {
       await service.getCurrentDueReturns('entity_1')
 
-      const cycle = last(createReturnCycles())
       const [, { qs }] = serviceRequest.get.lastCall.args
 
       expect(qs.status).to.equal('due')
-      expect(qs.startDate).to.equal(cycle.startDate)
-      expect(qs.endDate).to.equal(cycle.endDate)
-      expect(qs.isSummer).to.equal(cycle.isSummer)
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4796

We are updating the service to allow customers to upload returns quarterly (four times a year instead of just once).

The current logic tied displaying the link and generating the CSVs to the cycle you were currently in. To enable quarterly, we have to break that tie-in and move to a more flexible "I have a due return; give me the CSV!"

We've already made a change to allow the link to always be displayed (if you have bulk uploads enabled and have due returns) in [Always display bulk upload link on external site](https://github.com/DEFRA/water-abstraction-ui/pull/2677).

This change is about the changes needed to the CSV template generation.

They are

- Split out the CSV files further based on the 'due date' of the returns we're processing
- Change how the files are named to cater for customers with returns due on different dates
