### PR TITLE
Rename some /system/notifications to /notices

### DIFF
--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -32,7 +32,7 @@ const manageTabSkeleton = () => ({
     createLink('Invitations', _returnNotificationsInvitations(), scope.bulkReturnNotifications),
     createLink('Paper forms', '/returns-notifications/forms', scope.returns),
     createLink('Reminders', _returnNotificationsReminders(), scope.bulkReturnNotifications),
-    createLink('Ad-hoc', '/system/notifications/setup?journey=ad-hoc', config.featureToggles.enableSystemNotifications && scope.returns)
+    createLink('Ad-hoc', '/system/notices/setup?journey=ad-hoc', config.featureToggles.enableSystemNotifications && scope.returns)
   ],
   licenceNotifications: [
     createLink('Renewal', 'notifications/2?start=1', scope.renewalNotifications)
@@ -69,7 +69,7 @@ const getManageTabConfig = request => mapValues(
 
 const _returnNotificationsInvitations = () => {
   if (config.featureToggles.enableSystemNotifications) {
-    return '/system/notifications/setup?journey=invitations'
+    return '/system/notices/setup?journey=invitations'
   } else {
     return '/returns-notifications/invitations'
   }
@@ -77,7 +77,7 @@ const _returnNotificationsInvitations = () => {
 
 const _returnNotificationsReminders = () => {
   if (config.featureToggles.enableSystemNotifications) {
-    return '/system/notifications/setup?journey=reminders'
+    return '/system/notices/setup?journey=reminders'
   } else {
     return '/returns-notifications/reminders'
   }

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -235,7 +235,7 @@ experiment('getManageTabConfig', () => {
 
       expect(config.returnNotifications[0]).to.equal({
         name: 'Invitations',
-        path: '/system/notifications/setup?journey=invitations',
+        path: '/system/notices/setup?journey=invitations',
         scopes: 'bulk_return_notifications'
       })
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4781

We've been migrating and updating the legacy returns invitations and reminders journeys. Adding support for quarterly returns was the driver, which is also encompassed by our ongoing replacement of the legacy service.

What we've built so far has been done on the `/notifications` path, with folders and files all using the name 'notifications'. But we've realised this has driven us into a corner.

For example, when creating a 'returns invitation', you'll select the period, and the service will determine which licences should receive a notification and who the recipient is for each one. It'll then clean up and de-dupe the recipients and send a notification for each one left.

Behind the scenes, we create an `event` record of type `notification` with a unique reference that links all the 'notifications' sent, plus the 'when' and 'who'.

> The previous team's decision to make it an `event` record rather than its own thing is something we have to live with for now until we generate all notifications.

We are also rebuilding the page that displays these `event` records (of type `notification`), and when you click on one, we need to display all the notifications linked to it. The problem is that we've also been naming these pages and their supporting services 'notifications'. We've also rebuilt the page that displays the content of the notification and named all its parts 'notification'.

You can see the corner we've now found ourselves in. We're calling the 'thing' that links together notifications 'notifications', which means things are now confusing, or even worse, clashing.

You currently access the page that lists the `events` of type `notification` from a link labelled 'Notices' (the legacy page is known as the 'Notices report').

`notice` is as good a name as any for the 'thing' that links the notifications sent, so we intend to use it going forward.

This change updates our links to `/system/notifications` to be `/system/notices`.