### PR TITLE
Add new endpoint for change address button to UI

### DIFF
--- a/src/internal/modules/billing-accounts/controllers/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/controllers/billing-accounts.js
@@ -24,6 +24,27 @@ const getBillingAccountRedirectLink = request => {
 }
 
 /**
+ * Change billing account address
+ */
+const getBillingAccountChangeAddress = (request, h) => {
+  const { billingAccountId } = request.params
+  const { billingAccount } = request.pre
+
+  const data = {
+    caption: `Billing account ${billingAccount.accountNumber}`,
+    key: `change-address-${billingAccountId}`,
+    back: `/billing-accounts/${billingAccountId}`,
+    redirectPath: `/billing-accounts/${billingAccountId}`,
+    isUpdate: true,
+    data: pick(billingAccount, 'id', 'company')
+  }
+
+  const redirectPath = request.billingAccountEntryRedirect(data)
+
+  return h.redirect(redirectPath)
+}
+
+/**
  * View billing account
  */
 const getBillingAccount = (request, h) => {
@@ -72,3 +93,4 @@ const getBillingAccountBills = (request, h) => {
 
 exports.getBillingAccount = getBillingAccount
 exports.getBillingAccountBills = getBillingAccountBills
+exports.getBillingAccountChangeAddress = getBillingAccountChangeAddress

--- a/src/internal/modules/billing-accounts/routes/billing-accounts.js
+++ b/src/internal/modules/billing-accounts/routes/billing-accounts.js
@@ -38,6 +38,31 @@ module.exports = {
     }
   },
 
+  getBillingAccountChangeAddress: {
+    method: 'GET',
+    path: '/billing-accounts/{billingAccountId}/change-address',
+    handler: controller.getBillingAccountChangeAddress,
+    options: {
+      auth: {
+        scope: allowedScopes
+      },
+      plugins: {
+        viewContext: {
+          activeNavLink: 'view'
+        }
+      },
+      validate: {
+        params: Joi.object().keys({
+          billingAccountId: VALID_GUID
+        }),
+        query: Joi.object().keys({
+          back: Joi.string().optional()
+        })
+      },
+      pre: [{ method: preHandlers.loadBillingAccount, assign: 'billingAccount' }]
+    }
+  },
+
   getBillingAccountBills: {
     method: 'GET',
     path: '/billing-accounts/{billingAccountId}/bills',

--- a/test/internal/modules/billing-accounts/controllers/billing-accounts.test.js
+++ b/test/internal/modules/billing-accounts/controllers/billing-accounts.test.js
@@ -75,6 +75,7 @@ const createRequest = (query = {}) => ({
 })
 
 const h = {
+  redirect: sandbox.stub(),
   view: sandbox.stub()
 }
 
@@ -192,6 +193,31 @@ experiment('internal/modules/billing-accounts/controllers/billing-accounts', () 
       const { billingAccountId } = request.params
       const [, { back }] = h.view.lastCall.args
       expect(back).to.equal(`/billing-accounts/${billingAccountId}`)
+    })
+  })
+
+  experiment('.getBillingAccountChangeAddress', () => {
+    beforeEach(() => {
+      request = createRequest()
+      controller.getBillingAccountChangeAddress(request, h)
+    })
+
+    test('redirects to the change address link', () => {
+      expect(h.redirect.calledWith(addressChangeLink)).to.be.true()
+    })
+
+    test('calls billingAccountEntryRedirect with correct data', () => {
+      const [data] = request.billingAccountEntryRedirect.lastCall.args
+
+      expect(data.caption).to.equal('Billing account A12345678A')
+      expect(data.key).to.equal('change-address-test-billing-account-id')
+      expect(data.back).to.equal('/billing-accounts/test-billing-account-id')
+      expect(data.redirectPath).to.equal('/billing-accounts/test-billing-account-id')
+      expect(data.isUpdate).to.be.true()
+      expect(data.data).to.equal({
+        id: 'test-billing-account-id',
+        company: { name: 'Test Company' }
+      })
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

While working on the view billing account page in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), we noticed an issue with the change address button. Although we used the same endpoint as the legacy page, it brought up an error whenever loading in from the new system. After some digging, this was concluded to be because of some complex manipulation of the request by the legacy system.

To get around this, we introduced a new dedicated endpoint for the change address flow when accessed from the view billing account page. This avoids the quirks of the legacy implementation and allows the new system to handle the logic in a cleaner and more predictable way.

This PR will add a new endpoint for the change address button for the view billing accounts page.