### PR TITLE
Access view billing account page via search

### DIFF
--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -170,6 +170,7 @@ module.exports = {
     triggerSrocAnnual: (get(process.env, 'TRIGGER_SROC_ANNUAL') || '').toLowerCase() === 'true',
     useNewBillRunSetup: (get(process.env, 'USE_NEW_BILL_RUN_SETUP') || '').toLowerCase() === 'true',
     useWorkflowSetupLinks: (get(process.env, 'USE_WORKFLOW_SETUP_LINKS') || 'true').toLowerCase() === 'true',
+    enableBillingAccountView: process.env.ENABLE_BILLING_ACCOUNT_VIEW === 'true',
     enableSystemLicenceView: process.env.ENABLE_SYSTEM_LICENCE_VIEW === 'true',
     enableSystemNotifications: process.env.ENABLE_SYSTEM_NOTIFICATIONS === 'true',
     enableSystemReturnsView: process.env.ENABLE_SYSTEM_RETURNS_VIEW === 'true',

--- a/src/internal/modules/internal-search/lib/redirect-to-billing-account.js
+++ b/src/internal/modules/internal-search/lib/redirect-to-billing-account.js
@@ -1,6 +1,8 @@
 const { get } = require('lodash')
 const Boom = require('@hapi/boom')
 
+const config = require('../../../config')
+
 /**
  * Redirects the user to the billing account
  * @param  {Object} billingAccount
@@ -11,7 +13,11 @@ const Boom = require('@hapi/boom')
 const redirectToBillingAccount = (billingAccount, view, h) => {
   const billingAccountId = get(view, 'billingAccount.invoiceAccountId')
   if (billingAccountId) {
-    return h.redirect(`/billing-accounts/${billingAccountId}`)
+    if (config.featureToggles.enableBillingAccountView) {
+      return h.redirect(`/system/billing-accounts/${billingAccountId}`)
+    } else {
+      return h.redirect(`/billing-accounts/${billingAccountId}`)
+    }
   } else {
     throw Boom.notFound('Billing account not found')
   }

--- a/test/internal/modules/internal-search/lib/redirect-to-billing-account.test.js
+++ b/test/internal/modules/internal-search/lib/redirect-to-billing-account.test.js
@@ -1,7 +1,10 @@
 const sinon = require('sinon')
+const sandbox = require('sinon').createSandbox()
 const { expect, fail } = require('@hapi/code')
-const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
+const { experiment, test, beforeEach } = (exports.lab = require('@hapi/lab').script())
 const { redirectToBillingAccount } = require('internal/modules/internal-search/lib/redirect-to-billing-account')
+
+const config = require('../../../../../src/internal/config.js')
 
 experiment('redirectToBillingAccount', () => {
   const billingAccount = {
@@ -27,11 +30,31 @@ experiment('redirectToBillingAccount', () => {
     }
   })
 
-  test('It should redirect if the return has a path property', async () => {
-    const view = {
-      billingAccount
-    }
-    redirectToBillingAccount(billingAccount, view, h)
-    expect(h.redirect.firstCall.args[0]).to.equal(`/billing-accounts/${view.billingAccount.invoiceAccountId}`)
+  experiment('When enableBillingAccountView is not enabled', () => {
+    beforeEach(async () => {
+      sandbox.stub(config.featureToggles, 'enableBillingAccountView').value(false)
+    })
+
+    test('It should redirect if the return has a path property', async () => {
+      const view = {
+        billingAccount
+      }
+      redirectToBillingAccount(billingAccount, view, h)
+      expect(h.redirect.firstCall.args[0]).to.equal(`/billing-accounts/${view.billingAccount.invoiceAccountId}`)
+    })
+  })
+
+  experiment('When enableBillingAccountView is enabled', () => {
+    beforeEach(async () => {
+      sandbox.stub(config.featureToggles, 'enableBillingAccountView').value(true)
+    })
+
+    test('It should redirect if the return has a path property', async () => {
+      const view = {
+        billingAccount
+      }
+      redirectToBillingAccount(billingAccount, view, h)
+      expect(h.redirect.firstCall.args[0]).to.equal(`/system/billing-accounts/${view.billingAccount.invoiceAccountId}`)
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

After completing the view billing account page in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), it was noticed during testing that searching for a billing account would redirect to the legacy billing account page. When a user searches for a billing account, it should redirect to the new billing account page created.

This PR will amend searching for a billing account to redirect to the new billing account page.