### PR TITLE
Update change address redirect to new billing account page

### DIFF
--- a/src/internal/modules/billing-accounts/controllers/select-billing-account.js
+++ b/src/internal/modules/billing-accounts/controllers/select-billing-account.js
@@ -10,6 +10,8 @@ const { logger } = require('../../../logger')
 const services = require('../../../lib/connectors/services')
 const mapper = require('../lib/mapper')
 
+const { featureToggles } = require('../../../config')
+
 // Form containers
 const selectBillingAccountForm = require('../forms/select-billing-account')
 const selectAccountForm = require('../forms/select-account')
@@ -275,7 +277,12 @@ const postCheckAnswers = async (request, h) => {
     // Set address in session and redirect back to parent flow
     const { key } = request.params
     const { redirectPath } = session.merge(request, key, { data })
-    return h.redirect(redirectPath)
+
+    if (featureToggles.enableBillingAccountView) {
+      return h.redirect('/system' + redirectPath)
+    } else {
+      return h.redirect(redirectPath)
+    }
   } catch (err) {
     logger.error('Error saving billing account', err.stack)
     throw err


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4988

While working on the view billing accounts page, it was noticed that after a user goes through the change address journey, it would redirect to the legacy billing accounts page.

This PR fixes the redirect to sent users back to the new billing account page.