### PR TITLE
Fix issue with returns csv template generation

### DIFF
--- a/src/external/modules/returns/lib/csv-templates.js
+++ b/src/external/modules/returns/lib/csv-templates.js
@@ -103,12 +103,11 @@ const createCSVData = (returns) => {
     nestedGroups[key] = groupBy(group, ret => ret.frequency)
   }
 
-  const data = {}
-
   for (const dueDateKey in nestedGroups) {
     const dueDateGroup = nestedGroups[dueDateKey]
 
     for (const frequencyKey in dueDateGroup) {
+      const data = {}
       const frequencyGroup = dueDateGroup[frequencyKey]
 
       // sort by return ID


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4796

We are updating the service to allow customers to upload returns quarterly (four times a year instead of just once).

In [Update upload CSV generation to support quarterly](https://github.com/DEFRA/water-abstraction-ui/pull/2679), we 'broke' the logic that tied the templates generated to only those in the current cycle. Instead, it is a more flexible "I have a due return; give me the CSV!"

However, during testing, we discovered a bug. Though the templates generated seemed to match the returns due, our eagle-eyed QA team spotted that something was screwy with the dates.

This was one of those 'head-scratchers', as though tweaked, our code and that provided initially by @chris-barrett-ddts in [Make bulk upload work for quarterly](https://github.com/DEFRA/water-abstraction-ui/pull/2645/files) were doing the same thing.

Not surprisingly, it all came down to a variable being declared in _altogether_ the wrong place! Essentially, we were generating each group correctly, but overwriting the previous with the next as we looped because of where we had declared the variable.