### PR TITLE
Exclude not-ended rtns from generated CSV template

### DIFF
--- a/src/shared/lib/connectors/services/water/CompaniesService.js
+++ b/src/shared/lib/connectors/services/water/CompaniesService.js
@@ -10,7 +10,8 @@ class CompaniesService extends ServiceClient {
     const url = this.joinUrl('company', entityId, 'returns')
     const options = {
       qs: {
-        status: 'due'
+        status: 'due',
+        endDate: new Date().toISOString().split('T')[0]
       }
     }
     return this.serviceRequest.get(url, options)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4796

We are updating the service to allow customers to upload returns quarterly (four times a year instead of just once).

In [Update upload CSV generation to support quarterly](https://github.com/DEFRA/water-abstraction-ui/pull/2679), we 'broke' the logic that tied the templates generated to only those in the current cycle. Instead, it is a more flexible "I have a due return; give me the CSV!"

However, during testing, we discovered that returns which show as `NOT DUE YET` in the internal UI and aren't even listed in the external UI are included in the CSV templates generated.

These need to be excluded. So, this change adds 'end date' as a filter to the [water-abstraction-service](https://github.com/DEFRA/water-abstraction-service/pull/2693) API endpoint that supplies the returns data. It uses the value provided to apply a 'less than or equal to' clause to the query it runs.