### PR TITLE
Remove show future returns externally feature

### DIFF
--- a/src/external/config.js
+++ b/src/external/config.js
@@ -82,10 +82,6 @@ module.exports = {
     airbrakeLevel: 'error'
   },
 
-  returns: {
-    showFutureReturns: testMode
-  },
-
   sanitize: {
     pruneMethod: 'replace',
     replaceValue: ''

--- a/src/external/lib/connectors/services/returns/ReturnsApiClient.js
+++ b/src/external/lib/connectors/services/returns/ReturnsApiClient.js
@@ -6,10 +6,9 @@ const SharedReturnsApiClient = require('shared/lib/connectors/services/returns/R
 /**
  * Gets the filter to use for retrieving licences from returns service
  * @param {Array} licenceNumbers
- * @param {Boolean} showFutureReturns
  * @return {Object} filter
  */
-const getLicenceReturnsFilter = (licenceNumbers, showFutureReturns = false) => {
+const getLicenceReturnsFilter = (licenceNumbers) => {
   const filter = {
     regime: 'water',
     licence_type: 'abstraction',
@@ -24,12 +23,6 @@ const getLicenceReturnsFilter = (licenceNumbers, showFutureReturns = false) => {
     },
     'metadata->>isCurrent': 'true',
     status: { $ne: 'void' }
-  }
-
-  // External users on production-like environments can only view returns where
-  // return cycle is in the past
-  if (showFutureReturns) {
-    delete filter.end_date
   }
 
   return filter
@@ -50,7 +43,7 @@ class ReturnsApiClient extends SharedReturnsApiClient {
    * @return {Promise} resolves with returns
    */
   async getLicenceReturns (licenceNumbers, page = 1) {
-    const filter = getLicenceReturnsFilter(licenceNumbers, this.showFutureReturns)
+    const filter = getLicenceReturnsFilter(licenceNumbers)
 
     const sort = {
       start_date: -1,

--- a/src/external/modules/returns/lib/helpers.js
+++ b/src/external/modules/returns/lib/helpers.js
@@ -37,8 +37,6 @@ const getNewTaggingLicenceNumbers = (request, filter = {}) => {
  * @return {Object} filter
  */
 const getLicenceReturnsFilter = licenceNumbers => {
-  const showFutureReturns = get(config, 'returns.showFutureReturns', false)
-
   const filter = {
     regime: 'water',
     licence_type: 'abstraction',
@@ -48,17 +46,12 @@ const getLicenceReturnsFilter = licenceNumbers => {
     start_date: {
       $gte: '2008-04-01'
     },
+    end_date: {
+      $lte: moment().format('YYYY-MM-DD')
+    },
     'metadata->>isCurrent': 'true',
     status: {
       $ne: 'void'
-    }
-  }
-
-  // External users on production-like environments can only view returns where
-  // return cycle is in the past
-  if (!showFutureReturns) {
-    filter.end_date = {
-      $lte: moment().format('YYYY-MM-DD')
     }
   }
 

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -90,10 +90,6 @@ module.exports = {
     airbrakeLevel: 'error'
   },
 
-  returns: {
-    showFutureReturns: testMode
-  },
-
   sanitize: {
     pruneMethod: 'replace',
     replaceValue: ''

--- a/src/shared/lib/connectors/services/returns/ReturnsApiClient.js
+++ b/src/shared/lib/connectors/services/returns/ReturnsApiClient.js
@@ -1,5 +1,4 @@
 const { APIClient } = require('@envage/hapi-pg-rest-api')
-const { get } = require('lodash')
 const urlJoin = require('url-join')
 const { http } = require('@envage/water-abstraction-helpers')
 
@@ -22,8 +21,6 @@ class ReturnsApiClient extends APIClient {
         Authorization: config.jwt.token
       }
     })
-
-    this.showFutureReturns = get(config, 'returns.showFutureReturns', false)
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5006

For reasons we cannot fathom, the previous team built a feature that allows the external UI to display returns that are in the future to a user.

In `production`, this is disabled so external users can only see return logs where the end date is less than or equal to the current date.

We've been caught out by this a few times, and we've also been asked to investigate why a return in the future is showing during testing, only to recall this quirk in the app.

While working on WATER-5006 , it happened again. Five minutes of panic ensued as we tried to figure out why something from the future was showing, only to discover that the end date was dynamically applied to the filter due to this toggle.

Well, enough is enough!