### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -2,8 +2,7 @@
  * Contains functions to help with building a list of notifications that
  * can be sent by the current authenticated user
  */
-const config = require('internal/config')
-const { featureToggles } = require('../../../config')
+const config = require('../../../config')
 const { hasScope } = require('../../../lib/permissions')
 const { mapValues } = require('lodash')
 const { scope } = require('../../../lib/constants')
@@ -43,7 +42,7 @@ const manageTabSkeleton = () => ({
     createLink('Resume', 'notifications/4?start=1', scope.hofNotifications)
   ],
   uploadChargeInformation: [
-    createLink('Upload a file', '/charge-information/upload', featureToggles.allowChargeVersionUploads && scope.chargeVersionWorkflowReviewer)
+    createLink('Upload a file', '/charge-information/upload', config.featureToggles.allowChargeVersionUploads && scope.chargeVersionWorkflowReviewer)
   ],
   accounts: [
     createLink('Create an internal account', '/account/create-user', scope.manageAccounts)

--- a/test/internal/modules/manage/lib/manage-nav.test.js
+++ b/test/internal/modules/manage/lib/manage-nav.test.js
@@ -3,12 +3,13 @@ const { experiment, test, beforeEach, afterEach } = exports.lab = require('@hapi
 
 const { expect } = require('@hapi/code')
 
-const { getManageTabConfig } = require('internal/modules/manage/lib/manage-nav')
 const { scope } = require('internal/lib/constants')
-const config = require('internal/config')
+const InternalConfig = require('internal/config')
 
 const { flatMap } = require('lodash')
 const sinon = require('sinon')
+
+const ManageNav = require('internal/modules/manage/lib/manage-nav')
 
 const mapLinkGroup = (links, group) => links.map(link => ({
   group,
@@ -30,29 +31,121 @@ const createRequest = (scopes = []) => {
 
 const sandbox = sinon.createSandbox()
 
-experiment('getManageTabConfig', () => {
+experiment('Manage Nav', () => {
+  beforeEach(() => {
+    sandbox.stub(InternalConfig, 'featureToggles').value({ allowChargeVersionUploads: true, enableSystemNotifications: false })
+  })
+
   afterEach(() => {
     sandbox.restore()
   })
 
-  experiment('when a user has no scopes', () => {
-    test('none of the links are visible', async () => {
-      const request = createRequest()
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([])
-    })
-  })
-
-  experiment('when user has bulk returns notifications scope', () => {
-    beforeEach(() => {
-      config.featureToggles.enableSystemNotifications = false
+  experiment('#getManageTabConfig', () => {
+    experiment('when a user has no scopes', () => {
+      test('none of the links are visible', async () => {
+        const request = createRequest()
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([])
+      })
     })
 
-    test('they can view notification report, return invitations and return reminders notifications', async () => {
-      const request = createRequest(scope.bulkReturnNotifications)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([
-        {
+    experiment('when user has bulk returns notifications scope', () => {
+      test('they can view notification report, return invitations and return reminders notifications', async () => {
+        const request = createRequest(scope.bulkReturnNotifications)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          {
+            group: 'reports',
+            name: 'Notices',
+            path: '/notifications/report'
+          },
+          {
+            group: 'reports',
+            name: 'Key performance indicators',
+            path: '/reporting/kpi-reporting'
+          },
+          {
+            group: 'returnNotifications',
+            name: 'Invitations',
+            path: '/returns-notifications/invitations'
+          },
+          {
+            group: 'returnNotifications',
+            name: 'Reminders',
+            path: '/returns-notifications/reminders'
+          }
+        ])
+      })
+    })
+
+    experiment('when user has abstraction reform approver scope', () => {
+      test('they can view Digitise! report', async () => {
+        const request = createRequest(scope.abstractionReformApprover)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          { group: 'reports', name: 'Digitise!', path: '/digitise/report' },
+          { group: 'reports', name: 'Key performance indicators', path: '/reporting/kpi-reporting' }
+        ])
+      })
+    })
+
+    experiment('when user has renewal notifications scope', () => {
+      test('they can view notifications report and renewal notice', async () => {
+        const request = createRequest(scope.renewalNotifications)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          {
+            group: 'reports',
+            name: 'Notices',
+            path: '/notifications/report'
+          },
+          {
+            group: 'reports',
+            name: 'Key performance indicators',
+            path: '/reporting/kpi-reporting'
+          },
+          {
+            group: 'licenceNotifications',
+            name: 'Renewal',
+            path: 'notifications/2?start=1'
+          }
+        ])
+      })
+    })
+
+    experiment('when user has returns scope', () => {
+      test('they can view notifications and returns cycles reports and send paper returns forms', async () => {
+        const request = createRequest(scope.returns)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          {
+            group: 'reports',
+            name: 'Notices',
+            path: '/notifications/report'
+          },
+          {
+            group: 'reports',
+            name: 'Returns cycles',
+            path: '/returns-reports'
+          },
+          {
+            group: 'reports',
+            name: 'Key performance indicators',
+            path: '/reporting/kpi-reporting'
+          },
+          {
+            group: 'returnNotifications',
+            name: 'Paper forms',
+            path: '/returns-notifications/forms'
+          }])
+      })
+    })
+
+    experiment('when user has HoF notifications scope', () => {
+      test('they can view notifications reports and all HoF notifications', async () => {
+        const request = createRequest(scope.hofNotifications)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([{
           group: 'reports',
           name: 'Notices',
           path: '/notifications/report'
@@ -63,180 +156,57 @@ experiment('getManageTabConfig', () => {
           path: '/reporting/kpi-reporting'
         },
         {
-          group: 'returnNotifications',
-          name: 'Invitations',
-          path: '/returns-notifications/invitations'
+          group: 'hofNotifications',
+          name: 'Restriction',
+          path: 'notifications/1?start=1'
         },
         {
-          group: 'returnNotifications',
-          name: 'Reminders',
-          path: '/returns-notifications/reminders'
-        }
-      ])
-    })
-  })
-
-  experiment('when user has abstraction reform approver scope', () => {
-    test('they can view Digitise! report', async () => {
-      const request = createRequest(scope.abstractionReformApprover)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([
-        { group: 'reports', name: 'Digitise!', path: '/digitise/report' },
-        { group: 'reports', name: 'Key performance indicators', path: '/reporting/kpi-reporting' }
-      ])
-    })
-  })
-
-  experiment('when user has renewal notifications scope', () => {
-    test('they can view notifications report and renewal notice', async () => {
-      const request = createRequest(scope.renewalNotifications)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([
-        {
-          group: 'reports',
-          name: 'Notices',
-          path: '/notifications/report'
+          group: 'hofNotifications',
+          name: 'Hands-off flow',
+          path: 'notifications/3?start=1'
         },
         {
-          group: 'reports',
-          name: 'Key performance indicators',
-          path: '/reporting/kpi-reporting'
-        },
-        {
-          group: 'licenceNotifications',
-          name: 'Renewal',
-          path: 'notifications/2?start=1'
-        }
-      ])
-    })
-  })
-
-  experiment('when user has returns scope', () => {
-    test('they can view notifications and returns cycles reports and send paper returns forms', async () => {
-      const request = createRequest(scope.returns)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([
-        {
-          group: 'reports',
-          name: 'Notices',
-          path: '/notifications/report'
-        },
-        {
-          group: 'reports',
-          name: 'Returns cycles',
-          path: '/returns-reports'
-        },
-        {
-          group: 'reports',
-          name: 'Key performance indicators',
-          path: '/reporting/kpi-reporting'
-        },
-        {
-          group: 'returnNotifications',
-          name: 'Paper forms',
-          path: '/returns-notifications/forms'
+          group: 'hofNotifications',
+          name: 'Resume',
+          path: 'notifications/4?start=1'
         }])
-    })
-  })
-
-  experiment('when user has HoF notifications scope', () => {
-    test('they can view notifications reports and all HoF notifications', async () => {
-      const request = createRequest(scope.hofNotifications)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([{
-        group: 'reports',
-        name: 'Notices',
-        path: '/notifications/report'
-      },
-      {
-        group: 'reports',
-        name: 'Key performance indicators',
-        path: '/reporting/kpi-reporting'
-      },
-      {
-        group: 'hofNotifications',
-        name: 'Restriction',
-        path: 'notifications/1?start=1'
-      },
-      {
-        group: 'hofNotifications',
-        name: 'Hands-off flow',
-        path: 'notifications/3?start=1'
-      },
-      {
-        group: 'hofNotifications',
-        name: 'Resume',
-        path: 'notifications/4?start=1'
-      }])
-    })
-  })
-
-  experiment('when user has manage accounts scope', () => {
-    test('they can view create account link', async () => {
-      const request = createRequest(scope.manageAccounts)
-      const config = getManageTabConfig(request)
-      expect(getAllLinks(config)).to.equal([
-        {
-          group: 'reports',
-          name: 'Key performance indicators',
-          path: '/reporting/kpi-reporting'
-        }, {
-          group: 'accounts',
-          name: 'Create an internal account',
-          path: '/account/create-user'
-        }
-      ])
-    })
-  })
-
-  experiment('when user has manage accounts scope', () => {
-    let request
-    beforeEach(() => {
-      request = createRequest(scope.chargeVersionWorkflowReviewer)
+      })
     })
 
-    test('they can only view check licences link', async () => {
-      sandbox.stub(config.featureToggles, 'allowChargeVersionUploads').value(false)
-      expect(getAllLinks(getManageTabConfig(request))).to.equal([
-        {
-          group: 'chargeInformationWorkflow',
-          name: 'Check licences in workflow',
-          path: '/charge-information-workflow'
-        }
-
-      ])
+    experiment('when user has manage accounts scope', () => {
+      test('they can view create account link', async () => {
+        const request = createRequest(scope.manageAccounts)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          {
+            group: 'reports',
+            name: 'Key performance indicators',
+            path: '/reporting/kpi-reporting'
+          }, {
+            group: 'accounts',
+            name: 'Create an internal account',
+            path: '/account/create-user'
+          }
+        ])
+      })
     })
 
-    test('they can view upload a file link as well as check licences link', async () => {
-      sandbox.stub(config.featureToggles, 'allowChargeVersionUploads').value(true)
-      expect(getAllLinks(getManageTabConfig(request))).to.equal([
-        {
-          group: 'uploadChargeInformation',
-          name: 'Upload a file',
-          path: '/charge-information/upload'
-        }, {
-          group: 'chargeInformationWorkflow',
-          name: 'Check licences in workflow',
-          path: '/charge-information-workflow'
-        }
+    experiment('when user has manage accounts scope', () => {
+      test('they can view upload a file link as well as check licences link', async () => {
+        const request = createRequest(scope.chargeVersionWorkflowReviewer)
+        const result = ManageNav.getManageTabConfig(request)
+        expect(getAllLinks(result)).to.equal([
+          {
+            group: 'uploadChargeInformation',
+            name: 'Upload a file',
+            path: '/charge-information/upload'
+          }, {
+            group: 'chargeInformationWorkflow',
+            name: 'Check licences in workflow',
+            path: '/charge-information-workflow'
+          }
 
-      ])
-    })
-  })
-
-  experiment('when the "enableSystemNotifications" flag is true', () => {
-    beforeEach(() => {
-      config.featureToggles.enableSystemNotifications = true
-    })
-
-    test('they click the link to "system"', async () => {
-      const request = createRequest(scope.bulkReturnNotifications)
-      const config = getManageTabConfig(request)
-
-      expect(config.returnNotifications[0]).to.equal({
-        name: 'Invitations',
-        path: '/system/notices/setup?journey=invitations',
-        scopes: 'bulk_return_notifications'
+        ])
       })
     })
   })


### PR DESCRIPTION
Spotted that when running the unit tests locally, the `manage-nav.test.js` would always fail. No doubt this is due to changes we've been making as we migrate legacy journeys that start from the Manage page to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system).

Initially, we thought it was because we hadn't stubbed the config properly. However, we then noticed that the `manage-nav.js` module was requiring the same configuration twice, using both standard and destructuring methods.

This change sorts the issue and gets the tests running again in all environments.