### PR TITLE
Fix ext view returns showing 'not due yet' returns

### DIFF
--- a/src/external/lib/connectors/services/returns/ReturnsApiClient.js
+++ b/src/external/lib/connectors/services/returns/ReturnsApiClient.js
@@ -19,7 +19,7 @@ const getLicenceReturnsFilter = (licenceNumbers) => {
       $gte: '2008-04-01'
     },
     end_date: {
-      $lte: moment().format('YYYY-MM-DD')
+      $lt: moment().format('YYYY-MM-DD')
     },
     'metadata->>isCurrent': 'true',
     status: { $ne: 'void' }

--- a/src/external/modules/returns/lib/helpers.js
+++ b/src/external/modules/returns/lib/helpers.js
@@ -46,7 +46,7 @@ const getLicenceReturnsFilter = licenceNumbers => {
       $gte: '2008-04-01'
     },
     end_date: {
-      $lte: moment().format('YYYY-MM-DD')
+      $lt: moment().format('YYYY-MM-DD')
     },
     'metadata->>isCurrent': 'true',
     status: {

--- a/src/internal/lib/return-path.js
+++ b/src/internal/lib/return-path.js
@@ -14,7 +14,7 @@ const {
   isVoid
 } = require('shared/lib/returns/return-path-helpers')
 
-const { featureToggles } = require('../config.js')
+const config = require('../config.js')
 
 /**
  * Checks if return can be edited by internal returns user
@@ -48,7 +48,7 @@ const getEditButtonPath = (ret, request) => {
 const getReturnPath = (ret, request) => {
   const returnId = getReturnId(ret)
 
-  if (featureToggles.enableSystemReturnsView) {
+  if (config.featureToggles.enableSystemReturnsView) {
     return { path: `/system/return-logs?id=${returnId}`, isEdit: false }
   }
 

--- a/test/internal/lib/return-path.test.js
+++ b/test/internal/lib/return-path.test.js
@@ -1,14 +1,15 @@
 'use strict'
 
 const Lab = require('@hapi/lab')
-const { experiment, test } = exports.lab = Lab.script()
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
 const { expect } = require('@hapi/code')
+const sinon = require('sinon')
 
-const {
-  getReturnPath,
-  isInternalEdit,
-  getEditButtonPath
-} = require('internal/lib/return-path')
+const sandbox = sinon.createSandbox()
+
+const InternalConfig = require('../../../src/internal/config.js')
+
+const ReturnPath = require('internal/lib/return-path')
 
 const { scope } = require('internal/lib/constants')
 
@@ -35,103 +36,113 @@ const getInternalRequest = (isEditor = false) => {
   }
 }
 
-experiment('returnPath -  internal users', () => {
-  test('An internal user can view a return if has completed status', async () => {
-    const request = getInternalRequest()
-    expect(getReturnPath(ret, request)).to.equal({
-      path: internalView,
-      isEdit: false
+experiment('return-path', () => {
+  beforeEach(() => {
+    sandbox.stub(InternalConfig, 'featureToggles').value({ enableSystemReturnsView: false })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  experiment('#getReturnPath()', () => {
+    test('An internal user can view a return if has completed status', async () => {
+      const request = getInternalRequest()
+      expect(ReturnPath.getReturnPath(ret, request)).to.equal({
+        path: internalView,
+        isEdit: false
+      })
+    })
+
+    test('An internal user can view a return if has void status', async () => {
+      const request = getInternalRequest()
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'void' }, request)).to.equal({
+        path: internalView,
+        isEdit: false
+      })
+    })
+
+    test('An internal user cannot edit a return if has due status', async () => {
+      const request = getInternalRequest()
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'due' }, request)).to.equal(undefined)
+    })
+
+    test('An internal returns user can edit a return if has due status', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'due' }, request)).to.equal({
+        path: internalEdit,
+        isEdit: true
+      })
+    })
+
+    test('An internal returns user can edit a return if has received status', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'received' }, request)).to.equal({
+        path: internalEdit,
+        isEdit: true
+      })
+    })
+
+    test('An internal returns user can edit a return if has completed status', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'completed' }, request)).to.equal({
+        path: internalView,
+        isEdit: false
+      })
+    })
+
+    test('An internal returns user cannot edit a return if the cycle ends in the future', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'received', end_date: '3000-01-01' }, request)).to.equal(undefined)
+    })
+
+    test('An internal returns user cannot edit a return if the cycle ends before 2018-10-31', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getReturnPath({ ...ret, status: 'received', end_date: '2018-10-30' }, request)).to.equal(undefined)
     })
   })
 
-  test('An internal user can view a return if has void status', async () => {
-    const request = getInternalRequest()
-    expect(getReturnPath({ ...ret, status: 'void' }, request)).to.equal({
-      path: internalView,
-      isEdit: false
+  experiment('#getEditButtonPath()', () => {
+    test('An internal user cannot see the edit return button', async () => {
+      const request = getInternalRequest()
+      expect(ReturnPath.getEditButtonPath(ret, request)).to.equal(undefined)
+    })
+
+    test('An internal returns user cannot see the edit return button if isInternalEdit is false', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getEditButtonPath({ ...ret, status: 'void' }, request)).to.equal(undefined)
+    })
+
+    test('An internal returns user can see the edit return button if isInternalEdit is true', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.getEditButtonPath(ret, request)).to.equal(internalEdit)
     })
   })
 
-  test('An internal user cannot edit a return if has due status', async () => {
-    const request = getInternalRequest()
-    expect(getReturnPath({ ...ret, status: 'due' }, request)).to.equal(undefined)
-  })
-
-  test('An internal returns user can edit a return if has due status', async () => {
-    const request = getInternalRequest(true)
-    expect(getReturnPath({ ...ret, status: 'due' }, request)).to.equal({
-      path: internalEdit,
-      isEdit: true
+  experiment('#isInternalEdit()', () => {
+    test('An internal user cannot see the edit return button', async () => {
+      const request = getInternalRequest()
+      expect(ReturnPath.isInternalEdit(ret, request)).to.equal(false)
     })
-  })
 
-  test('An internal returns user can edit a return if has received status', async () => {
-    const request = getInternalRequest(true)
-    expect(getReturnPath({ ...ret, status: 'received' }, request)).to.equal({
-      path: internalEdit,
-      isEdit: true
+    test('An internal returns user cannot edit a return if it has void status', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.isInternalEdit({ ...ret, status: 'void' }, request)).to.equal(false)
     })
-  })
 
-  test('An internal returns user can edit a return if has completed status', async () => {
-    const request = getInternalRequest(true)
-    expect(getReturnPath({ ...ret, status: 'completed' }, request)).to.equal({
-      path: internalView,
-      isEdit: false
+    test('An internal returns user cannot edit a return if the end date is before Summer 2018', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.isInternalEdit({ ...ret, end_date: '2018-10-30' }, request)).to.equal(false)
     })
-  })
 
-  test('An internal returns user cannot edit a return if the cycle ends in the future', async () => {
-    const request = getInternalRequest(true)
-    expect(getReturnPath({ ...ret, status: 'received', end_date: '3000-01-01' }, request)).to.equal(undefined)
-  })
+    test('An internal returns user cannot edit a return if it the end date has not passed', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.isInternalEdit({ ...ret, end_date: '3000-01-01' }, request)).to.equal(false)
+    })
 
-  test('An internal returns user cannot edit a return if the cycle ends before 2018-10-31', async () => {
-    const request = getInternalRequest(true)
-    expect(getReturnPath({ ...ret, status: 'received', end_date: '2018-10-30' }, request)).to.equal(undefined)
-  })
-})
-
-experiment('Edit Return button - internal users', () => {
-  test('An internal user cannot see the edit return button', async () => {
-    const request = getInternalRequest()
-    expect(getEditButtonPath(ret, request)).to.equal(undefined)
-  })
-
-  test('An internal returns user cannot see the edit return button if isInternalEdit is false', async () => {
-    const request = getInternalRequest(true)
-    expect(getEditButtonPath({ ...ret, status: 'void' }, request)).to.equal(undefined)
-  })
-
-  test('An internal returns user can see the edit return button if isInternalEdit is true', async () => {
-    const request = getInternalRequest(true)
-    expect(getEditButtonPath(ret, request)).to.equal(internalEdit)
-  })
-})
-
-experiment('isInternalEdit - internal users', () => {
-  test('An internal user cannot see the edit return button', async () => {
-    const request = getInternalRequest()
-    expect(isInternalEdit(ret, request)).to.equal(false)
-  })
-
-  test('An internal returns user cannot edit a return if it has void status', async () => {
-    const request = getInternalRequest(true)
-    expect(isInternalEdit({ ...ret, status: 'void' }, request)).to.equal(false)
-  })
-
-  test('An internal returns user cannot edit a return if the end date is before Summer 2018', async () => {
-    const request = getInternalRequest(true)
-    expect(isInternalEdit({ ...ret, end_date: '2018-10-30' }, request)).to.equal(false)
-  })
-
-  test('An internal returns user cannot edit a return if it the end date has not passed', async () => {
-    const request = getInternalRequest(true)
-    expect(isInternalEdit({ ...ret, end_date: '3000-01-01' }, request)).to.equal(false)
-  })
-
-  test('An internal returns user can edit a return if it has completed status', async () => {
-    const request = getInternalRequest(true)
-    expect(isInternalEdit({ ...ret, status: 'completed' }, request)).to.equal(true)
+    test('An internal returns user can edit a return if it has completed status', async () => {
+      const request = getInternalRequest(true)
+      expect(ReturnPath.isInternalEdit({ ...ret, status: 'completed' }, request)).to.equal(true)
+    })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5128

When testing WATER-5117, our QA team was looking at a water company licence (03/28/38/0018) that had its quarterly return logs all set up for the current year. In this case, they have three return requirements, so three return logs have been generated per quarter. That means 12 in total for the period from April 1, 2025, to March 31, 2026.

Logging in as an external user on 30 June 2025, they found they could see the first batch of quarterly return logs (1 April to June 30), all with a status of 'NOT DUE YET'. This was not expected.

The reason is a faulty assumption in the logic that determines whether to show a return log. If a return log's end date is less than _or equal to_ the current date, it will show it. It should be just less than the current date.

In our example, the return log can be submitted from 1 July, not 30 June, when it ends.

This change fixes that logic.