### PR TITLE
Add external privacy policy for surveys

### DIFF
--- a/src/external/modules/content/routes.js
+++ b/src/external/modules/content/routes.js
@@ -66,5 +66,26 @@ module.exports = {
       }
     },
     handler: controller.staticPage
+  },
+
+  researchPrivacy: {
+    method: 'GET',
+    path: '/research-privacy-policy',
+    config: {
+      auth: {
+        strategy: 'standard',
+        mode: 'try'
+      },
+      plugins: {
+        viewContext: {
+          pageTitle: 'Privacy notice for water resources user research',
+          back: '/licences'
+        },
+        config: {
+          view: 'nunjucks/content/research-privacy-policy'
+        }
+      }
+    },
+    handler: controller.staticPage
   }
 }

--- a/src/external/views/nunjucks/content/research-privacy-policy.njk
+++ b/src/external/views/nunjucks/content/research-privacy-policy.njk
@@ -1,0 +1,89 @@
+{% extends "./nunjucks/layout.njk" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p>Last updated: 24 April 2025</p>
+
+      <h2 class= "govuk-heading-l">Controller and data protection officer contact details</h2>
+
+      <p>
+        The Environment Agency is the controller for the personal data we process under the UK General Data Protection Regulation (UK GDPR) and Data Protection Act 2018 (DPA 2018).
+      </p>
+
+      <p class="govuk-body">
+        Our <a href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter" rel=noreferrer noopener target="_blank">personal information charter explains</a>:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how to contact our Data Protection Officer</li>
+        <li>what we do with your personal information (personal data) in general</li>
+        <li>your rights and how to complain to the Information Commissioner's Office</li>
+      </ul>
+
+      <h2 class= "govuk-heading-l">Why we may process your personal data and what we collect</h2>
+
+      <p>We process your personal data to do research to improve public services.</p>
+
+      <p>The lawful basis we rely on is article 6(1)(e) of the UK General Data Protection Regulation (UK GDPR), which allows us to process personal data when this is necessary to perform a task in the public interest. The processing has a basis in the Water Resources Act 1991 (as amended by the Water Act 2003), Environment Act 1995 and the Water Resources (Abstraction and Impounding) Regulations 2006.</p>
+
+      <p>For contacting you about research, we rely on your consent. You can withdraw your consent at any time by telling your researcher or emailing <a href="mailto:water_abstractiondigital@environment-agency.gov.uk" target="_blank" rel="ugc nofollow">water_abstractiondigital@environment-agency.gov.uk</a></p>
+
+      <p>For special category 'sensitive' data, we rely on article 9(2)(g) of the UK GDPR which allows us to process this where there is a substantial public interest.</p>
+
+      <h2 class= "govuk-heading-l">What personal data we process and how we use it</h2>
+
+      <p>We collect personal data directly from you, such as: your contact details, views and experiences of a topic, and personal characteristics relevant to the research.</p>
+
+      <p>We use your personal data to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>create research insights to help improve public services</li>
+        <li>communicate with you about relevant research activities</li>
+        <li>decide if you're suitable for a research activity (screening)</li>
+        <li>manage and administer research activities</li>
+      </ul>
+
+      <p>Your personal data may be processed by organisations acting on our behalf, such as:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>research agencies or consultants</li>
+        <li>providers of tools and software</li>
+        <li>incentive payment administrators</li>
+        <li>the Department for Environment, Food & Rural Affairs</li>
+      </ul>
+
+      <p>If you were recruited for this research via a third party, then they may share your contact and screening data with us.</p>
+
+      <p>We do not use your personal data to make an automated decision or for automated profiling.</p>
+
+      <h2 class= "govuk-heading-l">Where personal data is stored and processed</h2>
+
+      <p>Most of your personal data will be stored and processed in the UK or European Economic Area.</p>
+
+      <p>If we need to use storage based elsewhere, we will only transfer your data to a country that is deemed adequate under Article 45 of the UK GDPR.</p>
+
+      <h2 class= "govuk-heading-l">How long we keep your personal data</h2>
+
+      <p>We will keep your personal data for up to 3 years. We will erase data sooner if further research analysis is unlikely or if we don't expect to contact you again.</p>
+
+      <h2 class= "govuk-heading-l">Changes to this notice</h2>
+
+      <p>We may change this privacy notice. When this happens, the last updated date will change.</p>
+
+      <p>If these changes affect how your personal data is processed, we will take reasonable steps to let you know.</p>
+    </div>
+  </div>
+
+
+{% endblock %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5037

To initiate surveys and user research, a privacy policy is in place and being used for WRWA research. This privacy policy is currently hosted on a third-party website (Smart Survey).

We want the privacy policy to be hosted by the service to improve trust and confidence in its source.

![Screenshot 2025-07-08 at 10 31 03](https://github.com/user-attachments/assets/c5a75cae-7955-43bc-b864-20a6f84a299f)
