### PR TITLE
Amend charter link in new research privacy policy

### DIFF
--- a/src/external/views/nunjucks/content/research-privacy-policy.njk
+++ b/src/external/views/nunjucks/content/research-privacy-policy.njk
@@ -22,7 +22,7 @@
       </p>
 
       <p class="govuk-body">
-        Our <a href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter" rel=noreferrer noopener target="_blank">personal information charter explains</a>:
+        Our <a href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter" rel=noreferrer noopener target="_blank">personal information charter</a> explains:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5037

To initiate surveys and user research, a privacy policy is in place and being used for WRWA research. This privacy policy is currently hosted on a third-party website (Smart Survey).

In [Add external privacy policy for surveys](https://github.com/DEFRA/water-abstraction-ui/pull/2721), we added the new page. But one of the links was slightly wrong.

This change fixes it.