### PR TITLE
Update notice setup journey paths

### DIFF
--- a/src/internal/modules/manage/lib/manage-nav.js
+++ b/src/internal/modules/manage/lib/manage-nav.js
@@ -31,7 +31,7 @@ const manageTabSkeleton = () => ({
     createLink('Invitations', _returnNotificationsInvitations(), scope.bulkReturnNotifications),
     createLink('Paper forms', '/returns-notifications/forms', scope.returns),
     createLink('Reminders', _returnNotificationsReminders(), scope.bulkReturnNotifications),
-    createLink('Ad-hoc', '/system/notices/setup/adHoc', config.featureToggles.enableAdHocNotifications && scope.returns)
+    createLink('Ad-hoc', '/system/notices/setup/adhoc', config.featureToggles.enableAdHocNotifications && scope.returns)
   ],
   licenceNotifications: [createLink('Renewal', 'notifications/2?start=1', scope.renewalNotifications)],
   hofNotifications: [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5143

We need to refactor the existing notice setup journey structure to accommodate the coming adHoc invitations and paper forms.

This change updates the previous 'journey' to 'adHoc' or 'standard'.

The previously known journeys of 'invitations' and 'reminders' are now notice types. This updates fits in with upcoming changes where the user will select which notice type from the select notice type page (currently selected via a link)