### PR TITLE
Add snyk exception for tmp

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -37,4 +37,9 @@ ignore:
         reason: No direct upgrade or patch
         expires: 2025-09-06T09:47:46.633Z
         created: 2025-08-07T09:47:46.640Z
+  SNYK-JS-TMP-11501554:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-11T21:49:23.196Z
+        created: 2025-08-12T21:49:23.201Z
 patch: {}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/144

**Snyk** has identified that [tmp](https://github.com/raszi/node-tmp) has a [Symlink Attack vulnerability](https://security.snyk.io/vuln/SNYK-JS-TMP-11501554).

Unfortunately, it is introduced via [@hapi/scooter](https://github.com/hapijs/scooter), which hasn't been updated in more than 3 years, and is unlikely to be.

As this is an issue in the legacy code, the effort to find a replacement or resolve the issue puts it out of scope, hence we are adding an exception.