### PR TITLE
Fix broken view licence summary returns test

### DIFF
--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -15,6 +15,8 @@ const controller = require('internal/modules/view-licences/controller')
 const services = require('internal/lib/connectors/services')
 const { scope } = require('internal/lib/constants')
 
+const config = require('../../../../src/internal/config.js')
+
 experiment('internal/modules/billing/controllers/bills-tab', () => {
   let request, h
 
@@ -41,6 +43,8 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
 
   experiment('.getLicenceSummary', () => {
     beforeEach(() => {
+      sandbox.stub(config.featureToggles, 'enableSystemReturnsView').value(false)
+
       request = {
         auth: {
           credentials: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4805

In [Fix view this return link on edit submit page](https://github.com/DEFRA/water-abstraction-ui/pull/2683), we added a feature flag for whether to use the legacy or new [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) links to view a return.

However, _someone_ was naughty and didn't run the unit tests locally. If they had they would have spotted that the flag when set to `true` was causing a test to fail! 🤦😬

This change fixes the test by stubbing the config to set the feature flag to false.