### PR TITLE
Return search - Not due yet status

### DIFF
--- a/src/shared/lib/returns/badge.js
+++ b/src/shared/lib/returns/badge.js
@@ -14,7 +14,7 @@ function statusBadge (returnLog) {
   const status = returnLog.status
   const dueDateString = returnLog.due_date || returnLog.dueDate
 
-  const displayStatus = _displayStatus(status, new Date(dueDateString))
+  const displayStatus = _displayStatus(status, dueDateString)
 
   return {
     text: displayStatus,
@@ -22,40 +22,47 @@ function statusBadge (returnLog) {
   }
 }
 
-function _displayStatus (status, dueDate) {
+function _displayStatus (status, dueDateString) {
   // If the return is completed we are required to display it as 'complete'. This also takes priority over the other
   // statues
   if (status === 'completed') {
     return 'complete'
   }
 
+  // For all other statuses except 'due' we can just return the status
+  if (status !== 'due') {
+    return status
+  }
+
+  if (!dueDateString) {
+    return 'not due yet'
+  }
+
   // Work out if the return is overdue (status is still 'due' and it is past the due date)
+  const dueDate = new Date(dueDateString)
   const today = new Date()
 
   // The due date held in the record is date-only. If we compared it against 'today' without this step any return due
   // 'today' would be flagged as overdue when it is still due (just!)
   today.setHours(0, 0, 0, 0)
 
-  if (status === 'due') {
-    if (today > dueDate) {
-      return 'overdue'
-    }
-
-    // A return is considered "due" for 28 days, starting 28 days before the due date
-    // Any date before this period should be marked as "not due yet"
-    const notDueUntil = new Date(dueDate)
-
-    // Calculate the start of the "due" period, which begins 27 days before the due date
-    notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
-
-    // If today is before the "due" period starts, the return is "not due yet"
-    if (today < notDueUntil) {
-      return 'not due yet'
-    }
+  if (dueDate < today) {
+    return 'overdue'
   }
 
-  // For all other cases we can just return the status and the return-status-tag macro will know how to display it
-  return status
+  // A return is considered "due" for 28 days, starting 28 days before the due date
+  // Any date before this period should be marked as "not due yet"
+  const notDueUntil = new Date(dueDate)
+
+  // Calculate the start of the "due" period, which begins 27 days before the due date
+  notDueUntil.setDate(notDueUntil.getDate() - DUE_PERIOD_DAYS)
+
+  // If today is before the "due" period starts, the return is "not due yet"
+  if (today < notDueUntil) {
+    return 'not due yet'
+  }
+
+  return 'due'
 }
 
 module.exports = {

--- a/test/internal/modules/view-licences/controller.test.js
+++ b/test/internal/modules/view-licences/controller.test.js
@@ -218,7 +218,7 @@ experiment('internal/modules/billing/controllers/bills-tab', () => {
           id: 'test-return-id-1',
           status: 'due',
           endDate: '2021-03-31',
-          badge: { text: 'due', status: 'todo' },
+          badge: { text: 'not due yet', status: 'inactive' },
           path: '/return/internal?returnId=test-return-id-1',
           isEdit: true
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5216

Currently when a return log is created it is automatically pre-populated with a due date. However, the process of assigning a due date to a return log is being updated so that the due date is not set on creation. Instead, it is set when the reminders are sent out.

This means that some new return logs will now have a null due date where previously the due date would always have been populated.

This PR will update the search results so that when searching for a return. The status of a return will display ‘Not Due Yet’ when the due date is not set and the status is "due".