### PR TITLE
Update notifications view overflow wrap

### DIFF
--- a/src/shared/assets/sass/blocks/_message-preview.scss
+++ b/src/shared/assets/sass/blocks/_message-preview.scss
@@ -1,6 +1,7 @@
 .message-preview {
   background-color: govuk-colour("light-grey");
   border: 5px solid  $govuk-secondary-text-colour;
+  overflow-wrap: break-word;
   padding: 2rem;
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5614

The renewal invitations multiple licences template has been updated to show the licence refs as a comma separate string.

The bullet points for licence refs could be 50+ and would span multiple pages.

When we show the preview this was breaking the view by exceeding the container.

This change adds an 'overflow-wrap' to wrap the text within the container.

This is align's with the system code.