### PR TITLE
Add .npmrc with supply chain security settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
Adds a root `.npmrc` with `save-exact=true`, `ignore-scripts=true`, and `min-release-age=7`.
Pins installed versions exactly, disables install scripts, and sets a minimum release age for new dependency versions to reduce exposure to compromised npm releases.